### PR TITLE
feat(design): impeccable polish pass + deep naval accent

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,418 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-23T00:00:00Z",
+  "title": "Design System: Revv",
+  "extensions": {
+    "colorMeta": {
+      "coastal-teal": {
+        "role": "primary",
+        "displayName": "Coastal Teal",
+        "canonical": "oklch(46% 0.075 180)",
+        "tonalRamp": [
+          "oklch(15% 0.04 180)",
+          "oklch(25% 0.06 180)",
+          "oklch(35% 0.072 180)",
+          "oklch(46% 0.075 180)",
+          "oklch(55% 0.082 180)",
+          "oklch(65% 0.088 180)",
+          "oklch(78% 0.06 180)",
+          "oklch(95% 0.012 180)"
+        ]
+      },
+      "warm-paper": {
+        "role": "neutral",
+        "displayName": "Warm Paper",
+        "canonical": "oklch(98% 0.005 80)",
+        "tonalRamp": [
+          "oklch(15% 0.005 80)",
+          "oklch(28% 0.005 80)",
+          "oklch(46% 0.005 80)",
+          "oklch(64% 0.005 80)",
+          "oklch(78% 0.005 80)",
+          "oklch(88% 0.006 80)",
+          "oklch(94% 0.006 80)",
+          "oklch(98% 0.005 80)"
+        ]
+      },
+      "warm-stone": {
+        "role": "neutral",
+        "displayName": "Warm Stone",
+        "canonical": "oklch(95% 0.008 80)",
+        "tonalRamp": [
+          "oklch(18% 0.008 80)",
+          "oklch(30% 0.009 80)",
+          "oklch(48% 0.010 80)",
+          "oklch(66% 0.010 80)",
+          "oklch(80% 0.010 80)",
+          "oklch(88% 0.010 80)",
+          "oklch(92% 0.009 80)",
+          "oklch(95% 0.008 80)"
+        ]
+      },
+      "ink-primary": {
+        "role": "neutral",
+        "displayName": "Ink Primary",
+        "canonical": "oklch(22% 0.008 60)",
+        "tonalRamp": [
+          "oklch(15% 0.008 60)",
+          "oklch(22% 0.008 60)",
+          "oklch(34% 0.010 60)",
+          "oklch(46% 0.010 60)",
+          "oklch(58% 0.010 60)",
+          "oklch(70% 0.010 60)",
+          "oklch(82% 0.008 60)",
+          "oklch(94% 0.006 60)"
+        ]
+      },
+      "considered-violet": {
+        "role": "tertiary",
+        "displayName": "Considered Violet",
+        "canonical": "oklch(45% 0.20 290)",
+        "tonalRamp": [
+          "oklch(18% 0.10 290)",
+          "oklch(28% 0.14 290)",
+          "oklch(36% 0.18 290)",
+          "oklch(45% 0.20 290)",
+          "oklch(56% 0.21 290)",
+          "oklch(68% 0.18 290)",
+          "oklch(80% 0.12 290)",
+          "oklch(94% 0.04 290)"
+        ]
+      },
+      "considered-red": {
+        "role": "secondary",
+        "displayName": "Considered Red",
+        "canonical": "oklch(48% 0.19 25)",
+        "tonalRamp": [
+          "oklch(18% 0.09 25)",
+          "oklch(28% 0.13 25)",
+          "oklch(38% 0.17 25)",
+          "oklch(48% 0.19 25)",
+          "oklch(58% 0.19 25)",
+          "oklch(70% 0.16 25)",
+          "oklch(82% 0.10 25)",
+          "oklch(94% 0.03 25)"
+        ]
+      },
+      "considered-green": {
+        "role": "secondary",
+        "displayName": "Considered Green",
+        "canonical": "oklch(50% 0.15 145)",
+        "tonalRamp": [
+          "oklch(18% 0.08 145)",
+          "oklch(30% 0.12 145)",
+          "oklch(40% 0.14 145)",
+          "oklch(50% 0.15 145)",
+          "oklch(62% 0.15 145)",
+          "oklch(74% 0.13 145)",
+          "oklch(86% 0.08 145)",
+          "oklch(95% 0.03 145)"
+        ]
+      },
+      "workshop-amber": {
+        "role": "secondary",
+        "displayName": "Workshop Amber",
+        "canonical": "oklch(54% 0.15 65)",
+        "tonalRamp": [
+          "oklch(20% 0.07 65)",
+          "oklch(32% 0.11 65)",
+          "oklch(44% 0.13 65)",
+          "oklch(54% 0.15 65)",
+          "oklch(66% 0.16 65)",
+          "oklch(78% 0.13 65)",
+          "oklch(88% 0.08 65)",
+          "oklch(96% 0.03 65)"
+        ]
+      },
+      "demands-attention": {
+        "role": "tertiary",
+        "displayName": "Demands Attention (Warm Orange-700)",
+        "canonical": "oklch(53% 0.18 45)",
+        "tonalRamp": [
+          "oklch(20% 0.09 45)",
+          "oklch(32% 0.13 45)",
+          "oklch(42% 0.16 45)",
+          "oklch(53% 0.18 45)",
+          "oklch(65% 0.18 45)",
+          "oklch(76% 0.15 45)",
+          "oklch(86% 0.09 45)",
+          "oklch(95% 0.03 45)"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Display",
+        "purpose": "Rare; reserved for page-level titles when one exists. Most surfaces skip this and start at Headline."
+      },
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "Panel headers, walkthrough section titles."
+      },
+      "title": {
+        "displayName": "Title",
+        "purpose": "Card titles, PR titles in the watchtower list."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "All running text. Walkthrough markdown, recap content, chat messages. Caps at 70ch in prose contexts."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Inline labels, metadata, tab text. Sentence case; uppercase is prohibited as decoration."
+      },
+      "mono": {
+        "displayName": "Mono",
+        "purpose": "Code in diffs, identifiers in prose, filenames in the file tree."
+      }
+    },
+    "shadows": [
+      {
+        "name": "indicator",
+        "value": "0 1px 3px rgba(42, 40, 37, 0.08), 0 2px 8px rgba(42, 40, 37, 0.06), 0 0 0 0.5px rgba(42, 40, 37, 0.04)",
+        "purpose": "Soft ambient ring under the smallest floating elements (marker glows, status dots, active tab)."
+      },
+      {
+        "name": "sm",
+        "value": "0 2px 6px rgba(42, 40, 37, 0.08)",
+        "purpose": "Glass pills at rest, chip stacks."
+      },
+      {
+        "name": "md",
+        "value": "0 4px 16px rgba(42, 40, 37, 0.10)",
+        "purpose": "Popovers, tooltips, the line-action floating pill above a diff line."
+      },
+      {
+        "name": "lg",
+        "value": "0 8px 24px rgba(42, 40, 37, 0.12), 0 2px 8px rgba(42, 40, 37, 0.06)",
+        "purpose": "Sheets, the chat panel when it floats above the diff."
+      },
+      {
+        "name": "xl",
+        "value": "0 16px 48px rgba(42, 40, 37, 0.18), 0 4px 12px rgba(42, 40, 37, 0.10)",
+        "purpose": "Dialogs, modals, the command palette."
+      }
+    ],
+    "motion": [
+      {
+        "name": "duration-instant",
+        "value": "80ms",
+        "purpose": "Hover, focus rings, micro-state."
+      },
+      { "name": "duration-snap", "value": "120ms", "purpose": "Small surfaces, chevrons, badges." },
+      { "name": "duration-quick", "value": "160ms", "purpose": "Default UI motion." },
+      {
+        "name": "duration-smooth",
+        "value": "220ms",
+        "purpose": "Panels, sidebars, larger reveals."
+      },
+      { "name": "duration-slow", "value": "320ms", "purpose": "Dialogs, sheets, big surfaces." },
+      {
+        "name": "duration-page",
+        "value": "480ms",
+        "purpose": "Route morphs, shared-element transitions."
+      },
+      {
+        "name": "duration-ceremonial-quick",
+        "value": "280ms",
+        "purpose": "Onboarding-only theatrical entrance, quick variant."
+      },
+      {
+        "name": "duration-ceremonial-medium",
+        "value": "480ms",
+        "purpose": "Onboarding-only theatrical entrance, medium variant."
+      },
+      {
+        "name": "duration-ceremonial-slow",
+        "value": "720ms",
+        "purpose": "Onboarding-only theatrical entrance, slow variant."
+      },
+      {
+        "name": "ease-soft",
+        "value": "cubic-bezier(0.4, 0, 0.2, 1)",
+        "purpose": "Default in/out for exits and bidirectional state."
+      },
+      {
+        "name": "ease-out-expo",
+        "value": "cubic-bezier(0.16, 1, 0.3, 1)",
+        "purpose": "Default for appearance / enter. Slight overshoot."
+      },
+      {
+        "name": "ease-standard",
+        "value": "cubic-bezier(0.22, 0.61, 0.36, 1)",
+        "purpose": "Walkthrough chapter morphs, content reveals."
+      },
+      {
+        "name": "ease-anticipate",
+        "value": "cubic-bezier(0.68, -0.55, 0.27, 1.55)",
+        "purpose": "Reserved for delight moments. Use sparingly."
+      }
+    ],
+    "breakpoints": []
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Coastal Teal fill on warm-paper canvas. 1px tactile press on :active. The default brand CTA.",
+      "html": "<button class=\"ds-btn-primary\">Approve and merge</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; height: 32px; padding: 0 10px; background: #0f766e; color: #ffffff; border: 1px solid transparent; border-radius: 8px; font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; line-height: 1; letter-spacing: 0; cursor: pointer; transition: background 120ms cubic-bezier(0.16, 1, 0.3, 1), transform 120ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-primary:hover { background: #115e59; } .ds-btn-primary:active { transform: translateY(1px); } .ds-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.4); }"
+    },
+    {
+      "name": "Outline Button",
+      "kind": "button",
+      "refersTo": "button-outline",
+      "description": "Warm-paper background with a paper-edge hairline border. The default chrome action.",
+      "html": "<button class=\"ds-btn-outline\">View diff</button>",
+      "css": ".ds-btn-outline { display: inline-flex; align-items: center; justify-content: center; height: 32px; padding: 0 10px; background: #faf9f6; color: #2a2825; border: 1px solid #e4e0d8; border-radius: 8px; font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; line-height: 1; cursor: pointer; transition: background 120ms cubic-bezier(0.16, 1, 0.3, 1), transform 120ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-outline:hover { background: #f4f1eb; } .ds-btn-outline:active { transform: translateY(1px); } .ds-btn-outline:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.4); }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "Transparent at rest, lifts to warm-stone on hover. The most common button variant for chrome actions.",
+      "html": "<button class=\"ds-btn-ghost\">Cancel</button>",
+      "css": ".ds-btn-ghost { display: inline-flex; align-items: center; justify-content: center; height: 32px; padding: 0 10px; background: transparent; color: #5a5650; border: 1px solid transparent; border-radius: 8px; font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; line-height: 1; cursor: pointer; transition: background 120ms cubic-bezier(0.16, 1, 0.3, 1), color 120ms cubic-bezier(0.16, 1, 0.3, 1), transform 120ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-ghost:hover { background: #f4f1eb; color: #2a2825; } .ds-btn-ghost:active { transform: translateY(1px); } .ds-btn-ghost:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.4); }"
+    },
+    {
+      "name": "Destructive Button",
+      "kind": "button",
+      "refersTo": "button-destructive",
+      "description": "Considered Red at 10% alpha with Considered Red text. Never a solid red fill; the warning is in the color, not the volume.",
+      "html": "<button class=\"ds-btn-destructive\">Discard changes</button>",
+      "css": ".ds-btn-destructive { display: inline-flex; align-items: center; justify-content: center; height: 32px; padding: 0 10px; background: rgba(185, 28, 28, 0.10); color: #b91c1c; border: 1px solid transparent; border-radius: 8px; font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; font-weight: 500; line-height: 1; cursor: pointer; transition: background 120ms cubic-bezier(0.16, 1, 0.3, 1), transform 120ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-btn-destructive:hover { background: rgba(185, 28, 28, 0.20); } .ds-btn-destructive:active { transform: translateY(1px); } .ds-btn-destructive:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(185, 28, 28, 0.30); }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input-default",
+      "description": "Warm-stone fill with hairline border; focus glow rather than border-color change.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Search repos and PRs\" />",
+      "css": ".ds-input { display: block; width: 100%; height: 32px; padding: 8px 12px; background: #f4f1eb; color: #2a2825; border: 1px solid #e4e0d8; border-radius: 8px; font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; line-height: 1; outline: none; transition: box-shadow 160ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-input::placeholder { color: #9a958c; } .ds-input:focus-visible { box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.4); }"
+    },
+    {
+      "name": "Active Tab",
+      "kind": "nav",
+      "refersTo": "tab-active",
+      "description": "The active PR tab in the floating-tab track. Warm-paper fill against a stone-tone track; Indicator shadow lifts it.",
+      "html": "<div class=\"ds-tab-track\"><button class=\"ds-tab ds-tab--active\">user-auth.ts</button><button class=\"ds-tab\">middleware.ts</button></div>",
+      "css": ".ds-tab-track { display: inline-flex; gap: 4px; padding: 4px; background: rgba(42, 40, 37, 0.06); border-radius: 12px; } .ds-tab { display: inline-flex; align-items: center; height: 28px; padding: 0 12px; background: transparent; color: #7a756c; border: none; border-radius: 8px; font-family: Inter, system-ui, sans-serif; font-size: 0.8125rem; font-weight: 500; cursor: pointer; transition: background 120ms cubic-bezier(0.16, 1, 0.3, 1), color 120ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-tab:hover { background: #eae6de; color: #2a2825; } .ds-tab--active { background: #faf9f6; color: #2a2825; box-shadow: 0 1px 3px rgba(42, 40, 37, 0.08), 0 2px 8px rgba(42, 40, 37, 0.06), 0 0 0 0.5px rgba(42, 40, 37, 0.04); }"
+    },
+    {
+      "name": "Glass Pill",
+      "kind": "custom",
+      "refersTo": "glass-pill",
+      "description": "Floating chrome above the canvas. Warm-paper at 78% alpha with backdrop-blur. Used for the line-action pill, mode toggles, ambient status. Glass is a role, not a default.",
+      "html": "<div class=\"ds-glass-pill\"><span>2 of 12 files</span><span class=\"ds-glass-pill__sep\"></span><span>review session</span></div>",
+      "css": ".ds-glass-pill { display: inline-flex; align-items: center; gap: 8px; height: 28px; padding: 0 12px; background: rgba(250, 249, 246, 0.78); color: #2a2825; border: 1px solid rgba(42, 40, 37, 0.09); border-radius: 999px; backdrop-filter: blur(6px); -webkit-backdrop-filter: blur(6px); box-shadow: 0 2px 6px rgba(42, 40, 37, 0.08); font-family: Inter, system-ui, sans-serif; font-size: 0.75rem; font-weight: 500; letter-spacing: 0.01em; } .ds-glass-pill__sep { display: inline-block; width: 1px; height: 12px; background: rgba(42, 40, 37, 0.15); }"
+    },
+    {
+      "name": "File Tree Row (Active)",
+      "kind": "nav",
+      "refersTo": "file-tree-row",
+      "description": "A row in the file tree sidebar. Active state uses Coastal Teal *tinted* into the background (10% alpha), not the solid accent. The row whispers the brand.",
+      "html": "<div class=\"ds-tree\"><div class=\"ds-tree__row\">apps/web/<wbr>routes/<wbr>+page.svelte</div><div class=\"ds-tree__row ds-tree__row--active\">apps/web/<wbr>routes/<wbr>review/<wbr>+page.svelte</div><div class=\"ds-tree__row\">apps/server/<wbr>src/<wbr>index.ts</div></div>",
+      "css": ".ds-tree { display: flex; flex-direction: column; gap: 1px; padding: 4px; background: #f4f1eb; border-radius: 8px; } .ds-tree__row { padding: 6px 10px; border-radius: 6px; color: #5a5650; font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 0.8125rem; line-height: 1.4; cursor: pointer; transition: background 120ms cubic-bezier(0.16, 1, 0.3, 1), color 120ms cubic-bezier(0.16, 1, 0.3, 1); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; } .ds-tree__row:hover { background: #eae6de; color: #2a2825; } .ds-tree__row--active { background: rgba(15, 118, 110, 0.10); color: #115e59; }"
+    },
+    {
+      "name": "Diff Line (Addition)",
+      "kind": "custom",
+      "refersTo": "diff-add-line",
+      "description": "A single addition line in the diff canvas. Warm-stone canvas, deepened green tint, JetBrains Mono code at 0.8125rem. The full diff vocabulary lives in app.css.",
+      "html": "<div class=\"ds-diff\"><div class=\"ds-diff__row ds-diff__row--add\"><span class=\"ds-diff__gutter\">+12</span><span class=\"ds-diff__code\">  const session = await auth.verify(token);</span></div><div class=\"ds-diff__row\"><span class=\"ds-diff__gutter\">13</span><span class=\"ds-diff__code\">  if (!session) return new Response(null, { status: 401 });</span></div></div>",
+      "css": ".ds-diff { background: #f4f1eb; border: 1px solid #e4e0d8; border-radius: 8px; overflow: hidden; font-family: 'JetBrains Mono', 'Fira Code', monospace; font-size: 0.8125rem; line-height: 1.5; } .ds-diff__row { display: grid; grid-template-columns: 48px 1fr; align-items: baseline; transition: background 80ms cubic-bezier(0.16, 1, 0.3, 1); } .ds-diff__row:hover { background: #eae6de; } .ds-diff__gutter { padding: 1px 12px 1px 0; color: #9a958c; text-align: right; border-right: 1px solid #e4e0d8; background: #edeae3; user-select: none; font-size: 0.75rem; } .ds-diff__code { padding: 1px 12px; color: #2a2825; white-space: pre; } .ds-diff__row--add { background: #e6f4ec; } .ds-diff__row--add:hover { background: #d0ebd9; } .ds-diff__row--add .ds-diff__gutter { background: #ddf0e3; color: #14532d; } .ds-diff__row--add .ds-diff__code { color: #14532d; }"
+    },
+    {
+      "name": "AI Stream Cursor",
+      "kind": "custom",
+      "refersTo": "stream-cursor",
+      "description": "The 1ch-wide blinking cursor that appears while AI is producing tokens. Opt-back-in to motion under prefers-reduced-motion via .motion-essential-blink so the user can always tell the system is alive.",
+      "html": "<p class=\"ds-stream\">This change extracts the auth middleware into a reusable Effect layer<span class=\"ds-stream__cursor motion-essential-blink\"></span></p>",
+      "css": ".ds-stream { font-family: Inter, system-ui, sans-serif; font-size: 0.875rem; line-height: 1.5; color: #2a2825; } .ds-stream__cursor { display: inline-block; width: 1ch; height: 1em; margin-left: 2px; vertical-align: -2px; background: #0f766e; border-radius: 1px; box-shadow: 0 0 8px rgba(15, 118, 110, 0.35); } @keyframes ds-stream-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } } .motion-essential-blink { animation: ds-stream-blink 1s steps(2, end) infinite; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Reading Room",
+    "overview": "Revv is the reading room of code review: warm paper underfoot, considered ink, expert silence, and exactly one accent worth lifting your eyes for. The canvas reads as a page, not a screen. Reviewers come here to think, not to be sold to or coached. Chrome recedes; code and conversation are the foreground.\n\nThe system rejects the noisy SaaS dashboard, the GitHub web UI's marketing chrome, and the neon-on-black AI-tool aesthetic in equal measure. Where other code-review tools ship stock Tailwind blue, Revv ships Coastal Teal at low frequency. Where others stack shadows for 'depth,' Revv layers warm tones and reserves shadows for things that genuinely float. Where others make AI feel magical with sparkles and gradients, Revv makes it feel collaborative with a single streaming character: the cursor.",
+    "keyCharacteristics": [
+      "Warm-paper background, never neutral gray, never #fff.",
+      "One brand accent (Coastal Teal #0f766e), used on ≤10% of any given screen.",
+      "Hybrid elevation: tonal layering for chrome, soft shadows only for floating UI.",
+      "Refined and restrained components: quiet at rest, precise on interaction.",
+      "Icons-only iconography (phosphor-svelte); emoji prohibited.",
+      "Reduced-motion is a contract, not a courtesy."
+    ],
+    "rules": [
+      {
+        "name": "The One Voice Rule",
+        "body": "The brand accent (Coastal Teal in light, Signal Blue in dark) is used on ≤10% of any given screen. Its rarity is the point. If three teal elements are competing on one surface, two are wrong.",
+        "section": "colors"
+      },
+      {
+        "name": "The No-Pure-Black Rule",
+        "body": "#000 is prohibited in light theme, and the dark theme canvas stops at #0a0a0a. Every neutral is tinted toward warm-paper or midnight-paper; no element ever sits on pure black or pure white.",
+        "section": "colors"
+      },
+      {
+        "name": "The Deepened Severity Rule",
+        "body": "Reds, greens, ambers in this system are one step deeper than the Tailwind defaults (red-700, green-700, amber-700 rather than 500). The intent is 'considered' rather than 'alarming.' Stock-bright severity reads as a prototype.",
+        "section": "colors"
+      },
+      {
+        "name": "The Single-Family Rule",
+        "body": "Inter is the only sans in the system; JetBrains Mono is the only mono. No display serif, no condensed sans, no second body family. Variety comes from weight (400/500/600) and scale, not from font-mixing.",
+        "section": "typography"
+      },
+      {
+        "name": "The Earned-Uppercase Rule",
+        "body": "Uppercase is prohibited as a decorative style. Use sentence case for everything except technical identifiers that are uppercase by convention.",
+        "section": "typography"
+      },
+      {
+        "name": "The 65–75ch Rule",
+        "body": "Body prose in walkthrough markdown, recap content, and chat messages caps at 70ch (max-w-prose in Tailwind). The diff is exempt; code wraps to the panel width.",
+        "section": "typography"
+      },
+      {
+        "name": "The Hybrid Rule",
+        "body": "Chrome layers via warm tones (paper → stone → ash). Floating UI layers via shadows. The two languages do not cross: a sidebar never gets a drop shadow, and a tooltip never relies on a tone step to read as 'above.'",
+        "section": "elevation"
+      },
+      {
+        "name": "The No-Heavy-Shadows Rule",
+        "body": "Shadow alpha caps at 0.18 (XL) in light theme. If a shadow needs to be heavier than XL to read, the elevation language is wrong: either the underlying surface contrast is off or the element should not be floating at all.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Tactile Press",
+        "body": "All buttons translate down 1px on :active (excluding popover triggers). The 1px press is deliberate; it makes interaction feel tangible against the paper canvas.",
+        "section": "components"
+      }
+    ],
+    "dos": [
+      "Do use Coastal Teal sparingly. ≤10% of any given screen. The streaming cursor, the active file row, the primary CTA, the focus ring. Not all four at once on the same surface.",
+      "Do use warm-paper as the canvas in light theme and warm-stone as the secondary surface. Tone steps carry chrome elevation.",
+      "Do use phosphor-svelte for every icon. Inline SVG only when no phosphor equivalent fits.",
+      "Do deepen severity colors one step from stock Tailwind (700 weight rather than 500) so reds and greens read as considered, not bright.",
+      "Do translate buttons 1px down on :active. The press is tactile and on purpose.",
+      "Do cap body prose at 70ch (Tailwind's max-w-prose). The diff is exempt.",
+      "Do honor prefers-reduced-motion as a contract. Opt back in only for motion that carries meaning, using .motion-essential-* classes.",
+      "Do use motion tokens from the @theme block: duration-snap, duration-quick, duration-smooth, ease-out-expo, ease-soft. No hand-typed durations."
+    ],
+    "donts": [
+      "Don't use emoji in rendered UI, ever. Not in buttons, not in fallback avatars, not in toast messages, not in placeholders. Use a phosphor icon or nothing.",
+      "Don't use stock Tailwind blue (blue-500, #3b82f6) as a brand accent in light theme. That is the color every other dashboard ships. Coastal Teal is the move.",
+      "Don't use side-stripe borders (border-left > 1px as a colored accent on cards, list items, callouts). Use a full hairline border, a background tint, or a leading icon instead.",
+      "Don't use gradient text (background-clip: text on a gradient). Decorative always, meaningful never. Emphasis comes from weight and size.",
+      "Don't use glassmorphism as a default surface style. The Glass Pill is the exception, not the rule.",
+      "Don't ship the hero-metric template (big number, small label, supporting stats, gradient accent). Watchtower mode does not need a SaaS-dashboard pastiche.",
+      "Don't stack identical card grids. If three cards in a row do not differ in weight or content, the grid is the lazy answer.",
+      "Don't reach for a modal as the first thought. Inline expansion, progressive disclosure, and side panels exhaust before a modal is justified.",
+      "Don't animate CSS layout properties. Translate, scale, opacity, and color only.",
+      "Don't use heavy purple gradients or neon accents to signal 'AI.' Revv's AI surfaces are warm paper with a single Considered Violet accent and a streaming cursor; that is the entire AI vocabulary.",
+      "Don't use #000 or #fff. Every neutral is tinted: warm-paper toward 36° in light, midnight-paper toward neutral in dark. Pure values read as 'untouched default.'",
+      "Don't use bright stock severity colors. red-500, green-500, amber-500 all read as prototype-bright. Use the deepened 700-weight equivalents already in the palette."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,472 @@
+---
+name: Revv
+description: A desktop watchtower and review surface for GitHub repositories.
+colors:
+  # Brand accent (the one distinctive move)
+  deep-naval: "oklch(46% 0.11 225)"
+  deep-naval-hover: "oklch(40% 0.1 225)"
+  deep-naval-muted: "oklch(58% 0.09 225)"
+  # Dark accent (lifted for midnight canvas)
+  phosphor-naval: "oklch(71% 0.14 225)"
+  phosphor-naval-hover: "oklch(65% 0.14 225)"
+  phosphor-naval-muted: "oklch(80% 0.11 225)"
+
+  # Warm-paper surface stack (light theme)
+  warm-paper: "#faf9f6"
+  warm-stone: "#f4f1eb"
+  warm-ash: "#eae6de"
+  warm-paper-edge: "#e4e0d8"
+  warm-paper-edge-subtle: "#ece8e0"
+
+  # Ink (text)
+  ink-primary: "#2a2825"
+  ink-secondary: "#5a5650"
+  ink-muted: "#9a958c"
+
+  # AI accent
+  considered-violet: "#6d28d9"
+
+  # Severity (deepened from stock Tailwind)
+  workshop-amber: "#b45309"
+  considered-green: "#15803d"
+  considered-red: "#b91c1c"
+  demands-attention: "#c2410c"
+
+  # Dark theme surface stack (kept for parity)
+  midnight-paper: "#0a0a0a"
+  midnight-stone: "#111111"
+  midnight-ash: "#1a1a1a"
+  midnight-elevated: "#222222"
+  midnight-edge: "#262626"
+  midnight-ink-primary: "#e4e4e7"
+  midnight-ink-secondary: "#a1a1aa"
+  midnight-ink-muted: "#52525b"
+  midnight-accent: "oklch(71% 0.14 225)"
+
+typography:
+  display:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "-0.01em"
+  headline:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 600
+    lineHeight: 1.3
+  title:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "0.9375rem"
+    fontWeight: 600
+    lineHeight: 1.4
+  body:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "0.875rem"
+    fontWeight: 400
+    lineHeight: 1.5
+  label:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "0.75rem"
+    fontWeight: 500
+    lineHeight: 1.3
+    letterSpacing: "0.01em"
+  mono:
+    fontFamily: "JetBrains Mono, Fira Code, monospace"
+    fontSize: "0.8125rem"
+    fontWeight: 400
+    lineHeight: 1.5
+
+rounded:
+  sm: "4px"
+  md: "8px"
+  lg: "12px"
+
+spacing:
+  island-half: "4px"
+  island: "8px"
+  inset: "12px"
+  island-2x: "16px"
+
+components:
+  button-primary:
+    backgroundColor: "{colors.deep-naval}"
+    textColor: "#ffffff"
+    rounded: "{rounded.md}"
+    padding: "0 10px"
+    height: "32px"
+  button-primary-hover:
+    backgroundColor: "{colors.deep-naval-hover}"
+    textColor: "#ffffff"
+    rounded: "{rounded.md}"
+  button-outline:
+    backgroundColor: "{colors.warm-paper}"
+    textColor: "{colors.ink-primary}"
+    rounded: "{rounded.md}"
+    padding: "0 10px"
+    height: "32px"
+  button-outline-hover:
+    backgroundColor: "{colors.warm-stone}"
+    textColor: "{colors.ink-primary}"
+    rounded: "{rounded.md}"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink-secondary}"
+    rounded: "{rounded.md}"
+    padding: "0 10px"
+    height: "32px"
+  button-ghost-hover:
+    backgroundColor: "{colors.warm-stone}"
+    textColor: "{colors.ink-primary}"
+    rounded: "{rounded.md}"
+  button-destructive:
+    backgroundColor: "rgba(185, 28, 28, 0.10)"
+    textColor: "{colors.considered-red}"
+    rounded: "{rounded.md}"
+    padding: "0 10px"
+    height: "32px"
+  input-default:
+    backgroundColor: "{colors.warm-stone}"
+    textColor: "{colors.ink-primary}"
+    rounded: "{rounded.md}"
+    padding: "8px 12px"
+    height: "32px"
+  card-warm:
+    backgroundColor: "{colors.warm-paper}"
+    textColor: "{colors.ink-primary}"
+    rounded: "{rounded.md}"
+    padding: "16px"
+  tab-active:
+    backgroundColor: "{colors.warm-paper}"
+    textColor: "{colors.ink-primary}"
+    rounded: "{rounded.md}"
+    padding: "4px 12px"
+    height: "28px"
+  tab-inactive:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink-muted}"
+    rounded: "{rounded.md}"
+    padding: "4px 12px"
+    height: "28px"
+---
+
+# Design System: Revv
+
+## 1. Overview
+
+**Creative North Star: "The Reading Room"**
+
+Revv is the reading room of code review: warm paper underfoot, considered ink, expert
+silence, and exactly one accent worth lifting your eyes for. The canvas reads as a page,
+not a screen. Reviewers come here to think, not to be sold to or coached. Chrome
+recedes; code and conversation are the foreground.
+
+The system rejects the noisy SaaS dashboard, the GitHub web UI's marketing chrome, and
+the neon-on-black AI-tool aesthetic in equal measure. Where other code-review tools
+ship stock Tailwind blue, Revv ships Deep Naval at low frequency. Where others stack
+shadows for "depth," Revv layers warm tones and reserves shadows for things that
+genuinely float. Where others make AI feel magical with sparkles and gradients, Revv
+makes it feel collaborative with a single streaming character: the cursor.
+
+**Key Characteristics:**
+
+- Warm-paper background, never neutral gray, never `#fff`.
+- One brand accent (Deep Naval `oklch(46% 0.11 225)`), used on ≤10% of any given screen.
+- Hybrid elevation: tonal layering for chrome, soft shadows only for floating UI.
+- Refined and restrained components: quiet at rest, precise on interaction.
+- Icons-only iconography (`phosphor-svelte`); emoji prohibited.
+- Reduced-motion is a contract, not a courtesy.
+
+## 2. Colors: The Warm-Paper Palette
+
+A warm-paper neutral stack tinted ~36° (paper, not gray) with one restrained accent
+that does all the brand work. Severity colors are deepened a notch from stock Tailwind
+so reds and greens read as considered, not alarming.
+
+### Primary
+
+- **Deep Naval** (`oklch(46% 0.11 225)`): the brand's one distinctive move. Used for the
+  streaming AI cursor, active states in the file tree, marker dots on open threads,
+  primary CTA fills, focus rings. Restricted to ≤10% of any given screen. Hover and
+  active deepen to `oklch(40% 0.1 225)`. A muted variant (`oklch(58% 0.09 225)`) is
+  reserved for archival states.
+
+### Neutral (warm-paper stack, light theme)
+
+- **Warm Paper** (`#faf9f6`): the canvas. Backgrounds, card faces, the visible page.
+- **Warm Stone** (`#f4f1eb`): sidebars, panels, inputs, the diff canvas. The first
+  layer up from the canvas.
+- **Warm Ash** (`#eae6de`): tracks, hover states, separators between regions.
+- **Paper Edge** (`#e4e0d8`): hairline borders. Subtle variant (`#ece8e0`) for
+  inside-panel dividers.
+
+### Ink (text)
+
+- **Ink Primary** (`#2a2825`): all body text and headings on warm-paper backgrounds.
+  Never `#000`.
+- **Ink Secondary** (`#5a5650`): metadata, captions, secondary labels.
+- **Ink Muted** (`#9a958c`): placeholder text, disabled labels, inactive tab text.
+
+### AI Accent
+
+- **Considered Violet** (`#6d28d9`): the AI accent. Used sparingly for AI-authored
+  surfaces (walkthroughs, recap headers). Deliberately deeper than the lavender that
+  ships with every AI tool. Not a brand color: a *role* color for AI presence.
+
+### Severity
+
+- **Considered Green** (`#15803d`): success states, pass scorecards, additions text.
+- **Workshop Amber** (`#b45309`): pending state, concern scorecards, in-progress.
+- **Considered Red** (`#b91c1c`): danger, destructive actions, blocker scorecards,
+  deletions text.
+- **Demands Attention** (`#c2410c`): the "your turn" marker on PR threads waiting on
+  the user. Warm orange-700; deliberately warmer than the warning amber so the eye
+  separates the two.
+
+### Dark Theme
+
+A parallel system on a near-black canvas (`#0a0a0a`) with stone-stack analogues
+(`#111`, `#1a1a1a`, `#222`) and a brand-consistent accent: **Phosphor Naval**
+(`oklch(71% 0.14 225)`). The dark theme keeps the deep-naval lineage and lifts it into
+a luminous value that reads against `#0a0a0a` without becoming the stock-Tailwind blue
+every other code review tool ships. Hover deepens to `oklch(65% 0.14 225)`; the muted
+variant brightens to `oklch(80% 0.11 225)` for icons. Severity, AI accent, and the
+neutral philosophy all carry over from light theme.
+
+### Named Rules
+
+**The One Voice Rule.** The brand accent (Deep Naval in light, Phosphor Naval in dark)
+is used on ≤10% of any given screen. Its rarity is the point. If three olive elements
+are competing on one surface, two are wrong.
+
+**The No-Pure-Black Rule.** `#000` is prohibited in light theme, and the dark theme
+canvas stops at `#0a0a0a`. Every neutral is tinted toward warm-paper or midnight-paper;
+no element ever sits on pure black or pure white.
+
+**The Deepened Severity Rule.** Reds, greens, ambers in this system are one step deeper
+than the Tailwind defaults (red-700, green-700, amber-700 rather than 500). The intent
+is "considered" rather than "alarming." Stock-bright severity reads as a prototype.
+
+## 3. Typography
+
+**Display + Body Font:** Inter (with `system-ui, sans-serif` fallback)
+**Mono Font:** JetBrains Mono (with `Fira Code, monospace` fallback)
+
+**Character:** A single warm humanist sans for the whole interface, paired with a clean
+geometric mono for code and identifiers. Inter is used at restrained weights (400, 500,
+600) and modest sizes. The hierarchy is built from scale and weight contrast, not from
+six display families competing for attention.
+
+### Hierarchy
+
+- **Display** (600, 1.5rem, 1.2): rare; reserved for page-level titles when one exists.
+- **Headline** (600, 1.125rem, 1.3): panel headers, walkthrough section titles.
+- **Title** (600, 0.9375rem, 1.4): card titles, PR titles in the list.
+- **Body** (400, 0.875rem, 1.5): all running text. Body line length caps at 70ch in
+  prose contexts (walkthrough markdown, recap text).
+- **Label** (500, 0.75rem, 0.01em letter-spacing): inline labels, metadata, tab text.
+  Never uppercase by default; case is meaningful, not decorative.
+- **Mono** (400, 0.8125rem, JetBrains Mono): code in diffs, identifiers in prose,
+  filenames in lists.
+
+### Named Rules
+
+**The Single-Family Rule.** Inter is the only sans in the system; JetBrains Mono is
+the only mono. No display serif, no condensed sans, no second body family. Variety
+comes from weight (400/500/600) and scale, not from font-mixing.
+
+**The Earned-Uppercase Rule.** Uppercase is prohibited as a decorative style. Use
+sentence case for everything except technical identifiers that are uppercase by
+convention (HTTP verbs, env var names, type names).
+
+**The 65–75ch Rule.** Body prose in walkthrough markdown, recap content, and chat
+messages caps at 70ch (`max-w-prose` in Tailwind). The diff is exempt; code wraps to
+the panel width.
+
+## 4. Elevation: Hybrid
+
+Depth in this system is mostly tonal, with shadows reserved for things that genuinely
+float. Chrome (sidebars, panels, tabs, headers) gets no shadows: it sits on the
+warm-paper canvas via warm-stone and warm-ash tone steps. Anything that escapes the
+flow (floating pills, popovers, tooltips, dialogs, the stream cursor's glow) earns a
+shadow.
+
+### Shadow Vocabulary
+
+- **Indicator** (`0 1px 3px rgba(42,40,37,0.08), 0 2px 8px rgba(42,40,37,0.06), 0 0 0 0.5px rgba(42,40,37,0.04)`):
+  a very soft ambient ring under the smallest floating elements (marker glows, status
+  dots).
+- **Small** (`0 2px 6px rgba(42,40,37,0.08)`): glass pills at rest, chip stacks.
+- **Medium** (`0 4px 16px rgba(42,40,37,0.10)`): popovers, tooltips, the line-action
+  floating pill above a diff line.
+- **Large** (`0 8px 24px rgba(42,40,37,0.12), 0 2px 8px rgba(42,40,37,0.06)`): sheets,
+  the chat panel when it floats above the diff.
+- **XL** (`0 16px 48px rgba(42,40,37,0.18), 0 4px 12px rgba(42,40,37,0.10)`): dialogs,
+  modals, the command palette.
+
+Dark theme shadows mirror these but use `rgba(0,0,0,...)` at 2–3× the alpha to read
+against the midnight-paper canvas.
+
+### Named Rules
+
+**The Hybrid Rule.** Chrome layers via warm tones (paper → stone → ash). Floating UI
+layers via shadows. The two languages do not cross: a sidebar never gets a drop shadow,
+and a tooltip never relies on a tone step to read as "above."
+
+**The No-Heavy-Shadows Rule.** Shadow alpha caps at 0.18 (XL) in light theme. If a
+shadow needs to be heavier than XL to read, the elevation language is wrong: either the
+underlying surface contrast is off or the element should not be floating at all.
+
+## 5. Components
+
+For each component, lead with the character, then specify shape, color assignment,
+states, and any distinctive behavior.
+
+### Buttons
+
+Refined and restrained at rest, tactile on press. Six variants
+(default / outline / secondary / ghost / destructive / link) and five sizes
+(xs / sm / default / lg / icon).
+
+- **Shape:** rounded (`rounded-lg`, 8px). Small variants use a `min(--radius-md, 10–12px)`
+  clamp so they don't out-radius the height.
+- **Default (Primary):** Deep Naval fill (`oklch(46% 0.11 225)`), white text, no border. Height
+  32px, horizontal padding 10px, font-size 0.875rem, weight 500.
+- **Outline:** warm-paper background, ink-primary text, paper-edge border (1px).
+  Hover lifts to warm-stone.
+- **Ghost:** transparent at rest, ink-secondary text. Hover lifts to warm-stone fill,
+  ink-primary text. The default chrome button.
+- **Secondary:** warm-stone fill, ink-primary text. Hover deepens 20%.
+- **Destructive:** Considered Red at 10% alpha, Considered Red text. Hover lifts to
+  20% alpha. Never a solid red fill: the warning is in the color, not in the volume.
+- **Link:** Deep Naval text, no fill, underline on hover.
+
+**The Tactile Press.** All buttons translate down 1px on `:active` (excluding popover
+triggers). The 1px press is deliberate; it makes interaction feel tangible against the
+paper canvas.
+
+**Focus:** 3px outer ring at `var(--ring)` (Deep Naval in light, Phosphor Naval in
+dark). Border shifts in on aria-invalid.
+
+### Inputs / Fields
+
+- **Style:** warm-stone fill, ink-primary text, paper-edge hairline border, 8px
+  radius. Height 32px, padding 8px 12px.
+- **Focus:** focus ring at `color-mix(in srgb, var(--color-accent) 40%, transparent)`,
+  no border color change. The glow is the affordance.
+- **Disabled:** ink-muted text, 50% opacity, no border change.
+
+### Tabs (PR tabs in the chrome track)
+
+The signature navigation pattern. A pill-track of inactive tabs in ink-muted on a
+`rgba(42,40,37,0.06)` track, with the active tab fill stepping up to warm-paper. No
+borders. The track is the same warm-stone family as the sidebar, allowing the chrome
+to read as one continuous element.
+
+- **Active:** warm-paper fill, ink-primary text, soft Indicator shadow.
+- **Inactive:** transparent fill, ink-muted text (`#7a756c`).
+- **Hover (inactive):** warm-ash tint, ink-primary text.
+
+### Cards / Containers
+
+- **Corner Style:** 8px (cards), 12px (islands).
+- **Background:** warm-paper for default cards; warm-stone for embedded cards (e.g.,
+  inside a warm-paper panel). Nested cards beyond two levels are prohibited.
+- **Shadow Strategy:** none at rest. Cards are tonal; the warm-stone-on-warm-paper
+  contrast is the elevation. Hover may add a Small shadow for a single tier of lift,
+  but only when the card is genuinely actionable.
+- **Border:** 1px paper-edge hairline by default; omitted on warm-paper-over-warm-paper
+  cases where the border would be invisible anyway.
+- **Internal Padding:** 16px (`island-2x`) for content cards, 12px (`inset`) for
+  list-row cards.
+
+### Glass Pill
+
+A distinctive component used for chrome elements that float above the canvas: the
+line-action pill, mode toggles, ambient status. Warm-paper at 78% alpha, paper-edge at
+9% alpha, backdrop-blur 6px, Small shadow. Glass is a *role*, not a default style: use
+it only for floating chrome on the canvas, never for content surfaces.
+
+### File Tree Row
+
+- **Style:** transparent at rest, ink-secondary text, mono font for filenames at
+  0.8125rem.
+- **Hover:** warm-ash fill.
+- **Active:** Deep Naval at 10% alpha fill, deeper Deep Naval text
+  (`oklch(40% 0.1 225)`). The brand accent is *tinted* into the active state, not used
+  directly: the row is whispering the brand, not shouting it.
+
+### Diff Canvas
+
+The most distinctive surface in the product. A warm-stone canvas with a slightly cooler
+gutter (`#edeae3`), gutter border (`#e4e0d8`), and a full vocabulary of addition /
+deletion / context states with hover variants. Additions and deletions use deepened
+severity greens and reds at low alpha (4–8%) so the diff reads as a calm document, not
+a Tailwind-tutorial color explosion.
+
+- **Selection:** Deep Naval at 8% alpha. The same accent appears in the file tree's
+  active state and the marker dots; selection feels like "I'm working here" in the
+  brand voice.
+
+### Streaming AI Cursor
+
+A 1ch-wide vertical bar in Deep Naval that blinks while the AI is producing tokens.
+Single character. Its glow uses the Indicator shadow at low alpha. The cursor is
+opt-back-in to motion under `prefers-reduced-motion` via `.motion-essential-blink`: if
+motion is disabled globally, the cursor still blinks so the user can tell the system
+is alive.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** use Deep Naval sparingly. ≤10% of any given screen. The streaming cursor,
+  the active file row, the primary CTA, the focus ring. Not all four at once on the
+  same surface.
+- **Do** use warm-paper as the canvas in light theme and warm-stone as the secondary
+  surface. Tone steps carry chrome elevation.
+- **Do** use `phosphor-svelte` for every icon. Inline SVG only when no phosphor
+  equivalent fits.
+- **Do** deepen severity colors one step from stock Tailwind (700 weight rather than
+  500) so reds and greens read as considered, not bright.
+- **Do** translate buttons 1px down on `:active`. The press is tactile and on
+  purpose.
+- **Do** cap body prose at 70ch (Tailwind's `max-w-prose`). The diff is exempt.
+- **Do** honor `prefers-reduced-motion` as a contract. Opt back in only for motion
+  that carries meaning, using `.motion-essential-*` classes.
+- **Do** use motion tokens from the `@theme` block: `duration-snap`,
+  `duration-quick`, `duration-smooth`, `ease-out-expo`, `ease-soft`. No hand-typed
+  durations.
+
+### Don't:
+
+- **Don't** use emoji in rendered UI, ever. Not in buttons, not in fallback avatars,
+  not in toast messages, not in placeholders. Use a phosphor icon or nothing.
+- **Don't** use stock Tailwind blue (`blue-500`, `#3b82f6`) as a brand accent in light
+  theme. That is the color every other dashboard ships. Deep Naval is the move.
+- **Don't** use side-stripe borders (`border-left > 1px` as a colored accent on cards,
+  list items, callouts). Use a full hairline border, a background tint, or a leading
+  icon instead.
+- **Don't** use gradient text (`background-clip: text` on a gradient). Decorative
+  always, meaningful never. Emphasis comes from weight and size.
+- **Don't** use glassmorphism as a default surface style. The Glass Pill is the
+  exception, not the rule.
+- **Don't** ship the hero-metric template (big number, small label, supporting stats,
+  gradient accent). Watchtower mode does not need a SaaS-dashboard pastiche.
+- **Don't** stack identical card grids. If three cards in a row do not differ in
+  weight or content, the grid is the lazy answer.
+- **Don't** reach for a modal as the first thought. Inline expansion, progressive
+  disclosure, and side panels exhaust before a modal is justified.
+- **Don't** animate CSS layout properties. Translate, scale, opacity, and color only.
+- **Don't** use heavy purple gradients or neon accents to signal "AI." Revv's AI
+  surfaces are warm paper with a single Considered Violet accent and a streaming
+  cursor; that is the entire AI vocabulary.
+- **Don't** use `#000` or `#fff`. Every neutral is tinted: warm-paper toward 36° in
+  light, midnight-paper toward neutral in dark. Pure values read as "untouched
+  default."
+- **Don't** use bright stock severity colors. `red-500`, `green-500`, `amber-500` all
+  read as prototype-bright. Use the deepened 700-weight equivalents already in the
+  palette.
+- **Don't** add a "Layout Principles" or "Motion" or "Responsive Behavior" section
+  to this file. The system has six sections; layout and motion live inline with
+  Overview and Components.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,125 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Serious code reviewers across the full cross-section: indie maintainers, senior
+engineers on GitHub Enterprise, and team leads who treat review as a craft, not a
+checkbox. No single cohort is the priority; the through-line is people who care enough
+about both the *output* of a repo (what's shipping, what's stuck, what's next) and the
+*review* of that work to leave GitHub's UI for a dedicated desktop client.
+
+Context of use: extended focused sessions on a real workstation. Two distinct modes,
+often back-to-back:
+
+- **Watchtower mode.** A glance across one or several repos to understand the state of
+  ongoing work. Which PRs are stuck. What's been merged since yesterday. What still
+  needs a decision. A morning coffee, an end-of-day sweep, a "what did the team do this
+  week" check before standup.
+- **Review mode.** Deep, focused review of a specific PR. Walkthrough first, diff
+  second, chat to clarify, comments to record, proposed commits to push fixes back.
+
+Both modes share the same surface. The desktop client and persistent WebSocket make the
+watchtower viable in a way a browser tab can't match.
+
+## Product Purpose
+
+Revv is a desktop watchtower and review surface for GitHub repositories. It does two
+jobs the web UI does badly:
+
+1. **Surface what's happening across repos.** PRs sync in real time across every
+   watched repo and account. The user can see at a glance what's open, what's stuck,
+   what just merged, who is waiting on whom, without tab-juggling between repo
+   dashboards or refreshing the same page.
+
+2. **Review with depth GitHub can't offer.** When a reviewer drops into a specific PR,
+   they get AI walkthroughs that explain the change before the diff, a chat agent that
+   can answer "why did this file change" and propose actual commits, and conflict
+   resolution that doesn't break flow.
+
+Success looks like: a reviewer opens Revv in the morning, sees the queue change
+overnight, picks the two PRs that actually need them, spends real time on each, and
+ships substantive review. The depth and the awareness are both the point; neither
+alone justifies leaving GitHub.
+
+## Brand Personality
+
+Calm, precise, expert.
+
+- **Calm.** Stillness is the baseline. The UI does not flash, bounce, or interrupt.
+  Motion is reserved for state that genuinely changes (streaming AI cursor, panel
+  slides). Reduced-motion is a contract, not a courtesy.
+- **Precise.** Every value in the design system is considered. "Teal-700 because the
+  generic Tailwind blue ships in every other dashboard" is not a quip in `app.css`,
+  it's the working philosophy. Anti-references are encoded inline next to the tokens
+  they replace.
+- **Expert.** Defaults trust the user. No onboarding theatre, no tooltips explaining
+  obvious affordances, no progressive disclosure for the sake of it. The user knows
+  what a PR is. The first-run onboarding that exists earns its keep by setting up
+  accounts and watched repos, not by teaching the product.
+
+Voice in copy and microcopy: direct, considered, never cute. No exclamation marks. No
+filler ("Awesome!", "Just a moment..."). When the system has nothing useful to say, it
+says nothing.
+
+## Anti-references
+
+The visual system in `apps/web/src/app.css` already encodes some of these by name; this
+section makes them strategic, not just chromatic.
+
+- **GitHub's own web UI.** Busy, ad-laden, marketing chrome stitched onto a code review
+  tool. Revv is the opposite: chrome recedes, code and conversation are foreground.
+- **Generic SaaS dashboards.** Stock-Tailwind blue accent, identical card grids,
+  hero-metric template at the top of every page. Revv has one distinctive accent
+  (deep teal `#0f766e`) and no card grid as the default container, even in
+  watchtower mode.
+- **The AI-tool aesthetic du jour.** Neon-on-black, purple gradients, glassmorphism
+  panels, "magical sparkle" iconography. Revv's AI surfaces are warm paper with a
+  considered violet accent (`#6d28d9`), not lavender or neon.
+- **Heavy enterprise review tools** (Jira / Bitbucket / classic Crucible).
+  Gray-on-gray density, form-heavy modals, modal-as-first-thought. Revv is text-first
+  and inline-first; modals are rare.
+
+## Design Principles
+
+1. **Calm by default.** Stillness is the baseline. Motion is reserved for state that
+   genuinely changes. Reduced-motion is honored as a contract; meaningful motion opts
+   back in with explicit `.motion-essential-*` classes.
+
+2. **One distinctive move per surface.** The teal accent, the warm-paper background,
+   the persistent right-panel chat: each surface has one signature element, not three
+   competing accents.
+
+3. **Expert defaults.** Trust the user. The install flow assumes terminal fluency. The
+   chat agent has plan mode for serious work. There is no first-run wizard explaining
+   what a PR is.
+
+4. **Text-first, chrome-last.** Code, diffs, and prose are the heroes. Navigation,
+   sidebars, and tabs recede into warm-gray backgrounds. The tab track is the same
+   color as the sidebar; the chrome is allowed to be quiet.
+
+5. **AI is a collaborator, not a feature shelf.** AI surfaces (walkthroughs, chat,
+   recaps) live inline with the work, not in a separate "AI" tab. The streaming cursor
+   is the most prominent AI affordance: a single character that says "thinking now."
+
+## Accessibility & Inclusion
+
+Currently best-effort, leaning toward WCAG 2.1 AA. Specific contracts already in place:
+
+- **Reduced-motion.** A global `@media (prefers-reduced-motion: reduce)` block in
+  `app.css` collapses every transition to ~1ms. Motion that carries meaning (e.g., the
+  streaming AI cursor) opts back in via `.motion-essential-*` utility classes. Don't
+  bypass the global rule with `!important`.
+- **Color contrast.** Warm-paper foregrounds (`#2a2825` on `#faf9f6`) and the teal
+  accent against warm-paper meet AA at body sizes. Dark theme contrast is similarly
+  intentional, not transplanted from a default Tailwind palette.
+- **Icons only, no emoji.** `phosphor-svelte` is the standard icon library; inline SVG
+  only when no phosphor equivalent fits. Emoji in rendered UI is prohibited (this is
+  both an accessibility and a register decision).
+- **Color blindness.** Severity is never communicated by color alone: diff status,
+  marker state, and scorecard outcome all pair color with shape, icon, or label.
+
+No formal audit target yet. When one is set, it will be WCAG 2.2 AA (current default).

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -6,24 +6,24 @@
    Light theme (default)
    ────────────────────────────────────────────────────────── */
 /* ──────────────────────────────────────────────────────────
-   Light theme (default) — "warm paper, deep teal accent"
+   Light theme (default) — "warm paper, deep naval accent"
    - Background stays warm off-white (#faf9f6) like the
      onboarding, so the canvas reads as a page rather than
-     a screen. The distinctive move is the deep teal accent
-     (#0f766e) replacing the generic Tailwind blue every
-     other dashboard ships.
+     a screen. The distinctive move is the deep naval accent
+     (oklch(46% 0.11 225)) replacing the generic Tailwind blue
+     every other dashboard ships.
    - Severity colors deepen slightly so reds/greens read as
      considered, not stock-Tailwind-bright.
    ────────────────────────────────────────────────────────── */
 :root {
-  /* shadcn-svelte (HSL triplets — warm paper bg, deep teal primary) */
+  /* shadcn-svelte (HSL triplets — warm paper bg, deep naval primary) */
   --background: 36 14% 98%;
   --foreground: 28 12% 12%;
   --card: 36 14% 98%;
   --card-foreground: 28 12% 12%;
   --popover: 36 10% 95%;
   --popover-foreground: 28 12% 12%;
-  --primary: 174 78% 26%; /* #0f766e teal-700 */
+  --primary: 218 35% 43%; /* oklch(46% 0.11 225) deep naval */
   --primary-foreground: 0 0% 100%;
   --secondary: 36 10% 95%;
   --secondary-foreground: 28 10% 15%;
@@ -35,10 +35,10 @@
   --destructive-foreground: 0 0% 100%;
   --border: 36 12% 88%;
   --input: 36 12% 88%;
-  --ring: 174 78% 26%;
+  --ring: 218 35% 43%;
   --radius: 0.5rem;
 
-  /* Revv palette — warm paper surfaces, teal brand */
+  /* Revv palette — warm paper surfaces, deep naval accent */
   --revv-bg-primary: #faf9f6;
   --revv-bg-secondary: #f4f1eb; /* warm light gray — sidebars, panels */
   --revv-bg-tertiary: #eae6de; /* warm mid gray — tracks, hover */
@@ -48,9 +48,9 @@
   --revv-text-primary: #2a2825;
   --revv-text-secondary: #5a5650;
   --revv-text-muted: #9a958c;
-  --revv-accent: #0f766e; /* teal-700 — the one distinctive move */
-  --revv-accent-hover: #115e59; /* teal-800 */
-  --revv-accent-muted: #0d9488; /* teal-600 — muted variant for archival states */
+  --revv-accent: oklch(46% 0.11 225); /* deep naval — the one distinctive move */
+  --revv-accent-hover: oklch(40% 0.1 225); /* deepened */
+  --revv-accent-muted: oklch(58% 0.09 225); /* muted variant for archival states */
   --revv-success: #15803d; /* green-700 — slightly deeper than Tailwind 500 */
   --revv-warning: #b45309; /* amber-700 — keep */
   --revv-warning-fg: #ffffff; /* text on warning surfaces */
@@ -77,11 +77,11 @@
 
   /* Context line hover */
   --revv-diff-ctx-bg-hover: #eae6de;
-  --revv-diff-selected-bg: rgba(15, 118, 110, 0.08); /* teal selection */
+  --revv-diff-selected-bg: color-mix(in srgb, var(--revv-accent) 8%, transparent);
 
-  /* Gutter markers — open pinned to brand teal */
-  --revv-marker-open: #0f766e;
-  --revv-marker-open-glow: rgba(15, 118, 110, 0.25);
+  /* Gutter markers — open pinned to brand accent */
+  --revv-marker-open: oklch(46% 0.11 225);
+  --revv-marker-open-glow: color-mix(in srgb, var(--revv-accent) 25%, transparent);
   --revv-marker-pending: #b45309;
   --revv-marker-pending-glow: rgba(180, 83, 9, 0.25);
   --revv-marker-your-turn: #c2410c; /* warm orange-700 — "demands attention" */
@@ -95,16 +95,16 @@
   /* Comment / thread */
   --revv-thread-bg: #faf9f6;
   --revv-input-bg: #f4f1eb;
-  --revv-input-focus-ring: rgba(15, 118, 110, 0.4);
+  --revv-input-focus-ring: color-mix(in srgb, var(--revv-accent) 40%, transparent);
 
   /* Context panel */
   --revv-panel-bg: #f4f1eb;
   --revv-panel-header-bg: rgba(244, 241, 235, 0.96);
-  --revv-stream-cursor: #0f766e;
+  --revv-stream-cursor: oklch(46% 0.11 225);
 
   /* File tree */
-  --revv-tree-active-bg: rgba(15, 118, 110, 0.1);
-  --revv-tree-active-text: #115e59;
+  --revv-tree-active-bg: color-mix(in srgb, var(--revv-accent) 10%, transparent);
+  --revv-tree-active-text: oklch(40% 0.1 225);
   --revv-tree-hover-bg: #eae6de;
 
   /* Floating tabs */
@@ -168,14 +168,15 @@
   --revv-score-blocker-conf-bg: color-mix(in srgb, var(--revv-score-blocker-icon) 12%, transparent);
   --revv-score-blocker-conf: #b91c1c;
 
-  /* Info — accent-derived palette. With the brand teal accent, info
-       reads as a calm "FYI" rather than the old "click here" blue. */
+  /* Info — accent-derived palette. Deep naval keeps "info" in the
+       brand family. Darker and less saturated than pass-green so the two
+       remain visually distinct in the scorecard context. */
   --revv-score-info-bg: color-mix(in srgb, var(--revv-accent) 4%, var(--revv-bg-secondary));
-  --revv-score-info-border: #0f766e;
-  --revv-score-info-icon: #115e59;
-  --revv-score-info-label: #134e4a;
+  --revv-score-info-border: oklch(46% 0.11 225);
+  --revv-score-info-icon: oklch(40% 0.1 225);
+  --revv-score-info-label: oklch(34% 0.09 225);
   --revv-score-info-conf-bg: color-mix(in srgb, var(--revv-score-info-icon) 12%, transparent);
-  --revv-score-info-conf: #115e59;
+  --revv-score-info-conf: oklch(40% 0.1 225);
 }
 
 /* ──────────────────────────────────────────────────────────
@@ -189,8 +190,8 @@
   --card-foreground: 240 5% 91%;
   --popover: 0 0% 13%;
   --popover-foreground: 240 5% 91%;
-  --primary: 217 91% 60%;
-  --primary-foreground: 0 0% 100%;
+  --primary: 218 52% 67%; /* oklch(71% 0.14 225) phosphor naval, luminous dark accent */
+  --primary-foreground: 0 0% 8%; /* near-black ink on bright accent fill */
   --secondary: 0 0% 13%;
   --secondary-foreground: 240 5% 91%;
   --muted: 0 0% 13%;
@@ -201,9 +202,14 @@
   --destructive-foreground: 0 0% 100%;
   --border: 0 0% 15%;
   --input: 0 0% 15%;
-  --ring: 217 91% 60%;
+  --ring: 218 52% 67%;
 
-  /* Revv palette */
+  /* Revv palette — Phosphor Naval accent.
+     The dark theme keeps the deep-naval lineage (light: oklch(46% 0.11 225))
+     and lifts it into a luminous oklch(71% 0.14 225) that reads against
+     #0a0a0a without becoming the stock-Tailwind-blue every other dashboard
+     ships. The two themes share a story: deep naval is the one distinctive
+     move; only the luminance shifts to suit the canvas. */
   --revv-bg-primary: #0a0a0a;
   --revv-bg-secondary: #111111;
   --revv-bg-tertiary: #1a1a1a;
@@ -213,9 +219,9 @@
   --revv-text-primary: #e4e4e7;
   --revv-text-secondary: #a1a1aa;
   --revv-text-muted: #52525b;
-  --revv-accent: #3b82f6;
-  --revv-accent-hover: #2563eb;
-  --revv-accent-muted: #60a5fa;
+  --revv-accent: oklch(71% 0.14 225); /* phosphor naval — luminous dark accent */
+  --revv-accent-hover: oklch(65% 0.14 225); /* deepened press */
+  --revv-accent-muted: oklch(80% 0.11 225); /* muted icon variant */
   --revv-success: #22c55e;
   --revv-warning: #f59e0b;
   --revv-warning-fg: #ffffff;
@@ -242,11 +248,11 @@
 
   /* Context line hover */
   --revv-diff-ctx-bg-hover: #131313;
-  --revv-diff-selected-bg: rgba(59, 130, 246, 0.08);
+  --revv-diff-selected-bg: color-mix(in srgb, var(--revv-accent) 10%, transparent);
 
   /* Gutter markers */
-  --revv-marker-open: #3b82f6;
-  --revv-marker-open-glow: rgba(59, 130, 246, 0.35);
+  --revv-marker-open: oklch(71% 0.14 225);
+  --revv-marker-open-glow: color-mix(in srgb, var(--revv-accent) 35%, transparent);
   --revv-marker-pending: #f59e0b;
   --revv-marker-pending-glow: rgba(245, 158, 11, 0.35);
   --revv-marker-your-turn: #fb923c;
@@ -260,16 +266,16 @@
   /* Comment / thread */
   --revv-thread-bg: #111111;
   --revv-input-bg: #161616;
-  --revv-input-focus-ring: rgba(59, 130, 246, 0.4);
+  --revv-input-focus-ring: color-mix(in srgb, var(--revv-accent) 40%, transparent);
 
   /* Context panel */
   --revv-panel-bg: #0e0e0e;
   --revv-panel-header-bg: rgba(17, 17, 17, 0.95);
-  --revv-stream-cursor: #3b82f6;
+  --revv-stream-cursor: oklch(71% 0.14 225);
 
   /* File tree */
-  --revv-tree-active-bg: rgba(59, 130, 246, 0.1);
-  --revv-tree-active-text: #93c5fd;
+  --revv-tree-active-bg: color-mix(in srgb, var(--revv-accent) 12%, transparent);
+  --revv-tree-active-text: oklch(86% 0.08 225);
   --revv-tree-hover-bg: #141414;
 
   /* Floating tabs */
@@ -293,10 +299,12 @@
   --revv-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.55), 0 2px 8px rgba(0, 0, 0, 0.35);
   --revv-shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.65), 0 4px 12px rgba(0, 0, 0, 0.45);
 
-  /* Outline-style button (inverts with theme) */
-  --revv-btn-outline: rgba(255, 255, 255, 0.7);
-  --revv-btn-outline-fill: #ffffff;
-  --revv-btn-outline-fg: #000000;
+  /* Outline-style button (inverts with theme). Fill and fg are tinted
+     toward the canvas hue so the inverted button stays in the system
+     instead of reading as raw black/white. */
+  --revv-btn-outline: rgba(228, 228, 231, 0.7);
+  --revv-btn-outline-fill: #f4f4f5; /* zinc-100 */
+  --revv-btn-outline-fg: #0a0a0a; /* matches --revv-bg-primary */
 
   /* AI accent */
   --revv-ai-accent: #7c6af7;
@@ -333,14 +341,15 @@
   --revv-score-blocker-conf-bg: color-mix(in srgb, var(--revv-score-blocker-icon) 25%, transparent);
   --revv-score-blocker-conf: #f87171;
 
-  /* Info — accent-derived palette (dark variant). Blues brightened to
-       read against dark bg without losing distinction from pass-green. */
+  /* Info — accent-derived palette (dark variant). Phosphor Naval at varying
+       luminance keeps "info" in the brand family while staying clearly
+       distinct from pass-green (yellower) and concern-amber (warmer). */
   --revv-score-info-bg: color-mix(in srgb, var(--revv-accent) 4%, var(--revv-bg-secondary));
-  --revv-score-info-border: #3b82f6;
-  --revv-score-info-icon: #60a5fa;
-  --revv-score-info-label: #93c5fd;
+  --revv-score-info-border: oklch(71% 0.14 225);
+  --revv-score-info-icon: oklch(80% 0.11 225);
+  --revv-score-info-label: oklch(86% 0.08 225);
   --revv-score-info-conf-bg: color-mix(in srgb, var(--revv-score-info-icon) 25%, transparent);
-  --revv-score-info-conf: #60a5fa;
+  --revv-score-info-conf: oklch(80% 0.11 225);
 }
 
 /* ──────────────────────────────────────────────────────────
@@ -771,14 +780,18 @@ body {
    ────────────────────────────────────────────────────────── */
 :root.dark .shiki,
 :root.dark .shiki span {
-  /* !important is required because Shiki v3's dual-theme output writes
-     inline `style="background-color:var(--shiki-light-bg);..."` which has
-     higher specificity (1,0,0,0) than any CSS rule. Without !important the
-     dark-mode swap is silently ignored and code blocks stay light-themed. */
+  /* Shiki v3 dual-theme output writes inline style="..." with specificity
+     (1,0,0,0) — higher than any selector rule. !important is the only way
+     to make dark-mode theme swaps take effect. biome-ignore per-property. */
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline-style override */
   color: var(--shiki-dark) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline-style override */
   background-color: var(--shiki-dark-bg) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline-style override */
   font-style: var(--shiki-dark-font-style) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline-style override */
   font-weight: var(--shiki-dark-font-weight) !important;
+  /* biome-ignore lint/complexity/noImportantStyles: shiki inline-style override */
   text-decoration: var(--shiki-dark-text-decoration) !important;
 }
 
@@ -800,8 +813,14 @@ body {
   border: 1px solid var(--color-border-subtle);
   border-radius: var(--radius-card);
   background: var(--color-bg-primary);
-  /* Allow keyboard users to focus and scroll the region. */
+  /* Allow keyboard users to focus and scroll the region. The default browser
+     outline is suppressed only on focus (not focus-visible), so keyboard
+     focus still shows the accent ring; mouse-focus stays clean. */
   outline: none;
+  transition: box-shadow var(--duration-quick) var(--ease-out-expo);
+}
+.prose-table:focus-visible {
+  box-shadow: 0 0 0 3px var(--color-input-focus-ring);
 }
 
 .prose-table:focus-visible {

--- a/apps/web/src/lib/components/ai/tool/AnimatedNumber.svelte
+++ b/apps/web/src/lib/components/ai/tool/AnimatedNumber.svelte
@@ -56,6 +56,9 @@ const width = $derived(`${digits.length}ch`);
     flex-direction: row-reverse;
     justify-content: flex-end;
     line-height: inherit;
+    /* Width transition is deliberate: digit-count changes (9 → 10) need to
+       allocate one more tabular-nums column. Width is the only honest target
+       for this since tabular-nums already gives constant per-digit width. */
     transition: width var(--duration-smooth) var(--ease-out-expo);
   }
 </style>

--- a/apps/web/src/lib/components/ai/tool/ToolActivityReveal.svelte
+++ b/apps/web/src/lib/components/ai/tool/ToolActivityReveal.svelte
@@ -63,6 +63,9 @@ function handleTransitionEnd(event: TransitionEvent): void {
     min-width: 0;
     overflow: hidden;
     vertical-align: baseline;
+    /* Width transition is deliberate: inline text reveals need to grow to a
+       content-measured target, then snap to `width: auto` once settled. The
+       perf cost is negligible because the element is small and bounded. */
     transition: width var(--duration-smooth) var(--ease-out-expo);
   }
 

--- a/apps/web/src/lib/components/layout/FloatingTabs.svelte
+++ b/apps/web/src/lib/components/layout/FloatingTabs.svelte
@@ -78,7 +78,7 @@ function handleTabChange(tabId: string) {
 				tabindex={buttonVisible && !isPulling ? 0 : -1}
 				aria-hidden={!buttonVisible}
 				onclick={handlePullClick}
-				title={isPulling ? 'Pulling new commit…' : 'New commit — click to pull'}
+				title={isPulling ? 'Pulling new commit…' : 'New commit. Click to pull.'}
 				aria-label={isPulling
 					? 'Pulling new commit'
 					: 'New commit available. Click to pull the latest changes.'}

--- a/apps/web/src/lib/components/layout/PillTabs.svelte
+++ b/apps/web/src/lib/components/layout/PillTabs.svelte
@@ -123,8 +123,8 @@ function isDividerHidden(index: number): boolean {
 		display: flex;
 		align-items: center;
 		background: var(--color-tab-track-bg);
-		backdrop-filter: blur(16px) saturate(1.4);
-		-webkit-backdrop-filter: blur(16px) saturate(1.4);
+		backdrop-filter: blur(10px) saturate(1.4);
+		-webkit-backdrop-filter: blur(10px) saturate(1.4);
 		border: 1px solid var(--color-glass-border);
 		border-radius: 9999px;
 		padding: 3px;

--- a/apps/web/src/lib/components/layout/RequestChangesActionBar.svelte
+++ b/apps/web/src/lib/components/layout/RequestChangesActionBar.svelte
@@ -216,7 +216,7 @@ async function runMerge(method: import("@revv/shared").MergeMethod): Promise<voi
         disabled={rcSubmitting !== null}
         onclick={() => getRcOnApprove()()}
         title={rcApproveBlockerSummary
-          ? `Approve this pull request — ${rcApproveBlockerSummary} still open`
+          ? `Approve this pull request (${rcApproveBlockerSummary} still open)`
           : "Approve this pull request on GitHub"}
       >
         <Check size={16} weight="regular" />

--- a/apps/web/src/lib/components/layout/RightPanel.svelte
+++ b/apps/web/src/lib/components/layout/RightPanel.svelte
@@ -521,7 +521,7 @@ function activitiesForTurn(
 								<div class="push-menu-item-body">
 									<span class="push-menu-item-title">Push to new branch…</span>
 									<span class="push-menu-item-hint">
-										Don't change the PR — push the agent's commits to a new ref.
+										Don't change the PR. Push the agent's commits to a new ref.
 									</span>
 								</div>
 							</button>
@@ -742,7 +742,7 @@ function activitiesForTurn(
 								<MessageResponse content={item.content} class="text-sm leading-relaxed" />
 							{/if}
 							{#if item.error}
-								<div class="mt-2 flex items-start gap-1.5 rounded bg-muted/60 border-l-2 border-muted-foreground px-2 py-1.5 text-xs text-muted-foreground" role="alert">
+								<div class="mt-2 flex items-start gap-1.5 rounded border border-border bg-muted/60 px-2 py-1.5 text-xs text-muted-foreground" role="alert">
 									<Warning size={12} weight="fill" class="mt-0.5 shrink-0" />
 									<span class="min-w-0 break-words">{item.error}</span>
 								</div>
@@ -1139,7 +1139,7 @@ function activitiesForTurn(
 						tooltip={
 							planModeAvailable
 								? interactionMode === 'plan'
-									? 'Plan mode is on — the agent will propose a plan instead of editing. Click to disable.'
+									? 'Plan mode is on. The agent will propose a plan instead of editing. Click to disable.'
 									: 'Enable plan mode: ask the agent to propose a plan first.'
 								: 'Plan mode requires an opencode install with a `plan` agent.'
 						}
@@ -1379,11 +1379,13 @@ function activitiesForTurn(
 		pointer-events: auto;
 	}
 
-	/* Shared glass surface — blur + saturate like PillTabs. */
+	/* Shared glass surface — blur + saturate like PillTabs.
+	   10px blur is the standing-chrome cap; reserve 16px for short-lived
+	   overlays (dialogs, popovers, command palette). */
 	:global(.composer-glass) {
 		background: color-mix(in srgb, var(--color-panel-bg) 88%, transparent);
-		backdrop-filter: blur(16px) saturate(1.4);
-		-webkit-backdrop-filter: blur(16px) saturate(1.4);
+		backdrop-filter: blur(10px) saturate(1.4);
+		-webkit-backdrop-filter: blur(10px) saturate(1.4);
 		border-color: var(--color-glass-border);
 		box-shadow:
 			var(--color-glass-shadow),
@@ -1810,6 +1812,10 @@ function activitiesForTurn(
 		min-width: 0;
 		font-size: 10px;
 		line-height: 14px;
+		/* `top` is deliberate over `transform: translateY`: Svelte's `fly` enter
+		   transition writes inline `transform`, and a base-class transform would
+		   compose unpredictably with it. The animated property is bounded to
+		   ±14px so the layout cost is trivial. */
 		transition: top var(--duration-smooth) var(--ease-standard);
 	}
 

--- a/apps/web/src/lib/components/layout/WalkthroughActionBar.svelte
+++ b/apps/web/src/lib/components/layout/WalkthroughActionBar.svelte
@@ -59,7 +59,7 @@ const genActionState = $derived.by((): GenActionState | null => {
  *  destructive buttons are disabled with a contextual tooltip. */
 const combinedPendingAction = $derived(chatStreaming ? "chat" : walkthroughPendingAction);
 const combinedDisabledTitle = $derived(
-  chatStreaming ? "Chat edit in progress — wait for it to finish before regenerating" : undefined,
+  chatStreaming ? "Chat edit in progress. Wait for it to finish before regenerating." : undefined,
 );
 </script>
 

--- a/apps/web/src/lib/components/onboarding/AccountPicker.svelte
+++ b/apps/web/src/lib/components/onboarding/AccountPicker.svelte
@@ -101,7 +101,7 @@ function cycleTheme() {
                     </span>
                     <span class="picker-card-action">
                         {#if switching}
-                            <Loader2 size={14} weight="regular" class="picker-spinner" />
+                            <Loader2 size={14} weight="regular" class="picker-spinner motion-essential-spin" />
                         {:else}
                             <ArrowRight size={14} class="picker-arrow" />
                         {/if}
@@ -272,11 +272,6 @@ function cycleTheme() {
 
     :global(.picker-spinner) {
         color: var(--color-text-muted);
-        animation: spin 1s linear infinite;
-    }
-
-    @keyframes spin {
-        to { transform: rotate(360deg); }
     }
 
     .picker-footer {

--- a/apps/web/src/lib/components/onboarding/StepSignIn.svelte
+++ b/apps/web/src/lib/components/onboarding/StepSignIn.svelte
@@ -190,7 +190,9 @@ async function copyCode() {
 		color: var(--ob-error);
 		margin: 0;
 		padding: 10px 14px;
-		border-left: 2px solid var(--ob-error-border);
+		border: 1px solid var(--ob-error-border);
+		background: color-mix(in srgb, var(--ob-error) 6%, transparent);
+		border-radius: 6px;
 	}
 
 	.actions {
@@ -298,7 +300,9 @@ async function copyCode() {
 		letter-spacing: 0.12em;
 		text-transform: uppercase;
 		cursor: pointer;
-		transition: all var(--duration-snap) var(--ease-out-expo);
+		transition:
+			border-color var(--duration-snap) var(--ease-out-expo),
+			color var(--duration-snap) var(--ease-out-expo);
 	}
 
 	.copy-btn:hover {

--- a/apps/web/src/lib/components/recaps/RecapDetail.svelte
+++ b/apps/web/src/lib/components/recaps/RecapDetail.svelte
@@ -521,8 +521,11 @@ $effect(() => {
 	}
 
 	.thought-markdown :global(blockquote) {
-		padding-left: 0.75rem;
-		border-left: 2px solid color-mix(in srgb, var(--color-accent) 45%, transparent);
+		padding: 8px 12px;
+		margin: 0 0 12px;
+		border: 1px solid color-mix(in srgb, var(--color-accent) 30%, var(--color-border));
+		background: color-mix(in srgb, var(--color-accent) 5%, transparent);
+		border-radius: 6px;
 		color: var(--color-text-secondary);
 	}
 

--- a/apps/web/src/lib/components/repo/RepoTaggedPrs.svelte
+++ b/apps/web/src/lib/components/repo/RepoTaggedPrs.svelte
@@ -57,7 +57,7 @@ function handleClick(prId: string) {
 	{:else if prs.length === 0}
 		<div class="tagged-empty">
 			<User size={16} weight="regular" aria-hidden="true" />
-			<p>No pull requests need your attention — you're all caught up!</p>
+			<p>No pull requests need your attention.</p>
 		</div>
 	{:else}
 		<ul class="tagged-list">

--- a/apps/web/src/lib/components/review/AnnotationThread.svelte
+++ b/apps/web/src/lib/components/review/AnnotationThread.svelte
@@ -326,8 +326,10 @@ function focusOnMount(node: HTMLTextAreaElement) {
 	}
 	.msg-body :global(blockquote) {
 		margin: 4px 0;
-		padding-left: 10px;
-		border-left: 2px solid var(--color-border);
+		padding: 6px 10px;
+		border: 1px solid var(--color-border);
+		background: color-mix(in srgb, var(--color-text-muted) 4%, transparent);
+		border-radius: 6px;
 		color: var(--color-text-muted);
 	}
 	.msg-body :global(a) {
@@ -483,7 +485,7 @@ function focusOnMount(node: HTMLTextAreaElement) {
 		width: 100%;
 		min-height: 60px;
 		background: var(--color-input-bg);
-		border: 1px solid var(--color-accent);
+		border: 1px solid var(--color-border);
 		border-radius: 4px;
 		padding: 6px 8px;
 		font-family: var(--font-sans);
@@ -493,6 +495,10 @@ function focusOnMount(node: HTMLTextAreaElement) {
 		resize: vertical;
 		outline: none;
 		box-sizing: border-box;
+		transition: box-shadow var(--duration-quick) var(--ease-out-expo);
+	}
+	.edit-textarea:focus-visible {
+		box-shadow: 0 0 0 3px var(--color-input-focus-ring);
 	}
 	.edit-actions {
 		display: flex;

--- a/apps/web/src/lib/components/review/DiffViewerInner.svelte
+++ b/apps/web/src/lib/components/review/DiffViewerInner.svelte
@@ -688,8 +688,9 @@ export interface ThreadMeta {
 		margin-left: 4px;
 		vertical-align: middle;
 		background: var(--color-glass-bg);
-		backdrop-filter: blur(16px) saturate(1.4);
-		-webkit-backdrop-filter: blur(16px) saturate(1.4);
+		/* Standing chrome: 10px blur, not 16px. */
+		backdrop-filter: blur(10px) saturate(1.4);
+		-webkit-backdrop-filter: blur(10px) saturate(1.4);
 		border: 1px solid var(--color-glass-border);
 		box-shadow:
 			var(--color-glass-shadow),
@@ -720,6 +721,12 @@ export interface ThreadMeta {
 
 	:global([data-view-btn='active']:hover) {
 		background-color: var(--color-glass-active-bg);
+	}
+
+	/* inset box-shadow avoids clipping by the pill's overflow:hidden */
+	:global([data-view-btn]:focus-visible) {
+		box-shadow: inset 0 0 0 2px var(--color-accent);
+		outline: none;
 	}
 
 	:global([data-view-sep]) {

--- a/apps/web/src/lib/components/review/ProposedCommentChip.svelte
+++ b/apps/web/src/lib/components/review/ProposedCommentChip.svelte
@@ -40,9 +40,8 @@ let { body, onEdit, onDelete }: Props = $props();
 		display: flex;
 		align-items: flex-start;
 		gap: 8px;
-		background: var(--color-input-bg);
-		border-top: 1px solid var(--color-border);
-		border-left: 2px solid var(--color-accent);
+		background: color-mix(in srgb, var(--color-accent) 5%, var(--color-input-bg));
+		border-top: 1px solid color-mix(in srgb, var(--color-accent) 25%, var(--color-border));
 		padding: 6px 10px;
 	}
 
@@ -84,5 +83,15 @@ let { body, onEdit, onDelete }: Props = $props();
 	.chip-btn:hover {
 		background: var(--color-bg-tertiary);
 		color: var(--color-text-secondary);
+	}
+
+	.chip-btn:active {
+		background: var(--color-bg-tertiary);
+		opacity: 0.7;
+	}
+
+	.chip-btn:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 1px;
 	}
 </style>

--- a/apps/web/src/lib/components/review/RequestChanges.svelte
+++ b/apps/web/src/lib/components/review/RequestChanges.svelte
@@ -97,9 +97,9 @@ function buildBody(): string {
     for (const issue of selectedIssues) {
       const loc =
         issue.filePath && issue.startLine != null
-          ? ` — \`${issue.filePath}:${issue.startLine}${issue.endLine != null && issue.endLine !== issue.startLine ? `–${issue.endLine}` : ""}\``
+          ? ` (\`${issue.filePath}:${issue.startLine}${issue.endLine != null && issue.endLine !== issue.startLine ? `–${issue.endLine}` : ""}\`)`
           : issue.filePath
-            ? ` — \`${issue.filePath}\``
+            ? ` (\`${issue.filePath}\`)`
             : "";
       parts.push(
         `- ${severityTag(issue.severity)} **${issue.title}**${loc}\n  ${issue.description}`,

--- a/apps/web/src/lib/components/shared/CloneStatusIndicator.svelte
+++ b/apps/web/src/lib/components/shared/CloneStatusIndicator.svelte
@@ -49,7 +49,7 @@ let tooltip = $derived.by(() => {
     case "ready":
       return showSuccess ? "Clone complete" : "";
     case "error":
-      return error && error.length > 0 ? error : "Clone failed — click to retry";
+      return error && error.length > 0 ? error : "Clone failed. Click to retry.";
   }
 });
 

--- a/apps/web/src/lib/components/shared/RepoGradientAvatar.svelte
+++ b/apps/web/src/lib/components/shared/RepoGradientAvatar.svelte
@@ -87,13 +87,10 @@ const letter = $derived((fullName.split("/")[1] ?? fullName).slice(0, 1).toUpper
     font-family: var(--font-sans);
     font-size: max(7px, calc(var(--rga-size) * 0.48));
     font-weight: 600;
-    background: var(--rga-text-grad);
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-    text-transform: uppercase;
+    color: oklch(98% 0.005 80 / 0.92);
     line-height: 1;
     pointer-events: none;
     user-select: none;
+    text-shadow: 0 1px 2px rgba(20, 20, 20, 0.35);
   }
 </style>

--- a/apps/web/src/lib/components/sidebar/ProjectHeader.svelte
+++ b/apps/web/src/lib/components/sidebar/ProjectHeader.svelte
@@ -62,8 +62,8 @@ function handleNewPr(): void {
 				</Tooltip.Trigger>
 				<Tooltip.Content side="bottom" sideOffset={6} align="end">
 					{newPrEnabled
-						? 'Start a new PR — chat with the agent in a worktree'
-						: 'Coming soon — agent-driven PR creation'}
+						? 'Start a new PR. Chat with the agent in a worktree.'
+						: 'Coming soon: agent-driven PR creation.'}
 				</Tooltip.Content>
 			</Tooltip.Root>
 		</div>
@@ -157,6 +157,11 @@ function handleNewPr(): void {
 		color: var(--color-text-primary);
 	}
 
+	.header-link:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
+	}
+
 	.header-link-label {
 		font-weight: 500;
 	}
@@ -179,6 +184,11 @@ function handleNewPr(): void {
 
 	.new-pr-button:hover:not(:disabled) {
 		filter: brightness(1.08);
+	}
+
+	.new-pr-button:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
 	}
 
 	.new-pr-button--disabled {

--- a/apps/web/src/lib/components/sidebar/UserMenu.svelte
+++ b/apps/web/src/lib/components/sidebar/UserMenu.svelte
@@ -132,7 +132,7 @@ async function handleSignOut(): Promise<void> {
 			{/if}
 			{#if isSwitching}
 				<span class="user-avatar-spinner" aria-hidden="true">
-					<Loader2 size={collapsed ? 12 : 14} weight="regular" class="spin-icon" />
+					<Loader2 size={collapsed ? 12 : 14} weight="regular" class="spin-icon motion-essential-spin" />
 				</span>
 			{/if}
 		</span>
@@ -188,7 +188,7 @@ async function handleSignOut(): Promise<void> {
 				<!-- Status indicator -->
 				<span class="acct-status-slot">
 					{#if switching}
-						<Loader2 size={12} weight="regular" class="acct-spinner" />
+						<Loader2 size={12} weight="regular" class="acct-spinner motion-essential-spin" />
 					{:else if active}
 						<Check size={12} weight="regular" class="acct-check" />
 					{/if}
@@ -276,7 +276,6 @@ async function handleSignOut(): Promise<void> {
 
 	:global(.spin-icon) {
 		color: var(--color-text-muted);
-		animation: spin 1s linear infinite;
 	}
 
 	.user-avatar {
@@ -450,7 +449,6 @@ async function handleSignOut(): Promise<void> {
 
 	:global(.acct-spinner) {
 		color: var(--color-text-muted);
-		animation: spin 1s linear infinite;
 	}
 
 	/* ── Divider ── */
@@ -500,7 +498,4 @@ async function handleSignOut(): Promise<void> {
 		flex: 1;
 	}
 
-	@keyframes spin {
-		to { transform: rotate(360deg); }
-	}
 </style>

--- a/apps/web/src/lib/components/ui/glass-pill/glass-pill.css
+++ b/apps/web/src/lib/components/ui/glass-pill/glass-pill.css
@@ -5,8 +5,10 @@
   height: 36px;
   padding: 0 16px;
   background: var(--color-tab-track-bg);
-  backdrop-filter: blur(16px) saturate(1.4);
-  -webkit-backdrop-filter: blur(16px) saturate(1.4);
+  /* 10px is the standing-chrome blur cap. Floating chrome stays light;
+     short-lived overlays (dialogs, popovers, command palette) keep 16px. */
+  backdrop-filter: blur(10px) saturate(1.4);
+  -webkit-backdrop-filter: blur(10px) saturate(1.4);
   border: 1px solid var(--color-glass-border);
   border-radius: 9999px;
   box-shadow:
@@ -22,13 +24,18 @@
   transition:
     background-color var(--duration-snap),
     color var(--duration-snap),
-    box-shadow var(--duration-snap);
+    box-shadow var(--duration-snap),
+    transform var(--duration-instant);
   -webkit-font-smoothing: antialiased;
   white-space: nowrap;
 }
 
 .glass-pill:hover {
   background: color-mix(in srgb, var(--color-tab-active-bg) 80%, var(--color-tab-track-bg));
+}
+
+.glass-pill:active:not(:disabled) {
+  transform: scale(0.97);
 }
 
 .glass-pill:focus-visible {

--- a/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
+++ b/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
@@ -1496,6 +1496,10 @@ function handleRegenerate(): void {
 		display: flex;
 		gap: 6px;
 		min-width: 0;
+		/* `top` is deliberate over `transform: translateY`: Svelte's `fly` enter
+		   transition (used inline) writes inline `transform`, and a base-class
+		   transform would compose unpredictably with it. The animated property
+		   is bounded to ±14px so the layout cost is trivial. */
 		transition: top var(--duration-smooth) var(--ease-standard);
 	}
 

--- a/apps/web/src/lib/components/walkthrough/IssueCard.svelte
+++ b/apps/web/src/lib/components/walkthrough/IssueCard.svelte
@@ -159,9 +159,8 @@ function onAnimEnd(event: AnimationEvent): void {
 	.issue-card {
 		padding: 10px 14px;
 		border-radius: 8px;
-		background: var(--color-bg-secondary);
-		border: 1px solid var(--color-border);
-		border-left: 3px solid var(--severity-color, var(--color-border));
+		background: color-mix(in srgb, var(--severity-color, transparent) 5%, var(--color-bg-secondary));
+		border: 1px solid color-mix(in srgb, var(--severity-color, transparent) 35%, var(--color-border));
 		display: flex;
 		flex-direction: row;
 		align-items: flex-start;
@@ -216,6 +215,11 @@ function onAnimEnd(event: AnimationEvent): void {
 
 	button.issue-card:hover .issue-step-tag {
 		color: var(--severity-color, var(--color-accent));
+	}
+
+	button.issue-card:active {
+		transform: translateY(0);
+		box-shadow: none;
 	}
 
 	button.issue-card:focus-visible {

--- a/apps/web/src/lib/components/walkthrough/WalkthroughCodeBlock.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughCodeBlock.svelte
@@ -107,18 +107,18 @@ function mountCodeBlock(el: HTMLDivElement) {
 		display: flex;
 		align-items: flex-start;
 		padding: 16px 20px;
-		background: var(--revv-bg-secondary);
+		background: color-mix(in srgb, var(--revv-accent) 4%, var(--revv-bg-secondary));
 		font-size: 14px;
 		line-height: 1.6;
 		color: var(--revv-text-secondary);
 	}
 
 	.annotation--left {
-		border-right: 2px solid var(--revv-accent);
+		border-right: 1px solid color-mix(in srgb, var(--revv-accent) 35%, var(--revv-border));
 	}
 
 	.annotation--right {
-		border-left: 2px solid var(--revv-accent);
+		border-left: 1px solid color-mix(in srgb, var(--revv-accent) 35%, var(--revv-border));
 	}
 
 	.annotation-content {

--- a/apps/web/src/lib/components/walkthrough/WalkthroughDiffBlock.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughDiffBlock.svelte
@@ -129,18 +129,18 @@ function mountDiffBlock(el: HTMLDivElement) {
 		display: flex;
 		align-items: flex-start;
 		padding: 16px 20px;
-		background: var(--revv-bg-secondary);
+		background: color-mix(in srgb, var(--revv-accent) 4%, var(--revv-bg-secondary));
 		font-size: 14px;
 		line-height: 1.6;
 		color: var(--revv-text-secondary);
 	}
 
 	.annotation--left {
-		border-right: 2px solid var(--revv-accent);
+		border-right: 1px solid color-mix(in srgb, var(--revv-accent) 35%, var(--revv-border));
 	}
 
 	.annotation--right {
-		border-left: 2px solid var(--revv-accent);
+		border-left: 1px solid color-mix(in srgb, var(--revv-accent) 35%, var(--revv-border));
 	}
 
 	.annotation-content {

--- a/apps/web/src/lib/components/walkthrough/WalkthroughMarkdownBlock.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughMarkdownBlock.svelte
@@ -93,12 +93,12 @@ const renderedContent = $derived.by(() => {
 	}
 
 	.prose :global(blockquote) {
-		border-left: 3px solid var(--color-accent);
-		padding: 4px 12px;
+		border: 1px solid color-mix(in srgb, var(--color-accent) 30%, var(--color-border));
+		padding: 8px 12px;
 		margin: 0 0 12px;
 		color: var(--color-text-secondary);
 		background: color-mix(in srgb, var(--color-accent) 5%, transparent);
-		border-radius: 0 4px 4px 0;
+		border-radius: 6px;
 	}
 
 	.prose :global(hr) {

--- a/apps/web/src/lib/stores/prs.svelte.ts
+++ b/apps/web/src/lib/stores/prs.svelte.ts
@@ -500,7 +500,6 @@ function flipPrDraftLocally(prId: string, isDraft: boolean): void {
 export async function convertPrToDraft(prId: string): Promise<void> {
   const pr = pullRequests.find((p) => p.id === prId);
   if (!pr || pr.isDraft) return;
-  const prevIsDraft = pr.isDraft;
 
   flipPrDraftLocally(prId, true);
 
@@ -508,7 +507,7 @@ export async function convertPrToDraft(prId: string): Promise<void> {
     const { error } = await api.api.prs({ id: prId })["convert-to-draft"].post();
     if (error) throw new Error(`HTTP ${error.status}`);
   } catch (e) {
-    flipPrDraftLocally(prId, prevIsDraft);
+    flipPrDraftLocally(prId, false);
     toast.error(e instanceof Error ? e.message : "Failed to convert to draft");
     throw e;
   }
@@ -517,7 +516,6 @@ export async function convertPrToDraft(prId: string): Promise<void> {
 export async function markPrReadyForReview(prId: string): Promise<void> {
   const pr = pullRequests.find((p) => p.id === prId);
   if (!pr?.isDraft) return;
-  const prevIsDraft = pr.isDraft;
 
   flipPrDraftLocally(prId, false);
 
@@ -525,16 +523,14 @@ export async function markPrReadyForReview(prId: string): Promise<void> {
     const { error } = await api.api.prs({ id: prId })["ready-for-review"].post();
     if (error) throw new Error(`HTTP ${error.status}`);
   } catch (e) {
-    flipPrDraftLocally(prId, prevIsDraft);
+    flipPrDraftLocally(prId, true);
     toast.error(e instanceof Error ? e.message : "Failed to mark ready for review");
     throw e;
   }
 }
 
 /**
- * Restore a PR from the archive back into the open list with prior status
- * and closedAt. Used by the `closePr` / `mergePr` rollback path — the
- * reverse of `onPrArchived`'s forward move. Touches only the one PR so
+ * Reverse of `onPrArchived`'s forward move. Touches only the one PR so
  * concurrent `prs:updated` reshuffles of other entries are preserved.
  */
 function restorePrFromArchive(

--- a/scripts/dev/ralph-wiggum-loop.ts
+++ b/scripts/dev/ralph-wiggum-loop.ts
@@ -217,7 +217,7 @@ async function verifyTypecheckOnFile(filePath: string): Promise<boolean> {
   if (hasErrorInFile) {
     console.log(`  ⚠️  Type error in ${filePath}:`);
     const errorLines = output.split("\n").filter((l) => l.includes(filePath));
-    console.log(errorLines.map((l) => "     " + l).join("\n"));
+    console.log(errorLines.map((l) => `     ${l}`).join("\n"));
     return false;
   }
 
@@ -310,7 +310,7 @@ async function main() {
     console.log(
       `  📝 Diff preview:\n${diff
         .split("\n")
-        .map((l) => "     " + l)
+        .map((l) => `     ${l}`)
         .join("\n")}\n`,
     );
 


### PR DESCRIPTION
## Summary

- **Polish pass**: replaced 11 side-stripe borders with full hairline borders or background tints, fixed the dark-theme accent off stock Tailwind blue, standardized all motion tokens to `app.css` theme variables, added `focus-visible` to the `AnnotationThread` textarea, and removed dead variable captures in `prs.svelte.ts` optimistic rollback
- **Accent color**: swapped Forest Olive (H=155) for Deep Naval (`oklch(46% 0.11 225)` light / `oklch(71% 0.14 225)` dark) — a midnight blue that reads as considered without defaulting to stock-Tailwind 259
- **Design system docs**: added `PRODUCT.md` and `DESIGN.md` capturing the warm-paper canvas, one-accent rule, and component token system

## Test plan

- [ ] Light theme: verify primary buttons, active file tree items, focus rings, open-thread markers, and stream cursor all render in Deep Naval
- [ ] Dark theme: verify the same surfaces use the luminous Phosphor Naval variant
- [ ] Confirm no side-stripe `border-left/right` accents remain on cards or list items
- [ ] Verify all transitions/animations use `var(--duration-*)` / `var(--ease-*)` tokens (no raw `ms` literals)
- [ ] Lint: `make lint` exits clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)