### PR TITLE
fix(ci): publish nightly as per-SHA tags to dodge immutable releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,10 +1,16 @@
 name: Nightly
 
-# Builds an unstable preview from every push to `main` and publishes it to a
-# moving `nightly` prerelease tag. The in-app updater hits this when the user
-# has selected `Settings → Updates → Release channel = Nightly`, and the
-# `revv update` CLI maps the nightly channel to `origin/main` HEAD — so
+# Builds an unstable preview from every push to `main` and publishes it as a
+# per-SHA `nightly-<short-sha>` prerelease. The in-app updater hits this when
+# the user has selected `Settings → Updates → Release channel = Nightly`, and
+# the `revv update` CLI maps the nightly channel to `origin/main` HEAD — so
 # source installs and binary installs stay aligned on the same edge.
+#
+# Why per-SHA tags: GitHub's "Immutable releases" feature permanently reserves
+# any tag that's been used by a release. A moving `nightly` tag is therefore
+# unrecoverable after the first publish. Per-SHA tags sidestep that entirely;
+# the server resolves "latest nightly" dynamically via the releases API (see
+# `apps/server/src/routes/update-manifest.ts`).
 #
 # Independent of release.yml: this never opens a release-please PR, never
 # moves `vX.Y.Z` tags, and never publishes the stable `latest.json` manifest.
@@ -49,42 +55,73 @@ jobs:
       - name: Build
         run: bun run build
 
-  # Re-point the moving `nightly` tag at the just-pushed SHA before the
-  # build matrix runs, so every artifact uploads to a stable, predictable
-  # release URL. Deleting + recreating is simpler than parsing existing
-  # release metadata for an in-place edit.
-  retag:
-    name: Re-point nightly tag
+  # Push a per-SHA tag (`nightly-<short-sha>`) so the build job can check it
+  # out and `tauri-action` can create the release against it. Idempotent on
+  # re-runs of the same commit.
+  prep:
+    name: Create nightly tag
     runs-on: ubuntu-latest
     needs: check
     permissions:
       contents: write
     outputs:
-      short_sha: ${{ steps.sha.outputs.short_sha }}
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+      short_sha: ${{ steps.tag.outputs.short_sha }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Compute short SHA
-        id: sha
-        run: echo "short_sha=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Reset nightly release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push per-SHA tag
+        id: tag
         run: |
-          gh release delete nightly --yes --cleanup-tag 2>/dev/null || true
-          gh release create nightly \
-            --target "$GITHUB_SHA" \
-            --title "Revv nightly (${{ steps.sha.outputs.short_sha }})" \
-            --notes "Auto-built from main @ ${GITHUB_SHA}. Expect bugs." \
-            --prerelease
+          short_sha=$(git rev-parse --short=7 HEAD)
+          tag_name="nightly-${short_sha}"
+          echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+          if git ls-remote --exit-code --tags origin "${tag_name}" >/dev/null 2>&1; then
+            echo "Tag ${tag_name} already exists on origin — reusing."
+          else
+            git tag "${tag_name}"
+            git push origin "${tag_name}"
+          fi
 
   build:
-    needs: retag
+    needs: prep
     uses: ./.github/workflows/_build-tauri.yml
     with:
-      tag_name: nightly
-      release_name: "Revv nightly (${{ needs.retag.outputs.short_sha }})"
-      release_body: "Auto-built from main. Expect bugs."
+      tag_name: ${{ needs.prep.outputs.tag_name }}
+      release_name: "Revv nightly (${{ needs.prep.outputs.short_sha }})"
+      release_body: "Auto-built from main @ ${{ github.sha }}. Expect bugs."
       prerelease: true
     secrets: inherit
+
+  # Cap the historical nightly count. Without trimming, every commit to main
+  # would leave a permanent release artifact, polluting the releases list.
+  # Keeps the 10 most recent `nightly-*` prereleases (including the one this
+  # run just published) and deletes the rest along with their tags.
+  trim:
+    name: Trim old nightlies
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Delete stale nightly releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          KEEP: "10"
+        run: |
+          set -euo pipefail
+          # `gh release list` sorts by created-at desc; skip the first $KEEP
+          # tagged `nightly-*` and delete the rest. `--cleanup-tag` removes
+          # the orphan tag too; immutable-releases means the tag slot stays
+          # reserved, which is fine — we never reuse a per-SHA tag.
+          gh release list \
+            --limit 200 \
+            --json tagName,isPrerelease,createdAt \
+            --jq '[.[] | select(.isPrerelease and (.tagName | startswith("nightly-")))] | sort_by(.createdAt) | reverse | .['"$KEEP"':] | .[] | .tagName' \
+            | while read -r tag; do
+                [ -z "$tag" ] && continue
+                echo "Deleting stale nightly release: $tag"
+                gh release delete "$tag" --yes --cleanup-tag || true
+              done

--- a/apps/server/src/routes/update-manifest.ts
+++ b/apps/server/src/routes/update-manifest.ts
@@ -23,10 +23,42 @@ import { updateChannelSchema } from "./schemas";
 
 const GITHUB_REPO = "alexandre-schaffner/revv";
 const STABLE_MANIFEST_URL = `https://github.com/${GITHUB_REPO}/releases/latest/download/latest.json`;
-// Same filename inside the moving `nightly` tag — the tag is what selects
-// the channel, the filename inside the release is just `latest.json` for
-// both pipelines so we don't need a post-build rename step in CI.
-const NIGHTLY_MANIFEST_URL = `https://github.com/${GITHUB_REPO}/releases/download/nightly/latest.json`;
+// Nightly uses per-SHA tags (`nightly-<short-sha>`) because GitHub's
+// immutable-releases feature permanently reserves any tag used by a release,
+// making a moving `nightly` tag a one-shot. We resolve "latest nightly" at
+// request time by listing releases and picking the newest prerelease whose
+// tag starts with `nightly-`. The asset filename inside each release is just
+// `latest.json` (same as stable) so no post-build rename step is needed.
+const NIGHTLY_RELEASES_API_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=30`;
+const NIGHTLY_TAG_PREFIX = "nightly-";
+
+interface GitHubAsset {
+  name: string;
+  browser_download_url: string;
+}
+interface GitHubRelease {
+  tag_name: string;
+  prerelease: boolean;
+  draft: boolean;
+  assets: GitHubAsset[];
+}
+
+async function resolveNightlyManifestUrl(): Promise<string | null> {
+  const res = await fetch(NIGHTLY_RELEASES_API_URL, {
+    headers: { Accept: "application/vnd.github+json" },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) return null;
+  const releases = (await res.json()) as GitHubRelease[];
+  // The releases API returns results sorted by published_at desc, so the
+  // first matching entry is the newest nightly.
+  const nightly = releases.find(
+    (r) => r.prerelease && !r.draft && r.tag_name.startsWith(NIGHTLY_TAG_PREFIX),
+  );
+  if (!nightly) return null;
+  const asset = nightly.assets.find((a) => a.name === "latest.json");
+  return asset?.browser_download_url ?? null;
+}
 
 export const updateManifestRoute = new Elysia()
   .get("/api/update-manifest", async () => {
@@ -38,11 +70,18 @@ export const updateManifestRoute = new Elysia()
       }).pipe(Effect.orElseSucceed(() => "stable" as const)),
     );
 
-    const target = channel === "nightly" ? NIGHTLY_MANIFEST_URL : STABLE_MANIFEST_URL;
+    let target: string | null;
+    if (channel === "nightly") {
+      target = await resolveNightlyManifestUrl();
+      // No nightly published yet — keep the toast silent.
+      if (!target) return new Response(null, { status: 204 });
+    } else {
+      target = STABLE_MANIFEST_URL;
+    }
 
     // The updater plugin treats any non-2xx as "no update available". When
-    // the nightly tag hasn't been published yet, returning 204 keeps the
-    // toast silent rather than surfacing a bogus error.
+    // the tag hasn't been published yet, returning 204 keeps the toast
+    // silent rather than surfacing a bogus error.
     const upstream = await fetch(target, {
       redirect: "follow",
       signal: AbortSignal.timeout(10_000),


### PR DESCRIPTION
## Summary

- Nightly was failing because GitHub's "Immutable releases" feature permanently reserves any tag used by a release, so the moving `nightly` tag broke after the first publish (`gh release create nightly` → `tag_name was used by an immutable release`).
- The workflow now publishes each build under a unique `nightly-<sha7>` tag (no recreation, no conflict), and a trim job keeps only the 10 most recent so the releases list doesn't grow unbounded.
- `apps/server/src/routes/update-manifest.ts` resolves "latest nightly" at request time via `GET /releases?per_page=30`, picking the newest prerelease whose tag starts with `nightly-` and proxying its `latest.json` asset. Stable channel is untouched.

## Test plan

- [ ] Merge and confirm the next push to `main` produces a `nightly-<sha7>` release with all 4 platform assets.
- [ ] Verify `GET /api/update-manifest` with `updateChannel=nightly` returns the new release's manifest (and 204 before the first nightly is published).
- [ ] Confirm subsequent pushes create new per-SHA releases without touching prior ones, and that `trim` deletes the 11th-oldest on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)