### PR TITLE
fix(ci): top-level permissions on release & nightly workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   # Newer pushes to main cancel in-flight nightly builds — we only ever

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,14 @@ concurrency:
   group: nightly
   cancel-in-progress: true
 
+# Top-level cap for the workflow's GITHUB_TOKEN. Must be ≥ the union of every
+# scope any job (including the reusable `_build-tauri.yml`) requests, otherwise
+# GitHub rejects the run at startup when the repo default is `read`.
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
 jobs:
   # Same gates as the stable release workflow. If main is red, we don't
   # publish a nightly that would surface broken binaries to opt-in users.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
 
+# Top-level cap for the workflow's GITHUB_TOKEN. Must be ≥ the union of every
+# scope any job (including the reusable `_build-tauri.yml`) requests, otherwise
+# GitHub rejects the run at startup when the repo default is `read`.
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+  attestations: write
+
 jobs:
   # ── Quality gates (fast, single runner) ───────────────────────
   check:
@@ -53,7 +62,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          bootstrap-sha: d0b10912
+          bootstrap-sha: d0b1091216cd1ad9a7aff9ba3d2d59cbcc4e53c8
 
   # ── Cross-platform Tauri builds ───────────────────────────────
   # Shared matrix lives in `_build-tauri.yml` and is reused by `nightly.yml`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 # Top-level cap for the workflow's GITHUB_TOKEN. Must be ≥ the union of every
 # scope any job (including the reusable `_build-tauri.yml`) requests, otherwise
@@ -62,7 +63,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          bootstrap-sha: d0b1091216cd1ad9a7aff9ba3d2d59cbcc4e53c8
+          bootstrap-sha: d0b10912
 
   # ── Cross-platform Tauri builds ───────────────────────────────
   # Shared matrix lives in `_build-tauri.yml` and is reused by `nightly.yml`.


### PR DESCRIPTION
## Summary
- Release and Nightly were failing with `startup_failure` (zero jobs spawned, ~1s, no logs) on every push to main. Repo default is `default_workflow_permissions: read`, and both workflows invoke the reusable `_build-tauri.yml` whose `build` job requests `id-token: write` / `attestations: write` / `contents: write` for Sigstore provenance — GitHub rejects the run at startup because the caller's effective token cap is below the callee's requested scopes.
- Adds a top-level `permissions:` union to each caller (release: contents/pull-requests/id-token/attestations; nightly: contents/id-token/attestations) so per-job least-privilege blocks can actually elevate within the cap.
- Adds `workflow_dispatch:` to both triggers so this fix can be validated manually on the merge commit (these workflows otherwise only trigger on push: main, with no pre-merge run path).

## Test plan
- [ ] After merge, manually `gh workflow run nightly.yml` and confirm jobs spawn (build matrix runs instead of instant `startup_failure`).
- [ ] On the next push to main, confirm Release spawns the `check` / `release-please` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)