### PR TITLE
fix: resolve CI lint annotations (Node 20 actions, noExplicitAny, noNonNullAssertion)

### DIFF
--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,7 +43,7 @@ jobs:
     name: Quality gates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: package.json
@@ -68,7 +68,7 @@ jobs:
       tag_name: ${{ steps.tag.outputs.tag_name }}
       short_sha: ${{ steps.tag.outputs.short_sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Push per-SHA tag
         id: tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -87,7 +87,7 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.tag_name }}
 

--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/ai/agent-stream/claude-walker.ts
+++ b/apps/server/src/ai/agent-stream/claude-walker.ts
@@ -219,7 +219,8 @@ export async function walkClaudeMessages(
       const attribution = parentId ?? fallbackParentId;
 
       for (let blockIdx = 0; blockIdx < message.message.content.length; blockIdx += 1) {
-        const block = message.message.content[blockIdx]!;
+        const block = message.message.content[blockIdx];
+        if (!block) continue;
         // Skip text/thinking blocks already streamed via `stream_event`
         // deltas — re-emitting would duplicate every chunk in the
         // assistant bubble. Tool blocks always go through (we only

--- a/apps/server/src/ai/agent-stream/fluid-chunker.ts
+++ b/apps/server/src/ai/agent-stream/fluid-chunker.ts
@@ -78,9 +78,8 @@ export function splitForFluidStream(text: string, targetLen: number): string[] {
     const stop = Math.min(i + targetLen * 2, text.length);
     let foundBoundary = false;
     for (let j = end; j < stop; j += 1) {
-      if (boundary.test(text[j]!)) {
-        // Include the boundary char so the next chunk starts on a
-        // fresh word — `"hello, "` then `"world"` reads cleanly.
+      const ch = text[j];
+      if (ch !== undefined && boundary.test(ch)) {
         end = j + 1;
         foundBoundary = true;
         break;

--- a/apps/server/src/ai/agent-stream/opencode-sse.ts
+++ b/apps/server/src/ai/agent-stream/opencode-sse.ts
@@ -63,7 +63,8 @@ function handleQuestionReplied(
   const answers: Record<string, ReadonlyArray<string>> = {};
   if (original) {
     for (let i = 0; i < original.length; i += 1) {
-      const q = original[i]!;
+      const q = original[i];
+      if (!q) continue;
       answers[q.question] = r.answers[i] ?? [];
     }
     lastQuestionsByRequestId.delete(r.requestID);

--- a/apps/server/src/ai/providers/chat-edit-tools/index.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/index.ts
@@ -51,7 +51,7 @@ export type { ChatEditToolResult, ChatWalkthroughEditContext } from "./spec";
 
 // ── Canonical spec list ─────────────────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: heterogenous tool spec array
 export const EDIT_TOOL_SPECS: Array<ChatEditToolSpec<any>> = [
   {
     name: "get_walkthrough_for_edit",

--- a/apps/server/src/ai/providers/chat-edit-tools/index.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/index.ts
@@ -25,7 +25,7 @@ import {
   updateIssueHandler,
   updateRatingHandler,
 } from "./review-handlers";
-import type { ChatEditToolSpec } from "./spec";
+import type { ChatEditToolSpecRecord } from "./spec";
 import {
   addBlockSchema,
   addIssueCommentEditSchema,
@@ -51,8 +51,7 @@ export type { ChatEditToolResult, ChatWalkthroughEditContext } from "./spec";
 
 // ── Canonical spec list ─────────────────────────────────────────────────────
 
-// biome-ignore lint/suspicious/noExplicitAny: heterogenous tool spec array
-export const EDIT_TOOL_SPECS: Array<ChatEditToolSpec<any>> = [
+export const EDIT_TOOL_SPECS: ChatEditToolSpecRecord[] = [
   {
     name: "get_walkthrough_for_edit",
     description:

--- a/apps/server/src/ai/providers/chat-edit-tools/spec.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/spec.ts
@@ -73,7 +73,7 @@ export interface ChatEditToolSpec<TShape extends z.ZodRawShape> {
   readonly name: string;
   readonly description: string;
   readonly inputSchema: z.ZodObject<TShape>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint/suspicious/noExplicitAny: handler input varies per tool in heterogenous array
   readonly handler: ChatEditToolHandler<any>;
 }
 

--- a/apps/server/src/ai/providers/chat-edit-tools/spec.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/spec.ts
@@ -73,8 +73,22 @@ export interface ChatEditToolSpec<TShape extends z.ZodRawShape> {
   readonly name: string;
   readonly description: string;
   readonly inputSchema: z.ZodObject<TShape>;
-  // biome-ignore lint/suspicious/noExplicitAny: handler input varies per tool in heterogenous array
-  readonly handler: ChatEditToolHandler<any>;
+  readonly handler: ChatEditToolHandler<z.input<z.ZodObject<TShape>>>;
+}
+
+/**
+ * Non-generic storage type for a heterogenous array of chat-edit tool specs.
+ * Uses method declaration (bivariant checking) so handlers with narrower
+ * input types are assignable to the wider Record<string, unknown> slot.
+ */
+export interface ChatEditToolSpecRecord {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: z.ZodObject<z.ZodRawShape>;
+  handler(
+    ctx: ChatWalkthroughEditContext,
+    input: Record<string, unknown>,
+  ): Promise<ChatEditToolResult>;
 }
 
 // ── Shared content sub-schemas (mirror walkthrough-tool-spec.ts shapes) ─────

--- a/apps/server/src/ai/providers/chat-mcp-tools.ts
+++ b/apps/server/src/ai/providers/chat-mcp-tools.ts
@@ -14,7 +14,7 @@
 
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { and, desc, eq, inArray } from "drizzle-orm";
-import { type ZodObject, z } from "zod";
+import { z } from "zod";
 import { commentThreads } from "../../db/schema/comment-threads";
 import { pullRequests } from "../../db/schema/pull-requests";
 import { reviewSessions } from "../../db/schema/review-sessions";
@@ -49,7 +49,7 @@ export type ChatToolHandler<TInput> = (
 export interface ChatToolSpec<TInput> {
   readonly name: string;
   readonly description: string;
-  readonly inputSchema: z.ZodType<TInput>;
+  readonly inputSchema: z.ZodObject<z.ZodRawShape>;
   readonly handler: ChatToolHandler<TInput>;
 }
 
@@ -335,7 +335,7 @@ export function createChatMcpServer(ctx: ChatToolContext): ReturnType<typeof cre
       tool(
         spec.name,
         spec.description,
-        (spec.inputSchema as ZodObject<z.ZodRawShape>).shape ?? {},
+        spec.inputSchema.shape,
         async (args: Record<string, unknown>) => spec.handler(ctx, args),
       ),
     ),

--- a/apps/server/src/ai/providers/chat-mcp-tools.ts
+++ b/apps/server/src/ai/providers/chat-mcp-tools.ts
@@ -14,7 +14,7 @@
 
 import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
 import { and, desc, eq, inArray } from "drizzle-orm";
-import { z } from "zod";
+import { type ZodObject, z } from "zod";
 import { commentThreads } from "../../db/schema/comment-threads";
 import { pullRequests } from "../../db/schema/pull-requests";
 import { reviewSessions } from "../../db/schema/review-sessions";
@@ -335,10 +335,8 @@ export function createChatMcpServer(ctx: ChatToolContext): ReturnType<typeof cre
       tool(
         spec.name,
         spec.description,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (spec.inputSchema as any).shape ?? {},
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async (args: any) => spec.handler(ctx, args),
+        (spec.inputSchema as ZodObject<z.ZodRawShape>).shape ?? {},
+        async (args: Record<string, unknown>) => spec.handler(ctx, args),
       ),
     ),
   });

--- a/apps/server/src/ai/providers/recap-tools/handlers.ts
+++ b/apps/server/src/ai/providers/recap-tools/handlers.ts
@@ -465,8 +465,11 @@ export const completeRecapHandler: RecapToolHandler<CompleteRecapInput> = async 
   // not used for correctness.
   const allBundlePrs = [...ctx.sourceBundle.prs, ...ctx.sourceBundle.openPrs];
   const sourceWalkthroughIds = allBundlePrs
-    .filter((p) => sourcePrIds.includes(p.id) && p.walkthrough)
-    .map((p) => p.walkthrough!.id);
+    .filter(
+      (p): p is typeof p & Record<"walkthrough", NonNullable<typeof p.walkthrough>> =>
+        sourcePrIds.includes(p.id) && !!p.walkthrough,
+    )
+    .map((p) => p.walkthrough.id);
 
   ctx.db
     .update(projectRecaps)

--- a/apps/server/src/ai/providers/recap-tools/index.ts
+++ b/apps/server/src/ai/providers/recap-tools/index.ts
@@ -28,6 +28,7 @@ import {
   listOpenPrsSchema,
   type RecapToolContext,
   type RecapToolSpec,
+  type RecapToolSpecRecord,
   setLedeSchema,
   setThemeSummarySchema,
 } from "./spec";
@@ -62,8 +63,7 @@ export {
   setThemeSummaryHandler,
 };
 
-// biome-ignore lint/suspicious/noExplicitAny: heterogenous tool spec array
-export const RECAP_TOOL_SPECS: Array<RecapToolSpec<any>> = [
+export const RECAP_TOOL_SPECS: RecapToolSpecRecord[] = [
   {
     name: "get_recap_state",
     description:

--- a/apps/server/src/ai/providers/recap-tools/index.ts
+++ b/apps/server/src/ai/providers/recap-tools/index.ts
@@ -62,7 +62,7 @@ export {
   setThemeSummaryHandler,
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// biome-ignore lint/suspicious/noExplicitAny: heterogenous tool spec array
 export const RECAP_TOOL_SPECS: Array<RecapToolSpec<any>> = [
   {
     name: "get_recap_state",
@@ -136,8 +136,7 @@ export function createRecapMcpServer(ctx: RecapToolContext): ReturnType<typeof c
         spec.name,
         spec.description,
         spec.inputSchema.shape,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async (args: any) => {
+        async (args: Record<string, unknown>) => {
           ctx.toolCalls?.add(spec.name);
           return spec.handler(ctx, args);
         },

--- a/apps/server/src/ai/providers/recap-tools/spec.ts
+++ b/apps/server/src/ai/providers/recap-tools/spec.ts
@@ -95,8 +95,19 @@ export interface RecapToolSpec<TShape extends z.ZodRawShape> {
   readonly name: string;
   readonly description: string;
   readonly inputSchema: z.ZodObject<TShape>;
-  // biome-ignore lint/suspicious/noExplicitAny: handler input varies per tool in heterogenous array
-  readonly handler: RecapToolHandler<any>;
+  readonly handler: RecapToolHandler<z.input<z.ZodObject<TShape>>>;
+}
+
+/**
+ * Non-generic storage type for a heterogenous array of tool specs.
+ * Uses method declaration (bivariant checking) so handlers with narrower
+ * input types are assignable to the wider Record<string, unknown> slot.
+ */
+export interface RecapToolSpecRecord {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema: z.ZodObject<z.ZodRawShape>;
+  handler(ctx: RecapToolContext, input: Record<string, unknown>): Promise<RecapToolResult>;
 }
 
 // ── Source bundle: the structured input the agent sees ───────────────────────

--- a/apps/server/src/ai/providers/recap-tools/spec.ts
+++ b/apps/server/src/ai/providers/recap-tools/spec.ts
@@ -95,7 +95,7 @@ export interface RecapToolSpec<TShape extends z.ZodRawShape> {
   readonly name: string;
   readonly description: string;
   readonly inputSchema: z.ZodObject<TShape>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint/suspicious/noExplicitAny: handler input varies per tool in heterogenous array
   readonly handler: RecapToolHandler<any>;
 }
 


### PR DESCRIPTION
Fixes all 11 warnings/annotations from the last CI release run:

**Workflow updates:**
- Updated `actions/checkout@v4` → `actions/checkout@v6` across all 5 workflow files (uses Node 24 runtime, resolves deprecation warning)

**TypeScript lint fixes:**
- `recap-tools/spec.ts`: Replaced ineffective eslint-disable with `biome-ignore` for heterogenous tool handler type
- `recap-tools/index.ts`: Replaced eslint-disable with `biome-ignore` for heterogenous array; changed `args: any` → `args: Record<string, unknown>`
- `recap-tools/handlers.ts": Replaced non-null assertion (`!`) with type-narrowing filter predicate
- `chat-mcp-tools.ts`: Cast `as any` → `as ZodObject<z.ZodRawShape>`; changed `args: any` → `args: Record<string, unknown>`
- `chat-edit-tools/spec.ts` + `index.ts`: Replaced eslint-disable with `biome-ignore`
- `opencode-sse.ts`: Replaced non-null assertion (`!`) with guard clause
- `fluid-chunker.ts`: Replaced non-null assertion (`!`) with undefined check
- `claude-walker.ts`: Replaced non-null assertion (`!`) with guard clause