### PR TITLE
fix: stop diff-tab comments from duplicating on re-render

### DIFF
--- a/apps/web/src/lib/components/review/DiffViewerInner.svelte
+++ b/apps/web/src/lib/components/review/DiffViewerInner.svelte
@@ -27,7 +27,7 @@ export interface ThreadMeta {
 	import type { ReviewFile, CommentThread, ThreadMessage } from '$lib/types/review';
 	import { workerManager } from '$lib/utils/worker-pool';
 	import { onMount, onDestroy } from 'svelte';
-	import { mountInto, cleanupAllMounted } from '$lib/utils/annotation-mount';
+	import { mountInto, cleanupAllMounted, pruneDetachedMounts } from '$lib/utils/annotation-mount';
 	import {
 		ANNOTATION_HOST_STYLE,
 		createMarkerDot,
@@ -297,11 +297,15 @@ export interface ThreadMeta {
 		threadDataRef.threadById = currentThreadById;
 		threadDataRef.threadMessages = currentThreadMessages;
 
-		// Clear annotation cache — the library caches DOM elements by annotation
-		// object reference. Without clearing, stale elements with empty thread
-		// data persist even after threadDataRef is updated.
-		// @ts-expect-error annotationCache is protected
-		instance.annotationCache?.clear();
+		// NOTE: do NOT clear `annotationCache` here. The library's
+		// renderAnnotations() is self-cleaning — it removes the previous wrapper
+		// before appending a new one whenever an annotation changed. Our store
+		// hands it a fresh `metadata` object every render and the library compares
+		// metadata by reference, so renderAnnotation always re-runs (picking up
+		// fresh thread data) AND the old row is removed. Calling `.clear()` empties
+		// the cache Map without removing the wrapper <div>s from the shadow DOM, so
+		// the next render appends fresh rows alongside the orphans → duplicate
+		// comments. That was the diff-tab comment-duplication bug.
 
 		// Clear header slots before re-render to prevent badge duplication.
 		// The library's applyHeaderToDOM reuses slot elements by reference; if
@@ -313,6 +317,11 @@ export interface ThreadMeta {
 		// Re-render with new annotations. Must pass lineAnnotations so the
 		// library updates its internal state and creates annotation rows.
 		instance.render({ lineAnnotations: currentAnnotations, forceRender: true });
+
+		// The library removes the previous annotation wrappers via element.remove(),
+		// but the Svelte components we mounted inside them stay registered and live.
+		// Unmount the now-detached ones so their effects/listeners don't leak.
+		pruneDetachedMounts();
 	});
 
 	// ── Line cursor highlight (diff-line mode) ────────────────────────────────

--- a/apps/web/src/lib/utils/annotation-mount.ts
+++ b/apps/web/src/lib/utils/annotation-mount.ts
@@ -35,6 +35,27 @@ export function mountInto<Props extends Record<string, unknown>>(
 }
 
 /**
+ * Unmount any registered components whose target has been detached from the DOM.
+ *
+ * @pierre/diffs removes the previous annotation wrapper (via `element.remove()`)
+ * on every re-render, but it has no knowledge of the Svelte components we mounted
+ * inside those wrappers — so they stay registered here with their effects and
+ * listeners still live. Call this after a re-render to unmount the orphans;
+ * freshly-mounted hosts are still connected and are left untouched.
+ */
+export function pruneDetachedMounts(): void {
+  for (const [target, instance] of registry) {
+    if (target.isConnected) continue;
+    try {
+      unmount(instance);
+    } catch {
+      // ignore unmount errors
+    }
+    registry.delete(target);
+  }
+}
+
+/**
  * Unmount ALL mounted Svelte components. Call this before instance.cleanUp()
  * to prevent orphaned Svelte state when the diff container is destroyed.
  */


### PR DESCRIPTION
Comment threads in the Diff tab duplicated, with extra copies accumulating on every thread mutation (add, resolve, reopen, reply, edit). The cause: `DiffViewerInner` called `@pierre/diffs`' `annotationCache.clear()` before each re-render, which empties the cache `Map` but leaves the wrapper `<div>`s in the shadow DOM — so the library's self-cleaning `renderAnnotations()` saw an empty cache, appended fresh rows, and orphaned the old ones. This drops the redundant `.clear()` call (the store already hands the library a fresh `metadata` reference each render, so it re-renders and removes the prior row on its own) and adds `pruneDetachedMounts()` to unmount the `AnnotationThread` Svelte components the library detaches on re-render, fixing a pre-existing leak on the same path. Verified locally with `bun run typecheck && bun run lint && bun run knip && bun run build` (all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)