### PR TITLE
feat(prs): one-week retention for archived PRs with poll-time backfill

### DIFF
--- a/apps/server/src/services/DbMaintenance.ts
+++ b/apps/server/src/services/DbMaintenance.ts
@@ -1,10 +1,11 @@
-import { lt, sql } from "drizzle-orm";
+import { and, inArray, isNotNull, lt, sql } from "drizzle-orm";
 import { Context, Duration, Effect, Fiber, Layer, Ref, Schedule } from "effect";
-import { cacheEntries, kvCache } from "../db/schema/index";
+import { cacheEntries, kvCache, pullRequests } from "../db/schema/index";
 import { logError } from "../logger";
 import { DbService } from "./Db";
 
 const SWEEP_INTERVAL_HOURS = 6;
+const PR_RETENTION_DAYS = 7;
 
 type DbMaintenanceService = {
   readonly start: () => Effect.Effect<void>;
@@ -24,6 +25,9 @@ export const DbMaintenanceLive = Layer.effect(
 
     const runMaintenance: Effect.Effect<void> = Effect.sync(() => {
       const nowIso = new Date().toISOString();
+      const prCutoffIso = new Date(
+        Date.now() - PR_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      ).toISOString();
 
       // 1. Sweep expired cache_entries rows
       const expiredCacheEntries = db
@@ -47,14 +51,32 @@ export const DbMaintenanceLive = Layer.effect(
         db.delete(kvCache).where(lt(kvCache.expiresAt, nowIso)).run();
       }
 
-      // 3. Checkpoint WAL to reclaim disk space from the WAL file
+      // 3. Sweep archived PRs older than the retention window. Cascades clean
+      // walkthroughs, review sessions, chat sessions, diff files, and pinned
+      // rows via the schema's onDelete: "cascade" declarations.
+      const expiredPrsPredicate = and(
+        inArray(pullRequests.status, ["closed", "merged"]),
+        isNotNull(pullRequests.closedAt),
+        lt(pullRequests.closedAt, prCutoffIso),
+      );
+      const expiredPrs = db
+        .select({ n: sql<number>`COUNT(*)` })
+        .from(pullRequests)
+        .where(expiredPrsPredicate)
+        .get();
+      const prsSwept = expiredPrs?.n ?? 0;
+      if (prsSwept > 0) {
+        db.delete(pullRequests).where(expiredPrsPredicate).run();
+      }
+
+      // 4. Checkpoint WAL to reclaim disk space from the WAL file
       db.run(sql`PRAGMA wal_checkpoint(TRUNCATE)`);
 
-      const total = cacheEntriesSwept + kvSwept;
+      const total = cacheEntriesSwept + kvSwept + prsSwept;
       if (total > 0) {
         logError(
           "DbMaintenance",
-          `sweep complete — cache_entries: ${cacheEntriesSwept} rows, kv_cache: ${kvSwept} rows, WAL checkpointed`,
+          `sweep complete — cache_entries: ${cacheEntriesSwept} rows, kv_cache: ${kvSwept} rows, pull_requests: ${prsSwept} rows, WAL checkpointed`,
         );
       }
     }).pipe(

--- a/apps/server/src/services/PollScheduler.ts
+++ b/apps/server/src/services/PollScheduler.ts
@@ -457,6 +457,108 @@ export const PollSchedulerLive = Layer.effect(
           }
         }
 
+        // ── Archive backfill ─────────────────────────────────────────────────
+        // Catch closed/merged PRs that never made it into the local mirror —
+        // e.g. closed before the user added the repo to Revv, or while the
+        // server was offline for longer than one poll interval. Bounded to
+        // the same 7-day window the DbMaintenance sweep uses for retention,
+        // so the local archive converges on "last week of activity" from
+        // GitHub. Per-repo fetch cap defends against bursty repos. Failures
+        // are non-fatal — we degrade silently to whatever the local mirror
+        // already has.
+        const ARCHIVE_BACKFILL_DAYS = 7;
+        const ARCHIVE_BACKFILL_MAX_FETCHES_PER_REPO = 25;
+        const backfillSinceIso = new Date(
+          Date.now() - ARCHIVE_BACKFILL_DAYS * 24 * 60 * 60 * 1000,
+        ).toISOString();
+        const backfillUntilIso = new Date().toISOString();
+
+        const existingExternalIdsByRepo = new Map<string, Set<number>>();
+        for (const pr of existingPrs) {
+          let set = existingExternalIdsByRepo.get(pr.repositoryId);
+          if (!set) {
+            set = new Set<number>();
+            existingExternalIdsByRepo.set(pr.repositoryId, set);
+          }
+          set.add(pr.externalId);
+        }
+
+        yield* Effect.forEach(
+          allRepos,
+          (repo) =>
+            Effect.gen(function* () {
+              const acc = accountForRepo(repo.id);
+              const token = acc?.accessToken ?? "";
+              if (!token) return;
+
+              const searched = yield* github
+                .searchClosedPrsInWindow(repo.fullName, backfillSinceIso, backfillUntilIso, token)
+                .pipe(
+                  Effect.tapError((err) =>
+                    Effect.sync(() => {
+                      logError(
+                        "PollScheduler",
+                        `archive backfill search failed for ${repo.fullName}:`,
+                        err,
+                      );
+                    }),
+                  ),
+                  Effect.catchAll(() =>
+                    Effect.succeed(
+                      [] as ReadonlyArray<{
+                        readonly number: number;
+                        readonly closedAt: string;
+                        readonly merged: boolean;
+                      }>,
+                    ),
+                  ),
+                );
+              if (searched.length === 0) return;
+
+              const known = existingExternalIdsByRepo.get(repo.id) ?? new Set<number>();
+              const missing = searched
+                .filter((s) => !known.has(s.number))
+                .slice(0, ARCHIVE_BACKFILL_MAX_FETCHES_PER_REPO);
+              if (missing.length === 0) return;
+
+              const fetched = yield* Effect.forEach(
+                missing,
+                (m) =>
+                  github
+                    .getPr(repo.fullName, m.number, token)
+                    .pipe(Effect.catchAll(() => Effect.succeed(null))),
+                { concurrency: 3 },
+              );
+
+              // Repoint every fetched row at our local repo id — `getPr`
+              // derives `id` and `repositoryId` from `${owner}/${repo}` because
+              // it doesn't know the local row id. Matches the recap-jobs
+              // backfill (see ProjectRecapJobs.backfillMissingPrs).
+              const upsertable = fetched
+                .filter((pr): pr is NonNullable<typeof pr> => pr !== null)
+                .map((pr) => ({
+                  ...pr,
+                  id: `${repo.id}:${pr.externalId}`,
+                  repositoryId: repo.id,
+                }));
+              if (upsertable.length === 0) return;
+
+              yield* withDb(prService.upsertPrs(upsertable)).pipe(
+                Effect.tapError((err) =>
+                  Effect.sync(() => {
+                    logError(
+                      "PollScheduler",
+                      `archive backfill upsert failed for ${repo.fullName}:`,
+                      err,
+                    );
+                  }),
+                ),
+                Effect.orElseSucceed(() => undefined),
+              );
+            }).pipe(Effect.orElseSucceed(() => undefined)),
+          { concurrency: 3 },
+        );
+
         // Detect PRs whose headSha or baseSha changed since last sync
         const changedPrIds = allPrs
           .filter((pr) => {


### PR DESCRIPTION
## Summary
- `DbMaintenance` sweep now deletes `pull_requests` rows whose `status` is `closed`/`merged` and `closed_at` is older than 7 days; cascades clean dependent walkthroughs, sessions, diffs, and pinned rows.
- `PollScheduler` adds a per-repo archive-backfill pass via `github.searchClosedPrsInWindow(now-7d, now)` + `getPr` + `upsertPrs` (capped at 25 fetches/repo, failures non-fatal) so the local mirror converges on "last week of activity" — covering PRs closed before the repo was added or while the server was offline.
- No schema change, no new service, no new WS envelope: clients reconcile through the next `prs:updated` and on-demand `/api/prs/archived` reads.

## Test plan
- [ ] `make typecheck` (server passes; pre-existing `@revv/ui` react-missing errors unrelated).
- [ ] Boot `make dev-server`, backdate one closed PR's `closed_at` to 8 days ago, restart, confirm `DbMaintenance` summary line reports `pull_requests: 1 rows` and walkthrough/review-session children are gone.
- [ ] Add a fresh repo with recent activity; confirm a poll cycle backfills closed PRs from the last 7 days into the archive listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)