### PR TITLE
feat(walkthrough): shimmer-grouped tool calls + chronological thoughts toggle

### DIFF
--- a/apps/server/src/ai/providers/mcp-walkthrough-opencode.ts
+++ b/apps/server/src/ai/providers/mcp-walkthrough-opencode.ts
@@ -346,12 +346,15 @@ export function streamWalkthroughViaOpencodeMCP(
             }
 
             if (ev.kind === "reasoning-delta") {
-              // Extended reasoning — keep stream guard alive
-              // (throttled to once per 30s). The opencode driver
-              // owns this heartbeat because the agent-side
-              // reasoning may run for 60+ s without producing a
-              // tool call, which would otherwise look like a
-              // stalled stream to the guard.
+              // Forward reasoning text so the client can interleave it
+              // chronologically with tool calls in the "Reviewing…"
+              // feed. Empty deltas are dropped (no signal).
+              if (ev.data.length > 0) {
+                push({ type: "thought", data: { text: ev.data } });
+              }
+              // Throttled phase heartbeat — keeps the stream guard
+              // alive when reasoning runs for 60+ s without producing
+              // a tool call.
               const now = Date.now();
               if (now - lastReasoningPush >= 30_000) {
                 lastReasoningPush = now;

--- a/apps/server/src/ai/providers/mcp-walkthrough.ts
+++ b/apps/server/src/ai/providers/mcp-walkthrough.ts
@@ -331,11 +331,17 @@ export function streamWalkthroughViaMCP(
         },
       });
 
-      // Walkthrough doesn't surface text/reasoning to the UI — content
-      // flows commit-first through MCP tool handlers. Tool calls drive
-      // either an `exploration` event (built-in tools) or a phase
-      // transition (MCP walkthrough tools).
+      // Walkthrough content flows commit-first through MCP tool handlers.
+      // We surface two ephemeral signals to the UI alongside that commit
+      // stream: `exploration` for built-in tool calls, and `thought` for
+      // streamed model reasoning text (so the client can interleave them
+      // chronologically in the live "Reviewing…" feed).
       const emit = (ev: NormalizedAgentEvent): void => {
+        if (ev.kind === "reasoning-delta") {
+          if (ev.data.length === 0) return;
+          push({ type: "thought", data: { text: ev.data } });
+          return;
+        }
         if (ev.kind !== "tool-call") return;
 
         if (ev.source === "builtin" && EXPLORATION_TOOLS.has(ev.toolName)) {

--- a/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
+++ b/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
@@ -8,9 +8,11 @@ const TOOL_CALL_ROW_H = 14; // px — 10px font × 1.4 line-height
 import type { WalkthroughBlock, WalkthroughSemanticStep } from "@revv/shared";
 import { API_BASE_URL } from "@revv/shared";
 import RefreshCw from "phosphor-svelte/lib/ArrowsClockwise";
+import CaretDown from "phosphor-svelte/lib/CaretDown";
 import AlertTriangle from "phosphor-svelte/lib/Warning";
 import AlertCircle from "phosphor-svelte/lib/WarningCircle";
 import { Shimmer } from "$lib/components/ai/shimmer";
+import { ToolActivityGroup } from "$lib/components/ai/tool";
 import { Button } from "$lib/components/ui/button";
 import { Dotmatrix } from "$lib/components/ui/dotmatrix/index.js";
 import FileBadge from "$lib/components/ui/FileBadge.svelte";
@@ -43,6 +45,8 @@ import {
   getStreamError,
   getStreamStartedAt,
   getSummary,
+  getThoughts,
+  getTimeline,
   hasBlockAnimated,
   hasContainerAnimated,
   hasIssueAnimated,
@@ -56,6 +60,12 @@ import {
   startWalkthrough,
   stopClonePoll,
 } from "$lib/stores/walkthrough.svelte";
+import {
+  groupActivityRuns,
+  isActivityGroup,
+  isExplorationActivity,
+  type GroupableActivity,
+} from "$lib/utils/activity-groups";
 import { initHighlighter } from "$lib/utils/code-highlight.svelte";
 import { renderMarkdown } from "$lib/utils/markdown";
 import { authHeaders } from "$lib/utils/session-token";
@@ -79,6 +89,8 @@ const riskLevel = $derived(getRiskLevel());
 const isStreaming = $derived(getIsStreaming());
 const streamError = $derived(getStreamError());
 const explorationSteps = $derived(getExplorationSteps());
+const thoughts = $derived(getThoughts());
+const timeline = $derived(getTimeline());
 const phase = $derived(getPhase());
 const streamStartedAt = $derived(getStreamStartedAt());
 const issues = $derived(getIssues());
@@ -323,6 +335,58 @@ const showDiffSkeleton = $derived(
     ratings.length === 0 &&
     (lastCompletedPhase === "none" || lastCompletedPhase === "A" || lastCompletedPhase === "B"),
 );
+
+// Below-chapter activity feed: mirrors the recap pattern
+// (`RecapDetail.svelte`). We only surface *exploration* tool calls
+// (Read/Grep/Glob/LS) here — MCP content-write calls like
+// `add_diff_step`, `set_overview`, `rate_axis`, etc. are deliberately
+// hidden because their output already lands as visible blocks/ratings
+// in the walkthrough itself. `groupActivityRuns` then collapses the
+// consecutive exploration calls into a single shimmer-labeled group
+// with odometer counts. We synthesize a stable `id` from the absolute
+// index because `Activity` doesn't carry one.
+const groupableExplorationSteps = $derived.by<readonly GroupableActivity[]>(() =>
+  explorationSteps
+    .map((step, i): GroupableActivity => ({ ...step, id: `step-${i}` }))
+    .filter((step) => isExplorationActivity(step)),
+);
+const walkthroughActivityEntries = $derived(groupActivityRuns(groupableExplorationSteps));
+
+// Interleaved view: walks the chronological `timeline` (mixed thoughts
+// + exploration tool calls) and emits a render list where consecutive
+// exploration calls between thoughts collapse into a single group (so
+// the "Exploring · N reads, M searches" shimmer/odometer still works
+// inside each chronological segment). MCP write tools are filtered
+// out for the same reason as above. Thoughts are emitted as discrete
+// markdown blocks; each entry keeps its `timeline` id so streaming
+// re-renders are stable.
+type InterleavedRenderEntry =
+  | { readonly kind: "thought"; readonly id: string; readonly text: string }
+  | {
+      readonly kind: "explorations";
+      readonly id: string;
+      readonly items: readonly GroupableActivity[];
+    };
+const interleavedEntries = $derived.by<readonly InterleavedRenderEntry[]>(() => {
+  const out: InterleavedRenderEntry[] = [];
+  for (const entry of timeline) {
+    if (entry.kind === "thought") {
+      out.push({ kind: "thought", id: entry.id, text: entry.text });
+      continue;
+    }
+    if (!isExplorationActivity(entry.activity)) continue;
+    const item: GroupableActivity = { ...entry.activity, id: entry.id };
+    const last = out.at(-1);
+    if (last && last.kind === "explorations") {
+      out[out.length - 1] = { ...last, items: [...last.items, item] };
+    } else {
+      out.push({ kind: "explorations", id: `group-${entry.id}`, items: [item] });
+    }
+  }
+  return out;
+});
+const hasThoughtText = $derived(thoughts.trim().length > 0);
+let thoughtsOpen = $state(false);
 
 const blocksWithDelay = $derived.by(() => {
   let newInBatch = 0;
@@ -1056,16 +1120,72 @@ function handleRegenerate(): void {
 				/>
 			{/each}
 
-		<!-- Diff-analysis shimmer text: placeholder while Phase B is active.
-		     Stays visible from when the overview lands (Phase A done) until the
-		     agent finishes all diff steps and moves to Phase C. -->
+		<!-- Diff-analysis skeleton: visible from Phase A→C. Mirrors the recap
+		     pattern (RecapDetail.svelte): the "Reviewing…" shimmer is a
+		     Collapsible trigger gating the model's reasoning text. When the
+		     toggle is closed, the activity stack below shows only the
+		     consolidated exploration groups (shimmer + odometer counts). When
+		     open, the stack switches to a chronological view that interleaves
+		     thought blocks with the same grouped tool calls — reads as a
+		     timeline. MCP write tools are filtered at the derived layer. -->
 		{#if showDiffSkeleton}
 			<div class="block-group">
 				<span class="block-step-dot" aria-hidden="true"></span>
-				<div class="block-wrapper block-wrapper--no-anim">
-					<Shimmer class="text-sm" aria-label="Reviewing...">
-						Reviewing...
-					</Shimmer>
+				<div class="block-wrapper block-wrapper--no-anim walkthrough-skeleton">
+					<button
+						type="button"
+						class="walkthrough-skeleton-trigger"
+						aria-label="Reviewing. Toggle streamed thoughts."
+						aria-expanded={thoughtsOpen}
+						onclick={() => { thoughtsOpen = !thoughtsOpen; }}
+					>
+						<Shimmer class="text-sm" aria-label="Reviewing">Reviewing...</Shimmer>
+						<span class="walkthrough-skeleton-meta">
+							<span>{hasThoughtText ? 'Thoughts' : 'Waiting for thoughts'}</span>
+							<span
+								class="walkthrough-skeleton-chevron-wrap"
+								data-state={thoughtsOpen ? 'open' : 'closed'}
+							>
+								<CaretDown class="walkthrough-skeleton-chevron" aria-hidden="true" />
+							</span>
+						</span>
+					</button>
+
+					{#if thoughtsOpen}
+						{#if interleavedEntries.length > 0}
+							<div class="walkthrough-activity-stack">
+								{#each interleavedEntries as entry, entryIdx (entry.id)}
+									{#if entry.kind === 'thought'}
+										<div class="walkthrough-inline-thought">
+											{@html renderMarkdown(entry.text)}
+										</div>
+									{:else}
+										<ToolActivityGroup
+											items={entry.items}
+											active={entryIdx === interleavedEntries.length - 1}
+											defaultOpen={false}
+										/>
+									{/if}
+								{/each}
+							</div>
+						{:else}
+							<p class="walkthrough-thought-empty">
+								No streamed thoughts yet. Tool calls will appear here as they happen.
+							</p>
+						{/if}
+					{:else if walkthroughActivityEntries.length > 0}
+						<div class="walkthrough-activity-stack">
+							{#each walkthroughActivityEntries as entry, entryIdx (isActivityGroup(entry) ? `group-${entry.items[0]?.id ?? entryIdx}` : entry.id)}
+								{#if isActivityGroup(entry)}
+									<ToolActivityGroup
+										items={entry.items}
+										active={entryIdx === walkthroughActivityEntries.length - 1}
+										defaultOpen={false}
+									/>
+								{/if}
+							{/each}
+						</div>
+					{/if}
 				</div>
 			</div>
 		{/if}
@@ -1861,6 +1981,133 @@ function handleRegenerate(): void {
 		opacity: 1;
 		transform: none;
 		filter: none;
+	}
+
+	/* ── Skeleton tool-call feed (mirrors recap-activity-stack) ──────────
+	   Renders below the "Reviewing…" shimmer in the Phase-A/B skeleton.
+	   `ToolActivityGroup` brings its own shimmer + odometer; when the
+	   thoughts toggle is open, the same stack interleaves inline thought
+	   markdown blocks chronologically between the groups. */
+	.walkthrough-skeleton {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.walkthrough-skeleton-trigger {
+		display: flex;
+		width: 100%;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem;
+		padding: 0.125rem 0;
+		text-align: left;
+		background: transparent;
+		border: 0;
+		color: inherit;
+		cursor: pointer;
+		font: inherit;
+	}
+
+	.walkthrough-skeleton-meta {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		flex-shrink: 0;
+		font-size: 0.75rem;
+		color: var(--color-text-muted);
+	}
+
+	.walkthrough-skeleton-chevron-wrap {
+		display: inline-grid;
+		place-items: center;
+		transition: transform var(--duration-snap) var(--ease-out-expo);
+	}
+
+	.walkthrough-skeleton-chevron-wrap[data-state="open"] {
+		transform: rotate(180deg);
+	}
+
+	.walkthrough-skeleton-chevron-wrap :global(.walkthrough-skeleton-chevron) {
+		width: 0.75rem;
+		height: 0.75rem;
+	}
+
+	.walkthrough-activity-stack {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		max-width: 42rem;
+		margin-top: 0.25rem;
+	}
+
+	.walkthrough-thought-empty {
+		margin: 0.375rem 0 0;
+		font-size: 0.8125rem;
+		color: var(--color-text-muted);
+	}
+
+	.walkthrough-inline-thought {
+		font-size: 0.875rem;
+		line-height: 1.6;
+		color: var(--color-text-muted);
+		word-break: break-word;
+	}
+
+	.walkthrough-inline-thought :global(p),
+	.walkthrough-inline-thought :global(ul),
+	.walkthrough-inline-thought :global(ol),
+	.walkthrough-inline-thought :global(pre),
+	.walkthrough-inline-thought :global(blockquote) {
+		margin: 0 0 0.5rem;
+	}
+
+	.walkthrough-inline-thought :global(:last-child) {
+		margin-bottom: 0;
+	}
+
+	.walkthrough-inline-thought :global(ul),
+	.walkthrough-inline-thought :global(ol) {
+		padding-left: 1.25rem;
+	}
+
+	.walkthrough-inline-thought :global(li) {
+		margin: 0.15rem 0;
+	}
+
+	.walkthrough-inline-thought :global(code) {
+		font-family: var(--font-mono);
+		font-size: 0.92em;
+		padding: 0.08em 0.3em;
+		border-radius: 0.25rem;
+		background: color-mix(in srgb, var(--color-bg-tertiary) 70%, transparent);
+		color: var(--color-text-secondary);
+	}
+
+	.walkthrough-inline-thought :global(pre) {
+		overflow-x: auto;
+		padding: 0.625rem;
+		border-radius: 0.375rem;
+		background: var(--color-bg-tertiary);
+	}
+
+	.walkthrough-inline-thought :global(pre code) {
+		padding: 0;
+		background: transparent;
+		font-size: inherit;
+	}
+
+	.walkthrough-inline-thought :global(blockquote) {
+		padding-left: 0.75rem;
+		border-left: 2px solid color-mix(in srgb, var(--color-accent) 45%, transparent);
+		color: var(--color-text-secondary);
+	}
+
+	.walkthrough-inline-thought :global(a) {
+		color: var(--color-accent);
+		text-decoration-line: underline;
+		text-decoration-color: color-mix(in srgb, var(--color-accent) 35%, transparent);
+		text-underline-offset: 2px;
 	}
 
 	/* ── Annotation rail ─────────────────────────────────────────────────

--- a/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
+++ b/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
@@ -61,10 +61,10 @@ import {
   stopClonePoll,
 } from "$lib/stores/walkthrough.svelte";
 import {
+  type GroupableActivity,
   groupActivityRuns,
   isActivityGroup,
   isExplorationActivity,
-  type GroupableActivity,
 } from "$lib/utils/activity-groups";
 import { initHighlighter } from "$lib/utils/code-highlight.svelte";
 import { renderMarkdown } from "$lib/utils/markdown";

--- a/apps/web/src/lib/stores/walkthrough.svelte.ts
+++ b/apps/web/src/lib/stores/walkthrough.svelte.ts
@@ -41,6 +41,17 @@ import { wtTrace } from "$lib/utils/wt-trace";
 
 // ── Entry shape ─────────────────────────────────────────────────────────────
 
+/**
+ * Chronologically ordered live-feed entry mixing model reasoning ("thought")
+ * with built-in exploration tool calls ("exploration"). Populated only during
+ * streaming so the client can render the "Reviewing…" feed with thoughts and
+ * tool calls interleaved in arrival order. Not persisted — rebuilt fresh on
+ * every stream.
+ */
+export type WalkthroughTimelineEntry =
+  | { kind: "thought"; id: string; text: string }
+  | { kind: "exploration"; id: string; activity: Activity };
+
 export interface WalkthroughEntry {
   semanticSteps: WalkthroughSemanticStep[];
   blocks: WalkthroughBlock[];
@@ -54,6 +65,16 @@ export interface WalkthroughEntry {
   doneReceived: boolean;
   superseded: boolean;
   explorationSteps: Activity[];
+  /**
+   * Streamed model reasoning text concatenated in arrival order. Drives the
+   * thoughts toggle UI alongside `timeline`. Ephemeral — not persisted.
+   */
+  thoughts: string;
+  /**
+   * Chronological mix of thoughts and exploration tool calls for the live
+   * "Reviewing…" feed. See `WalkthroughTimelineEntry`. Ephemeral.
+   */
+  timeline: WalkthroughTimelineEntry[];
   issues: WalkthroughIssue[];
   ratings: WalkthroughRating[];
   phase: WalkthroughLifecyclePhase;
@@ -122,6 +143,8 @@ export function freshEntry(): WalkthroughEntry {
     doneReceived: false,
     superseded: false,
     explorationSteps: [],
+    thoughts: "",
+    timeline: [],
     issues: [],
     ratings: [],
     phase: "connecting",
@@ -218,6 +241,12 @@ export function getStreamError(): string | null {
 }
 export function getExplorationSteps(): Activity[] {
   return _active?.explorationSteps ?? [];
+}
+export function getThoughts(): string {
+  return _active?.thoughts ?? "";
+}
+export function getTimeline(): WalkthroughTimelineEntry[] {
+  return _active?.timeline ?? [];
 }
 export function getIssues(): WalkthroughIssue[] {
   return _active?.issues ?? [];
@@ -399,9 +428,42 @@ export function applyEvents(prId: string, events: WalkthroughStreamEvent[]): voi
         case "usage":
           entry.tokenUsage = coerceTokenUsage(event.data.tokenUsage);
           break;
-        case "exploration":
+        case "exploration": {
           entry.explorationSteps = [...entry.explorationSteps, event.data];
+          entry.timeline = [
+            ...entry.timeline,
+            {
+              kind: "exploration",
+              id: `exp-${entry.timeline.length}`,
+              activity: event.data,
+            },
+          ];
           break;
+        }
+        case "thought": {
+          // Append to last thought-run instead of pushing a new entry per
+          // delta — the model emits hundreds of tiny deltas per burst, and
+          // we only want a new timeline entry when a tool call (or some
+          // other non-thought event) has broken the run.
+          const last = entry.timeline.at(-1);
+          if (last && last.kind === "thought") {
+            entry.timeline = [
+              ...entry.timeline.slice(0, -1),
+              { ...last, text: last.text + event.data.text },
+            ];
+          } else {
+            entry.timeline = [
+              ...entry.timeline,
+              {
+                kind: "thought",
+                id: `thought-${entry.timeline.length}`,
+                text: event.data.text,
+              },
+            ];
+          }
+          entry.thoughts = entry.thoughts + event.data.text;
+          break;
+        }
         case "issue": {
           const ii = entry.issues.findIndex((i) => i.id === event.data.id);
           if (ii >= 0) {

--- a/packages/shared/src/walkthrough.ts
+++ b/packages/shared/src/walkthrough.ts
@@ -390,6 +390,13 @@ export type WalkthroughStreamEvent =
     }
   | { type: "in-progress"; data: { walkthroughId: string } }
   | { type: "thinking"; data: Record<string, never> }
+  /**
+   * Streamed model reasoning text. Mirrors the recap `thought` event and is
+   * separate from `thinking` (which is the empty stream-guard heartbeat).
+   * Forwarded from agent-side `reasoning-delta` events; not persisted to
+   * SQLite — only meaningful during live generation.
+   */
+  | { type: "thought"; data: { text: string } }
   // ── Lifecycle events (formerly carried as standalone WS envelopes) ───────
   //
   // After the SSE-unification refactor these are folded into the same event


### PR DESCRIPTION
## Summary
- Below the chapter stepper, the "Reviewing…" shimmer is now a recap-style activity stack: exploration tool calls (Read/Grep/Glob/LS) collapse into a single shimmer-labeled `ToolActivityGroup` with odometer counts; MCP write tools (`add_diff_step`, `set_overview`, `rate_axis`, etc.) are filtered out since their output already lands as visible blocks/ratings.
- Adds a thoughts toggle on the "Reviewing…" trigger. When open, the stack switches to a chronological view that interleaves the model's streamed reasoning (rendered as markdown) with the same grouped tool calls in arrival order.
- New `thought` walkthrough event forwarded from `reasoning-delta` on both Claude (`mcp-walkthrough.ts`) and opencode (`mcp-walkthrough-opencode.ts`) paths — kept separate from the existing `thinking` heartbeat so the stream-guard loop guard in `WalkthroughJobs` stays intact.
- Store gains `thoughts: string` and `timeline: WalkthroughTimelineEntry[]` (ephemeral, stream-only) plus `getThoughts` / `getTimeline` accessors; the reducer appends thought deltas to the trailing thought-run and mirrors every exploration into the timeline.

## Test plan
- [ ] Start a fresh walkthrough on a PR with a meaningful diff; confirm the "Reviewing…" trigger appears with the shimmer label and an "Exploring · N reads, M searches" group whose counts animate via odometer.
- [ ] Open the toggle mid-stream and confirm thoughts render inline (markdown) interleaved with grouped tool-call runs in arrival order; close it and confirm the stack consolidates back into a single grouped view.
- [ ] Verify `add_diff_step`, `set_overview`, `rate_axis`, etc. never appear in the activity stack on either toggle state.
- [ ] Run with the opencode provider and confirm parity: thoughts stream, exploration groups update, no stream-guard regressions on long reasoning bursts.
- [ ] Cancel + resume a walkthrough; confirm no `each_key_duplicate` errors and that the rehydrated cache view shows no stale thoughts/timeline (both are ephemeral).
- [ ] Enable Reduce Motion and confirm the shimmer + odometer collapse per the global `prefers-reduced-motion` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)