### PR TITLE
feat(install): quiet installer output with spinner and verbose mode

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde_json",
  "tauri",

--- a/install.sh
+++ b/install.sh
@@ -98,23 +98,25 @@ _latest_nightly_tag() {
 }
 
 # ── Banner ────────────────────────────────────────────────────
-printf "\n"
-printf "  ${_CYAN}${_B}██████╗ ███████╗██╗   ██╗██╗   ██╗${_R}\n"
-printf "  ${_CYAN}${_B}██╔══██╗██╔════╝██║   ██║██║   ██║${_R}\n"
-printf "  ${_CYAN}${_B}██████╔╝█████╗  ██║   ██║██║   ██║${_R}\n"
-printf "  ${_CYAN}${_B}██╔══██╗██╔══╝  ╚██╗ ██╔╝╚██╗ ██╔╝${_R}\n"
-printf "  ${_CYAN}${_B}██║  ██║███████╗ ╚████╔╝  ╚████╔╝ ${_R}\n"
-printf "  ${_CYAN}${_B}╚═╝  ╚═╝╚══════╝  ╚═══╝    ╚═══╝  ${_R}\n"
-printf "\n"
-if [[ "$MODE" == "dev" ]]; then
-  printf "  ${_D}AI-powered code review${_R}  ${_B}dev setup${_R}\n"
-else
-  printf "  ${_D}AI-powered code review${_R}  ${_B}installer${_R}\n"
+if [[ -z "${REVV_SKIP_BANNER:-}" ]]; then
+  printf "\n"
+  printf "  ${_CYAN}${_B}██████╗ ███████╗██╗   ██╗██╗   ██╗${_R}\n"
+  printf "  ${_CYAN}${_B}██╔══██╗██╔════╝██║   ██║██║   ██║${_R}\n"
+  printf "  ${_CYAN}${_B}██████╔╝█████╗  ██║   ██║██║   ██║${_R}\n"
+  printf "  ${_CYAN}${_B}██╔══██╗██╔══╝  ╚██╗ ██╔╝╚██╗ ██╔╝${_R}\n"
+  printf "  ${_CYAN}${_B}██║  ██║███████╗ ╚████╔╝  ╚████╔╝ ${_R}\n"
+  printf "  ${_CYAN}${_B}╚═╝  ╚═╝╚══════╝  ╚═══╝    ╚═══╝  ${_R}\n"
+  printf "\n"
+  if [[ "$MODE" == "dev" ]]; then
+    printf "  ${_D}AI-powered code review${_R}  ${_B}dev setup${_R}\n"
+  else
+    printf "  ${_D}AI-powered code review${_R}  ${_B}installer${_R}\n"
+  fi
+  printf "\n"
+  printf "  ${_D}"
+  printf '─%.0s' {1..54}
+  printf "${_R}\n\n"
 fi
-printf "\n"
-printf "  ${_D}"
-printf '─%.0s' {1..54}
-printf "${_R}\n\n"
 
 # ── Locate the checkout, cloning if necessary ─────────────────
 #
@@ -200,6 +202,7 @@ On $os, clone the repo and run ./install.sh --dev manually:
 
   _info "Re-executing installer from the cloned checkout"
   # Preserve flags for the re-exec — quote heavily, path may contain spaces.
+  unset REVV_SKIP_BANNER
   exec bash "$dest/install.sh" "$@"
 fi
 
@@ -264,9 +267,7 @@ fi
 # ── 4. Install project deps ───────────────────────────────────
 step "Installing project dependencies"
 cd "$PROJECT_ROOT"
-info "Running bun install…"
-bun install
-success "Workspace dependencies installed"
+run_quiet "Installing workspace dependencies" bun install
 
 # Verify workspace deps actually landed in node_modules (Bun's workspace
 # hoisting can leave stale trees when the lockfile changes under a warm cache).
@@ -278,10 +279,9 @@ _verify_workspace_deps() {
   if [[ ${#missing[@]} -gt 0 ]]; then
     warn "Some workspace dependencies are missing from node_modules: ${missing[*]}"
     if confirm "Force a clean reinstall (rm -rf node_modules && bun install)?"; then
-      info "Clearing node_modules and reinstalling…"
+      info "Clearing node_modules…"
       rm -rf node_modules apps/web/node_modules apps/server/node_modules packages/shared/node_modules
-      bun install
-      success "Clean reinstall complete"
+      run_quiet "Reinstalling workspace dependencies" bun install
     else
       warn "Continuing with incomplete node_modules — builds may fail"
     fi

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dist:debug": "cd apps/desktop && bunx tauri build --debug",
     "dev:app": "cd packages/app && bun run dev",
     "clean": "rm -rf apps/web/build apps/web/.svelte-kit apps/server/dist apps/desktop/target .turbo",
-    "postinstall": "echo '\\n  Run `bun run dev` to start developing, or `bun run dist` to build an installer.\\n'"
+    "postinstall": "echo $'\\n  Run `bun run dev` to start developing, or `bun run dist` to build an installer.\\n'"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -95,6 +95,45 @@ spin_stop() {
   fi
 }
 
+# ── Quiet command runner ──────────────────────────────────────
+# Usage: run_quiet "Label" command [args...]
+#   Default: spinner while running; stdout+stderr captured to a temp log.
+#   REVV_VERBOSE=1: streams output inline with an indented label header.
+# On failure: prints exit code, log path, and last 15 log lines.
+run_quiet() {
+  local label="$1"; shift
+  local _log _rc
+
+  if [[ "${REVV_VERBOSE:-0}" == "1" ]]; then
+    printf "\n  %s%s▸%s  %s\n\n" "$REVV_BOLD" "$REVV_CYAN" "$REVV_RESET" "$label"
+    "$@" 2>&1 | sed 's/^/    /'
+    _rc="${PIPESTATUS[0]}"
+    if [[ "$_rc" -eq 0 ]]; then
+      success "$label"
+      return 0
+    else
+      fail "Command failed (exit $_rc): $*"
+    fi
+  fi
+
+  _log="$(mktemp)"
+  spin_start "$label"
+  if "$@" >"$_log" 2>&1; then
+    spin_stop 1
+    rm -f "$_log"
+    return 0
+  fi
+  _rc=$?
+  spin_stop 0
+  printf "\n  %s✗%s  Command failed (exit %d): %s\n" \
+    "$REVV_RED" "$REVV_RESET" "$_rc" "$*" >&2
+  printf "  %s→%s  Log: %s\n" "$REVV_DIM" "$REVV_RESET" "$_log" >&2
+  printf "  %sLast output:%s\n" "$REVV_DIM" "$REVV_RESET" >&2
+  tail -n 15 "$_log" | sed 's/^/    /' >&2
+  printf "\n" >&2
+  exit 1
+}
+
 # ── TTY-safe input (works under `curl … | bash`) ──────────────
 #
 # Reads from /dev/tty so prompts work even when stdin is the pipe carrying
@@ -364,8 +403,13 @@ install_release_app() {
   fi
 
   bundle_file="$(mktemp).dmg"
-  info "Downloading pre-built Revv.app from ${release_tag} (${asset_arch})"
-  curl -fL "$bundle_url" -o "$bundle_file" || { rm -f "$bundle_file"; return 1; }
+  spin_start "Downloading Revv.app from ${release_tag} (${asset_arch})"
+  if ! curl -fsSL "$bundle_url" -o "$bundle_file"; then
+    spin_stop 0
+    rm -f "$bundle_file"
+    return 1
+  fi
+  spin_stop 1
 
   if [[ -n "$bundle_sha" ]]; then
     actual_sha="$(revv_sha256_of "$bundle_file")"

--- a/scripts/release/install.sh.tmpl
+++ b/scripts/release/install.sh.tmpl
@@ -95,9 +95,11 @@ verify_attestation() {
   rm -f "$bundle"
 }
 
-printf '\n'
-printf '  %s%sRevv%s  %srelease installer%s  %sv%s%s\n' "$C" "$B" "$R" "$D" "$R" "$B" "$REVV_VERSION" "$R"
-printf '  %sRelease:%s %s%s%s\n\n' "$D" "$R" "$B" "$RELEASE_TAG" "$R"
+if [[ -z "${REVV_PREFLIGHT_DONE:-}" ]]; then
+  printf '\n'
+  printf '  %s%sRevv%s  %srelease installer%s  %sv%s%s\n' "$C" "$B" "$R" "$D" "$R" "$B" "$REVV_VERSION" "$R"
+  printf '  %sRelease:%s %s%s%s\n\n' "$D" "$R" "$B" "$RELEASE_TAG" "$R"
+fi
 
 SKIP_VERIFY_FLAG=0
 INSTALLER_ARGS=()
@@ -126,9 +128,9 @@ if [[ $# -eq 0 || ( " $* " != *" --help "* && " $* " != *" -h "* ) ]]; then
 
     rc=0
     if [[ "$SKIP_VERIFY_FLAG" == "1" ]]; then
-      bash "$SELF_PATH" --skip-verify "${INSTALLER_ARGS[@]+"${INSTALLER_ARGS[@]}"}" || rc=$?
+      REVV_PREFLIGHT_DONE=1 REVV_SKIP_BANNER=1 bash "$SELF_PATH" --skip-verify "${INSTALLER_ARGS[@]+"${INSTALLER_ARGS[@]}"}" || rc=$?
     else
-      bash "$SELF_PATH" "${INSTALLER_ARGS[@]+"${INSTALLER_ARGS[@]}"}" || rc=$?
+      REVV_PREFLIGHT_DONE=1 REVV_SKIP_BANNER=1 bash "$SELF_PATH" "${INSTALLER_ARGS[@]+"${INSTALLER_ARGS[@]}"}" || rc=$?
     fi
     rm -f "$SELF_PATH"
     exit "$rc"


### PR DESCRIPTION
- Add `run_quiet` to scripts/lib/common.sh: wraps any command with a spinner by default; captures stdout/stderr to a temp log; on failure prints exit code, log path, and last 15 lines. REVV_VERBOSE=1 streams inline instead.
- Fix `install_release_app` curl download to use a spinner (was leaking raw curl progress meter to stdout).
- Wrap `bun install` calls in install.sh with run_quiet for clean step-level reporting.
- Guard the ASCII art banner in install.sh with REVV_SKIP_BANNER so the release-installer self-copy bootstrap path doesn't print it twice.
- Guard the release preflight header in install.sh.tmpl with REVV_PREFLIGHT_DONE and pass both env vars when re-running the self- copy, eliminating the duplicate header on curl-pipe installs.
- Fix package.json postinstall: echo $'...' so \n renders as a real newline instead of literal backslash-n.