### PR TITLE
feat(tabs): ⌘+number shortcut hints on cmd hold

### DIFF
--- a/apps/web/src/lib/components/layout/FloatingTabs.svelte
+++ b/apps/web/src/lib/components/layout/FloatingTabs.svelte
@@ -2,6 +2,7 @@
 import DownloadCloud from "phosphor-svelte/lib/CloudArrowDown";
 import Loader2 from "phosphor-svelte/lib/Spinner";
 import PillTabs from "./PillTabs.svelte";
+import { getCmdHeld } from "$lib/stores/shortcuts.svelte";
 
 type Tab = "walkthrough" | "diff" | "request-changes";
 type WalkthroughStatus = "idle" | "generating" | "complete" | "error";
@@ -43,10 +44,12 @@ function handlePullClick(): void {
   if (buttonInteractive) onPullCommit?.();
 }
 
+const cmdHeld = $derived(getCmdHeld());
+
 const tabs = [
-  { id: "walkthrough" as Tab, label: "Walkthrough" },
-  { id: "diff" as Tab, label: "Diff" },
-  { id: "request-changes" as Tab, label: "Request Changes" },
+  { id: "walkthrough" as Tab, label: "Walkthrough", shortcut: "1" },
+  { id: "diff" as Tab, label: "Diff", shortcut: "2" },
+  { id: "request-changes" as Tab, label: "Request Changes", shortcut: "3" },
 ];
 
 function handleTabChange(tabId: string) {
@@ -54,7 +57,7 @@ function handleTabChange(tabId: string) {
 }
 </script>
 
-<PillTabs {tabs} {activeTab} onTabChange={handleTabChange}>
+<PillTabs {tabs} {activeTab} onTabChange={handleTabChange} {cmdHeld}>
 	{#snippet trailing()}
 		<div class="status-slot" aria-hidden={!dotVisible && !buttonVisible}>
 			<span

--- a/apps/web/src/lib/components/layout/FloatingTabs.svelte
+++ b/apps/web/src/lib/components/layout/FloatingTabs.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 import DownloadCloud from "phosphor-svelte/lib/CloudArrowDown";
 import Loader2 from "phosphor-svelte/lib/Spinner";
-import PillTabs from "./PillTabs.svelte";
 import { getCmdHeld } from "$lib/stores/shortcuts.svelte";
+import PillTabs from "./PillTabs.svelte";
 
 type Tab = "walkthrough" | "diff" | "request-changes";
 type WalkthroughStatus = "idle" | "generating" | "complete" | "error";

--- a/apps/web/src/lib/components/layout/PillTabs.svelte
+++ b/apps/web/src/lib/components/layout/PillTabs.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
 import type { Snippet } from "svelte";
 
-export type TabConfig = { id: string; label: string };
+export type TabConfig = { id: string; label: string; shortcut?: string };
 
 interface Props {
   tabs: TabConfig[];
   activeTab: string;
   onTabChange: (tab: string) => void;
   trailing?: Snippet;
+  cmdHeld?: boolean;
 }
 
-let { tabs, activeTab, onTabChange, trailing }: Props = $props();
+let { tabs, activeTab, onTabChange, trailing, cmdHeld = false }: Props = $props();
 
 let pillEl: HTMLDivElement | null = $state(null);
 let segmentEls = $state<(HTMLButtonElement | null)[]>([]);
@@ -83,7 +84,7 @@ function isDividerHidden(index: number): boolean {
 				onpointerleave={() => {
 					if (hoveredIndex === i) hoveredIndex = null;
 				}}
-			>{tab.label}</button>
+>{#if tab.shortcut}<span class="seg-shortcut" class:seg-shortcut--visible={cmdHeld}>⌘{tab.shortcut}</span>{/if}<span class="seg-label">{tab.label}</span></button>
 			{#if i < tabs.length - 1}
 				<span
 					class="pill-divider"
@@ -203,6 +204,27 @@ function isDividerHidden(index: number): boolean {
 
 	.pill-divider--hidden {
 		opacity: 0;
+	}
+
+	.seg-shortcut {
+		display: inline-block;
+		font-size: 11px;
+		font-weight: 400;
+		font-variant-numeric: tabular-nums;
+		color: var(--color-tab-inactive-text);
+		opacity: 0;
+		max-width: 0;
+		overflow: hidden;
+		transition:
+			opacity var(--duration-snap),
+			max-width var(--duration-snap),
+			margin-left var(--duration-snap);
+	}
+
+	.seg-shortcut--visible {
+		opacity: 0.45;
+		max-width: 22px;
+		margin-right: 5px;
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/lib/stores/shortcuts.svelte.ts
+++ b/apps/web/src/lib/stores/shortcuts.svelte.ts
@@ -6,7 +6,9 @@ import { toggleRightPanel, toggleSidebar } from "./sidebar.svelte";
 export type PaletteMode = "search" | "command";
 
 let cmdHeld = $state(false);
-export function getCmdHeld(): boolean { return cmdHeld; }
+export function getCmdHeld(): boolean {
+  return cmdHeld;
+}
 
 let paletteOpen = $state(false);
 let paletteMode = $state<PaletteMode>("search");
@@ -155,7 +157,9 @@ function handleKeyup(e: KeyboardEvent): void {
   if (e.key === "Meta") cmdHeld = false;
 }
 
-function handleBlur(): void { cmdHeld = false; }
+function handleBlur(): void {
+  cmdHeld = false;
+}
 
 /** Attach global keyboard listener. Returns cleanup function. */
 export function initShortcuts(): () => void {

--- a/apps/web/src/lib/stores/shortcuts.svelte.ts
+++ b/apps/web/src/lib/stores/shortcuts.svelte.ts
@@ -5,6 +5,9 @@ import { toggleRightPanel, toggleSidebar } from "./sidebar.svelte";
 
 export type PaletteMode = "search" | "command";
 
+let cmdHeld = $state(false);
+export function getCmdHeld(): boolean { return cmdHeld; }
+
 let paletteOpen = $state(false);
 let paletteMode = $state<PaletteMode>("search");
 
@@ -34,6 +37,7 @@ export function closePalette(): void {
 // ── Global keydown listener ──────────────────────────────
 
 function handleKeydown(e: KeyboardEvent): void {
+  if (e.metaKey && !cmdHeld) cmdHeld = true;
   // Only handle meta-key combos globally (these should work even in inputs)
   if (!e.metaKey) return;
 
@@ -147,8 +151,20 @@ function handleKeydown(e: KeyboardEvent): void {
   }
 }
 
+function handleKeyup(e: KeyboardEvent): void {
+  if (e.key === "Meta") cmdHeld = false;
+}
+
+function handleBlur(): void { cmdHeld = false; }
+
 /** Attach global keyboard listener. Returns cleanup function. */
 export function initShortcuts(): () => void {
   window.addEventListener("keydown", handleKeydown, { capture: true });
-  return () => window.removeEventListener("keydown", handleKeydown, { capture: true });
+  window.addEventListener("keyup", handleKeyup, { capture: true });
+  window.addEventListener("blur", handleBlur);
+  return () => {
+    window.removeEventListener("keydown", handleKeydown, { capture: true });
+    window.removeEventListener("keyup", handleKeyup, { capture: true });
+    window.removeEventListener("blur", handleBlur);
+  };
 }

--- a/apps/web/src/routes/repo/[repoId]/recaps/+page.svelte
+++ b/apps/web/src/routes/repo/[repoId]/recaps/+page.svelte
@@ -4,16 +4,35 @@ import { page } from "$app/state";
 import AuthGuard from "$lib/components/auth/AuthGuard.svelte";
 import PillTabs from "$lib/components/layout/PillTabs.svelte";
 import RecapPeriodView from "$lib/components/recaps/RecapPeriodView.svelte";
+import { getCmdHeld } from "$lib/stores/shortcuts.svelte";
 import { getMainAreaBounds } from "$lib/stores/sidebar.svelte";
 
 const repoId = $derived(page.params.repoId ?? "");
 
 let activePeriod = $state<RecapPeriod>("daily");
+const cmdHeld = $derived(getCmdHeld());
 
 const tabs = [
-  { id: "daily" as RecapPeriod, label: "Daily" },
-  { id: "weekly" as RecapPeriod, label: "Weekly" },
+  { id: "daily" as RecapPeriod, label: "Daily", shortcut: "1" },
+  { id: "weekly" as RecapPeriod, label: "Weekly", shortcut: "2" },
 ];
+
+$effect(() => {
+  function handleKeydown(e: KeyboardEvent): void {
+    if (!e.metaKey) return;
+    if (e.key === "1") {
+      e.preventDefault();
+      e.stopPropagation();
+      activePeriod = "daily";
+    } else if (e.key === "2") {
+      e.preventDefault();
+      e.stopPropagation();
+      activePeriod = "weekly";
+    }
+  }
+  window.addEventListener("keydown", handleKeydown, { capture: true });
+  return () => window.removeEventListener("keydown", handleKeydown, { capture: true });
+});
 
 // Center the floating tabs over the visible main area, mirroring
 // AppShell's `.main-tab-bar` math exactly.
@@ -28,6 +47,7 @@ const floatingTabsStyle = $derived(`left: ${bounds.left}px; right: ${bounds.righ
 				{tabs}
 				activeTab={activePeriod}
 				onTabChange={(tab) => (activePeriod = tab as RecapPeriod)}
+				{cmdHeld}
 			/>
 		</div>
 		<div class="page">


### PR DESCRIPTION
## Summary
- Tracks `metaKey` hold/release state in the global shortcuts store (`getCmdHeld()`)
- `PillTabs` gains an optional `shortcut` field on `TabConfig` and a `cmdHeld` prop; when held, a dimmed `⌘N` badge fades in to the left of each tab label
- `FloatingTabs` (review page) wires in `getCmdHeld()` and passes shortcuts `1/2/3` for Walkthrough/Diff/Request Changes
- Recap page wires in `getCmdHeld()`, passes shortcuts `1/2` for Daily/Weekly, and adds local Cmd+1/2 keyboard shortcuts (capture-phase, so they don't conflict with the global review-tab handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)