### PR TITLE
feat(prs): optimistic mutations for owner PR actions

### DIFF
--- a/apps/web/src/lib/stores/prs.svelte.ts
+++ b/apps/web/src/lib/stores/prs.svelte.ts
@@ -487,36 +487,94 @@ export function deleteRepo(id: string): Promise<void> {
 }
 
 /**
- * Owner-only PR mutations. The server runs the GitHub mutation, refreshes
- * the local row from a fresh GET, and broadcasts `prs:updated` — we only
- * surface the loading state and toast on failure here. The list refresh
- * arrives over the WebSocket; no local mutation is required.
+ * Owner-only PR mutations. Optimistic with entity-scoped rollback per
+ * conventions §4.6: flip the affected fields locally before awaiting the
+ * server, restore them on throw. The successful round-trip's `prs:updated`
+ * broadcast reconciles the canonical list as the source of truth — our
+ * optimistic write is only for the in-flight window.
  */
+function flipPrDraftLocally(prId: string, isDraft: boolean): void {
+  pullRequests = pullRequests.map((p) => (p.id === prId ? { ...p, isDraft } : p));
+}
+
 export async function convertPrToDraft(prId: string): Promise<void> {
+  const pr = pullRequests.find((p) => p.id === prId);
+  if (!pr || pr.isDraft) return;
+  const prevIsDraft = pr.isDraft;
+
+  flipPrDraftLocally(prId, true);
+
   try {
     const { error } = await api.api.prs({ id: prId })["convert-to-draft"].post();
     if (error) throw new Error(`HTTP ${error.status}`);
   } catch (e) {
+    flipPrDraftLocally(prId, prevIsDraft);
     toast.error(e instanceof Error ? e.message : "Failed to convert to draft");
     throw e;
   }
 }
 
 export async function markPrReadyForReview(prId: string): Promise<void> {
+  const pr = pullRequests.find((p) => p.id === prId);
+  if (!pr?.isDraft) return;
+  const prevIsDraft = pr.isDraft;
+
+  flipPrDraftLocally(prId, false);
+
   try {
     const { error } = await api.api.prs({ id: prId })["ready-for-review"].post();
     if (error) throw new Error(`HTTP ${error.status}`);
   } catch (e) {
+    flipPrDraftLocally(prId, prevIsDraft);
     toast.error(e instanceof Error ? e.message : "Failed to mark ready for review");
     throw e;
   }
 }
 
+/**
+ * Restore a PR from the archive back into the open list with prior status
+ * and closedAt. Used by the `closePr` / `mergePr` rollback path — the
+ * reverse of `onPrArchived`'s forward move. Touches only the one PR so
+ * concurrent `prs:updated` reshuffles of other entries are preserved.
+ */
+function restorePrFromArchive(
+  prId: string,
+  prevStatus: PullRequest["status"],
+  prevClosedAt: string | null,
+): void {
+  const archived = archivedPrs.find((p) => p.id === prId);
+  if (!archived) return;
+  archivedPrs = archivedPrs.filter((p) => p.id !== prId);
+  pullRequests = [{ ...archived, status: prevStatus, closedAt: prevClosedAt }, ...pullRequests];
+}
+
 export async function closePr(prId: string): Promise<void> {
+  const pr = pullRequests.find((p) => p.id === prId);
+  if (!pr) {
+    // PR not known locally — fall back to pessimistic. WS reconciles.
+    const { error } = await api.api.prs({ id: prId }).close.post();
+    if (error) {
+      toast.error(`Failed to close PR (HTTP ${error.status})`);
+      throw new Error(`HTTP ${error.status}`);
+    }
+    return;
+  }
+
+  const prevStatus = pr.status;
+  const prevClosedAt = pr.closedAt;
+
+  onPrArchived({
+    prId,
+    repoId: pr.repositoryId,
+    status: "closed",
+    closedAt: new Date().toISOString(),
+  });
+
   try {
     const { error } = await api.api.prs({ id: prId }).close.post();
     if (error) throw new Error(`HTTP ${error.status}`);
   } catch (e) {
+    restorePrFromArchive(prId, prevStatus, prevClosedAt);
     toast.error(e instanceof Error ? e.message : "Failed to close PR");
     throw e;
   }
@@ -534,11 +592,34 @@ export async function getMergeEligibility(prId: string): Promise<MergeEligibilit
 }
 
 export async function mergePr(prId: string, mergeMethod: MergeMethod): Promise<void> {
+  const pr = pullRequests.find((p) => p.id === prId);
+  if (!pr) {
+    // PR not known locally — fall back to pessimistic. WS reconciles.
+    const { error } = await api.api.prs({ id: prId }).merge.post({ mergeMethod });
+    if (error) {
+      toast.error(`Failed to merge pull request (HTTP ${error.status})`);
+      throw new Error(`HTTP ${error.status}`);
+    }
+    toast.success("Pull request merged successfully");
+    return;
+  }
+
+  const prevStatus = pr.status;
+  const prevClosedAt = pr.closedAt;
+
+  onPrArchived({
+    prId,
+    repoId: pr.repositoryId,
+    status: "merged",
+    closedAt: new Date().toISOString(),
+  });
+
   try {
     const { error } = await api.api.prs({ id: prId }).merge.post({ mergeMethod });
     if (error) throw new Error(`HTTP ${error.status}`);
     toast.success("Pull request merged successfully");
   } catch (e) {
+    restorePrFromArchive(prId, prevStatus, prevClosedAt);
     toast.error(e instanceof Error ? e.message : "Failed to merge pull request");
     throw e;
   }

--- a/docs/conventions-backlog.md
+++ b/docs/conventions-backlog.md
@@ -9,11 +9,39 @@ default sort.
 | Domain | Open | Severity mix |
 |---|---|---|
 | Server (Effect) | 0 | — |
-| Web stores | 0 | — |
+| Web stores | 1 | low |
 | UI / motion | 14 | all fixed |
-| **Total** | **0** | |
+| **Total** | **1** | |
 
-All outstanding convention violations are closed.
+---
+
+## Open
+
+<a id="s-005"></a>
+### S-005 — `deleteRepo` uses list-snapshot rollback instead of entity-scoped
+
+**Rule violated:** [§4.6 — Client-initiated mutations are optimistic with entity-scoped rollback](./conventions.md#stores-optimistic).
+
+**Where:** `apps/web/src/lib/stores/prs.svelte.ts:455-487` (`deleteRepo`), with helpers
+`snapshotRepoState` (`:188-196`) and `restoreRepoState` (`:198-205`).
+
+**Why it's a violation.** On error, `restoreRepoState` reassigns `repositories`,
+`pullRequests`, `archivedPrs`, `taggedPrsByRepo`, and `pinnedPrIds` to the pre-mutation
+snapshot. Any `prs:updated` / `repos:updated` / `pr:archived` broadcast that landed during
+the in-flight POST is silently dropped — including entirely unrelated entities the server
+added or removed for reasons that have nothing to do with this delete.
+
+**Fix shape.** Capture the *removed* state, not the *prior* state: which repo row was
+removed, which open PR ids and archived PR ids were removed, which pinned ids were removed.
+On rollback, re-insert each. Concurrent broadcasts that touched other entities survive
+untouched.
+
+**Severity:** Low — the failure mode is "concurrent unrelated broadcast lost during a
+rollback that itself is rare." Not actively biting in production. Tracked because
+`deleteRepo` is the canonical anti-pattern §4.6 was added to prevent and leaving it as-is
+implicitly endorses the shape.
+
+**Sizing:** ~30 lines. One PR. Worth pairing with any other touch to the repo-delete flow.
 
 ---
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -367,6 +367,43 @@ in `apps/web/src/lib/stores/chat.svelte.ts` (`resolveQuestionFromWs`).
 
 **Backlog.** [`S-004`](./conventions-backlog.md#s-004).
 
+<a id="stores-optimistic"></a>
+### 4.6 Client-initiated mutations are optimistic with entity-scoped rollback
+
+**Rule.** A store function that wraps a server mutation flips local state immediately, awaits
+the API call, and on error restores the same entity's prior fields. Rollback captures *the
+specific fields being mutated on the specific entities involved* — never a list snapshot. If
+the calling component branches on the throw (loading spinners, inline errors), the function
+rethrows after the toast; otherwise it may swallow.
+
+**Why.** Two reasons. (1) **UI lag.** Waiting for the server round-trip plus the WS
+rebroadcast before reflecting the user's action is the laggy-feel symptom this rule
+eliminates — closing a PR, flipping draft state, merging, pinning should feel
+instantaneous because the outcome is rarely in doubt. (2) **Concurrency.** A `prs:updated`
+arriving during the optimistic window can legitimately add or remove *other* entities.
+List-snapshot rollback (`pullRequests = openSnapshot`) would clobber those updates and
+re-introduce entities the server has since removed. Restoring only the fields you changed
+on the entity you touched is resilient to whatever else arrives over the wire.
+
+**Canonical example.** `apps/web/src/lib/stores/prs.svelte.ts:338-362` — `pinPr` and
+`unpinPr` capture the single field they mutate (`pinnedPrIds` membership), apply,
+and restore on throw. The four owner-only PR mutations (`convertPrToDraft`,
+`markPrReadyForReview`, `closePr`, `mergePr`) in the same file follow the same shape
+with more fields involved: draft flip uses a single-field local helper; close/merge reuse
+the existing `onPrArchived` for the forward open→archived move and `restorePrFromArchive`
+for the reverse rollback. Both helpers touch exactly one PR per call so concurrent
+`prs:updated` broadcasts that reshuffle the rest of the list survive intact.
+
+**Anti-pattern.** `apps/web/src/lib/stores/prs.svelte.ts:455-487` — `deleteRepo` snapshots
+`repositories`, `pullRequests`, `archivedPrs`, `taggedPrsByRepo`, and `pinnedPrIds` whole
+via `snapshotRepoState()`, restores them whole on error via `restoreRepoState()`. The
+shape works for the rare single-entity-delete case it lives in, but it does not generalize:
+any concurrent WS broadcast between snapshot and rollback is silently dropped. The fix is
+entity-scoped removal — capture the removed repo, the removed PR ids, and the removed
+pinned ids — and inverse them on rollback rather than restoring the whole world.
+
+**Backlog.** [`S-005`](./conventions-backlog.md#s-005).
+
 ---
 
 <a id="ui-motion"></a>


### PR DESCRIPTION
## Summary

- `closePr`, `mergePr`, `convertPrToDraft`, and `markPrReadyForReview` now flip local state immediately and roll back only the touched entity's fields on error — surviving concurrent `prs:updated` broadcasts during the in-flight window.
- Two private helpers (`flipPrDraftLocally`, `restorePrFromArchive`) keep the rollback entity-scoped; the forward close/merge path reuses the existing `onPrArchived` handler.
- Adds §4.6 to `docs/conventions.md` codifying this pattern (canonical: `pinPr`; anti-pattern: `deleteRepo` list-snapshot).
- Tracks the `deleteRepo` list-snapshot rollback as backlog item S-005 in `docs/conventions-backlog.md`.

## Test plan

- [ ] Open a PR you own; click "Close PR" — PR should disappear from the open list and appear in the archive instantly, before the server broadcast arrives
- [ ] Same for "Mark as draft" (badge flips) and "Mark ready for review" (badge flips back) and "Merge"
- [ ] Failure path: kill the server mid-click — PR should snap back to its prior position with a toast
- [ ] Verify `make typecheck` and `make lint` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)