### PR TITLE
feat(chat): reattach queue + composer on a shared glass surface

### DIFF
--- a/apps/web/src/lib/components/ai/prompt-input/PromptInputTextarea.svelte
+++ b/apps/web/src/lib/components/ai/prompt-input/PromptInputTextarea.svelte
@@ -41,6 +41,7 @@ export type PromptInputTextareaProps = HTMLTextareaAttributes & {
 	}
 
 	$effect(() => {
+		// Track ctx.value so autoResize fires on programmatic clear/fill.
 		void ctx.value;
 		autoResize();
 	});

--- a/apps/web/src/lib/components/ai/prompt-input/PromptInputTextarea.svelte
+++ b/apps/web/src/lib/components/ai/prompt-input/PromptInputTextarea.svelte
@@ -9,7 +9,7 @@ export type PromptInputTextareaProps = HTMLTextareaAttributes & {
 
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
-	import { getContext, tick } from "svelte";
+	import { getContext } from "svelte";
 	import { PROMPT_INPUT_CTX_KEY, type PromptInputContext } from "./context.js";
 
 	let {
@@ -30,17 +30,19 @@ export type PromptInputTextareaProps = HTMLTextareaAttributes & {
 
 	function autoResize() {
 		if (!textareaEl) return;
+		// Empty: defer to CSS min-height. Measuring scrollHeight during the
+		// first layout pass of the floating composer can latch oversized.
+		if (!ctx.value) {
+			textareaEl.style.height = "";
+			return;
+		}
 		textareaEl.style.height = "auto";
 		textareaEl.style.height = Math.min(textareaEl.scrollHeight, 160) + "px";
 	}
 
 	$effect(() => {
-		// Track context value so autoResize fires on programmatic clear/fill.
-		// Defer to a microtask so scrollHeight is read after the browser has
-		// reflected the new value — without this, the initial measurement
-		// happens before layout commit and the textarea sticks oversized.
 		void ctx.value;
-		void tick().then(autoResize);
+		autoResize();
 	});
 </script>
 

--- a/apps/web/src/lib/components/ai/queue/QueueSectionTrigger.svelte
+++ b/apps/web/src/lib/components/ai/queue/QueueSectionTrigger.svelte
@@ -18,7 +18,7 @@ export type QueueSectionTriggerProps = {
 <CollapsibleTrigger
 	data-slot="queue-section-trigger"
 	class={cn(
-		"group flex w-full items-center justify-between rounded-md bg-muted/40 px-3 py-2 text-left font-medium text-muted-foreground text-sm transition-colors duration-snap hover:bg-muted",
+		"group flex w-full items-center justify-between rounded-md bg-[var(--color-bg-tertiary)] px-3 py-2 text-left font-medium text-muted-foreground text-sm transition-colors duration-snap hover:bg-[var(--color-bg-tertiary)]/80",
 		className,
 	)}
 >

--- a/apps/web/src/lib/components/layout/RightPanel.svelte
+++ b/apps/web/src/lib/components/layout/RightPanel.svelte
@@ -844,13 +844,13 @@ function activitiesForTurn(
 		<ConversationScrollButton />
 	</Conversation>
 
-	<!-- Floating composer: queue dock + chat input sit on top of the
-		 conversation surface so messages scroll underneath them. -->
+	<!-- Floating composer: queue dock + chat input share one glass surface
+		 anchored to the panel bottom; messages scroll underneath them. -->
 	<div class="composer-float">
 	<!-- Queue dock: proposed commits + agent tasks + queued messages -->
 	{#if showQueueDock}
 		<div class="queue-dock" transition:slide={{ duration: 220, easing: cubicOut }}>
-			<Queue class="shadow-sm">
+			<Queue class="composer-glass rounded-t-xl rounded-b-none border-b-0 shadow-none">
 				<!-- Proposed commits from the agent -->
 				{#if commitCount > 0 && proposed}
 					<div transition:slide={{ duration: 220, easing: cubicOut }}>
@@ -1124,7 +1124,7 @@ function activitiesForTurn(
 			onsubmit={handlePromptSubmit}
 			onstop={handleStop}
 			status={inputStatus}
-			class={'bg-background/85 shadow-md backdrop-blur-md transition-[border-color,box-shadow] duration-quick ease-out-expo focus-within:border-accent/70 focus-within:shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-accent)_14%,transparent)] hover:not(:focus-within):not(:has(:disabled)):border-border-hover' + (!prId ? ' opacity-60' : '')}
+			class={'composer-glass composer-glass-input transition-[border-color,box-shadow] duration-quick ease-out-expo' + (showQueueDock ? ' composer-glass--attached rounded-t-none border-t-0' : '') + (!prId ? ' opacity-60' : '')}
 		>
 			<PromptInputBody>
 				<PromptInputTextarea
@@ -1363,8 +1363,7 @@ function activitiesForTurn(
 	}
 
 	/* Floating composer: queue dock + chat input float above the
-	   conversation. Anchored to the bottom of the panel; messages
-	   scroll underneath them. */
+	   conversation, flush with each other so they read as one panel. */
 	.composer-float {
 		position: absolute;
 		left: 10px;
@@ -1373,12 +1372,47 @@ function activitiesForTurn(
 		z-index: 4;
 		display: flex;
 		flex-direction: column;
-		gap: 6px;
 		pointer-events: none;
 	}
 
 	.composer-float > :global(*) {
 		pointer-events: auto;
+	}
+
+	/* Shared glass surface — blur + saturate like PillTabs. */
+	:global(.composer-glass) {
+		background: color-mix(in srgb, var(--color-panel-bg) 88%, transparent);
+		backdrop-filter: blur(16px) saturate(1.4);
+		-webkit-backdrop-filter: blur(16px) saturate(1.4);
+		border-color: var(--color-glass-border);
+		box-shadow:
+			var(--color-glass-shadow),
+			inset 0 0.5px 0 0 var(--color-glass-highlight);
+	}
+
+	/* Focus ring layered on top of the glass shadow, not replacing it. */
+	:global(.composer-glass-input:focus-within) {
+		border-color: color-mix(in srgb, var(--color-accent) 70%, transparent);
+		box-shadow:
+			0 0 0 3px color-mix(in srgb, var(--color-accent) 14%, transparent),
+			var(--color-glass-shadow),
+			inset 0 0.5px 0 0 var(--color-glass-highlight);
+	}
+
+	:global(.composer-glass-input:hover:not(:focus-within):not(:has(:disabled))) {
+		border-color: var(--color-border-hover);
+	}
+
+	/* Input attached under the queue: drop the inset top-highlight so the
+	   seam reads as one panel. */
+	:global(.composer-glass--attached) {
+		box-shadow: var(--color-glass-shadow);
+	}
+
+	:global(.composer-glass--attached.composer-glass-input:focus-within) {
+		box-shadow:
+			0 0 0 3px color-mix(in srgb, var(--color-accent) 14%, transparent),
+			var(--color-glass-shadow);
 	}
 
 	/* Header */


### PR DESCRIPTION
## Summary
- Merge the floating queue dock and PromptInput back into one attached panel (queue gets `rounded-t-xl` + stripped bottom border; input gets `rounded-t-none border-t-0` when the queue is present).
- Give the queue + composer a shared glass surface (`--color-panel-bg` at 88% + `blur(16px) saturate(1.4)`, matching the PillTabs pill), with the focus ring layered on top of the glass shadow instead of replacing it.
- Warm the `QueueSectionTrigger` header to `--color-bg-tertiary` so muted todo text stays legible.
- Fix the empty-textarea oversize on first render: clear inline height when value is empty and defer to `min-h-[2.75rem]` instead of measuring `scrollHeight` during the floating composer's first layout pass.

## Test plan
- [ ] Verify the queue dock + composer read as one panel (no seam) in both light and dark themes.
- [ ] Open the chat with no value — textarea lands at one-row resting size on first render.
- [ ] Focus the input — accent focus ring shows on top of the glass shadow without removing it.
- [ ] Send a long message that wraps — textarea grows up to the 160px cap, then scrolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)