### PR TITLE
fix: remove unused ChatEditToolSpec export (knip)

### DIFF
--- a/apps/server/src/ai/providers/chat-edit-tools/spec.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/spec.ts
@@ -69,7 +69,7 @@ export type ChatEditToolHandler<TInput> = (
   input: TInput,
 ) => Promise<ChatEditToolResult>;
 
-export interface ChatEditToolSpec<TShape extends z.ZodRawShape> {
+interface ChatEditToolSpec<TShape extends z.ZodRawShape> {
   readonly name: string;
   readonly description: string;
   readonly inputSchema: z.ZodObject<TShape>;


### PR DESCRIPTION
Follow-up to #85 — removes the now-unused export of `ChatEditToolSpec` that knip flagged after the biome-ignore cleanup.