### PR TITLE
feat: move GitHub tokens to OS secure store with transparent refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ packages/app/dist/
 *.db-wal
 *.db-shm
 *.db.pid
+*.db.*.pid
 
 # Turbo
 .turbo/

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,6 +16,7 @@
     "@effect/platform": "^0.96.0",
     "@elysiajs/cors": "^1",
     "@google-cloud/storage": "^7.13.0",
+    "@napi-rs/keyring": "^1.3.0",
     "@opencode-ai/sdk": "1.15.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.7.1",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "build": "bun build src/index.ts --outdir dist --target bun --external @effect/opentelemetry",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.142",

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -17,7 +17,6 @@ import { appDataDir } from "./paths";
 // longer revokes on GitHub's side. Users can revoke from the GitHub app
 // connections page if they want (linked from the settings UI).
 export const GITHUB_CLIENT_ID = serverEnv.githubClientId;
-export const GITHUB_CLIENT_ID_PUBLIC = serverEnv.githubClientIdPublic;
 
 /**
  * Locate (or create) the better-auth signing secret.

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,12 +1,12 @@
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir, platform } from "node:os";
 import { dirname, join } from "node:path";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { bearer } from "better-auth/plugins";
 import { serverEnv } from "./config";
 import { createDb } from "./db/index";
+import { appDataDir } from "./paths";
 
 // Re-exported for the handful of routes that still reach in directly.
 // All values are sourced from the centralized `serverEnv` snapshot in
@@ -51,20 +51,7 @@ function loadOrCreateAuthSecret(): string {
 
 /** OS-appropriate path for the persisted better-auth key. */
 function authKeyPath(): string {
-  const home = homedir();
-  const plat = platform();
-  const appDir = serverEnv.channel === "dev" ? "Revv Dev" : "Revv";
-  const xdgDir = serverEnv.channel === "dev" ? "revv-dev" : "revv";
-  if (plat === "darwin") {
-    return join(home, "Library", "Application Support", appDir, "auth.key");
-  }
-  if (plat === "win32") {
-    const appData = process.env.APPDATA ?? join(home, "AppData", "Roaming");
-    return join(appData, appDir, "auth.key");
-  }
-  // XDG on Linux / other POSIX.
-  const xdg = process.env.XDG_DATA_HOME ?? join(home, ".local", "share");
-  return join(xdg, xdgDir, "auth.key");
+  return join(appDataDir(), "auth.key");
 }
 
 const db = createDb();

--- a/apps/server/src/db/migrations/0190_account_reauth_required.sql
+++ b/apps/server/src/db/migrations/0190_account_reauth_required.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `account` ADD `reauth_required_at` integer;

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1779560000000,
       "tag": "0140_cache_signing",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1779580000000,
+      "tag": "0190_account_reauth_required",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/auth.ts
+++ b/apps/server/src/db/schema/auth.ts
@@ -50,6 +50,13 @@ export const account = sqliteTable("account", {
   password: text("password"),
   githubLogin: text("github_login"),
   avatarUrl: text("avatar_url"),
+  // Set when a GitHub call returns 401 and the token could not be silently
+  // refreshed (revoked, or no/expired refresh token). The orchestrator
+  // broadcasts `auth:reauth-required` and the client gates the app behind a
+  // re-sign-in modal. Cleared on any successful token write (device-flow
+  // re-auth or a successful refresh). Durable so the state survives restart
+  // and is reconcilable on WS reconnect.
+  reauthRequiredAt: integer("reauth_required_at", { mode: "timestamp" }),
   createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });

--- a/apps/server/src/github-oauth.ts
+++ b/apps/server/src/github-oauth.ts
@@ -1,0 +1,38 @@
+import { serverEnv } from "./config";
+
+/**
+ * Per-host GitHub OAuth wiring shared by the device-code sign-in flow
+ * (`routes/device-auth.ts`) and the token-refresh path (`TokenProvider`).
+ *
+ * Revv targets github.com with a public OAuth App and any GitHub Enterprise
+ * host with the bundled GHE OAuth App. The device-code flow — including its
+ * `refresh_token` grant — never needs a `client_secret`.
+ */
+
+/** `true` for public github.com, `false` for any GitHub Enterprise host. */
+export function isPublicGitHub(host: string): boolean {
+  return host === "github.com";
+}
+
+/**
+ * OAuth App client_id for a host. Throws a clear error when targeting
+ * github.com without `GITHUB_CLIENT_ID_PUBLIC` configured, so the user gets a
+ * diagnosable message instead of GitHub's opaque "invalid client".
+ */
+export function clientIdForHost(host: string): string {
+  if (isPublicGitHub(host)) {
+    if (!serverEnv.githubClientIdPublic) {
+      throw new Error(
+        "Public GitHub sign-in requires GITHUB_CLIENT_ID_PUBLIC to be set. " +
+          "Register an OAuth App on github.com and add GITHUB_CLIENT_ID_PUBLIC=<id> to your .env file.",
+      );
+    }
+    return serverEnv.githubClientIdPublic;
+  }
+  return serverEnv.githubClientId;
+}
+
+/** OAuth token endpoint (used for both device-code exchange and refresh). */
+export function tokenUrlForHost(host: string): string {
+  return `https://${host}/login/oauth/access_token`;
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -33,6 +33,7 @@ import { ensureHighlighter } from "./services/PrerenderCache";
 import { ProjectRecapJobs } from "./services/ProjectRecapJobs";
 import { RecapScheduler } from "./services/RecapScheduler";
 import { RepoCloneService } from "./services/RepoClone";
+import { migrateLegacyTokens } from "./services/SecretStore";
 import { WalkthroughJobs } from "./services/WalkthroughJobs";
 import { acquireSingleInstance } from "./singleInstance";
 
@@ -131,6 +132,18 @@ const app = new Elysia()
   });
 
 logError("server", `listening on http://localhost:${port}`);
+
+// Migrate any plaintext GitHub tokens left in the `account` table into the OS
+// secure store, then null the columns. Awaited before the sync scheduler boots
+// so the first poll cycle reads tokens from their new home. One-time and
+// idempotent — a no-op once every row has been migrated.
+await AppRuntime.runPromise(migrateLegacyTokens)
+  .then((n) => {
+    if (n > 0) logError("secret-store", `migrated ${n} GitHub token(s) into secure storage`);
+  })
+  .catch((err) => {
+    logError("secret-store", "legacy token migration failed:", err);
+  });
 
 // ── Graceful shutdown ────────────────────────────────────────────────────────
 // SIGTERM arrives on bun --watch restarts and launchd stops.

--- a/apps/server/src/paths.ts
+++ b/apps/server/src/paths.ts
@@ -1,0 +1,40 @@
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { serverEnv } from "./config";
+
+/**
+ * OS-appropriate per-user application data directory for Revv.
+ *
+ *   macOS:   ~/Library/Application Support/Revv
+ *   Windows: %APPDATA%/Revv
+ *   Linux:   $XDG_DATA_HOME/revv  (or ~/.local/share/revv)
+ *
+ * Dev builds use a distinct directory (`Revv Dev` / `revv-dev`) so a developer
+ * machine running both channels keeps secrets and keys separate. This is the
+ * shared resolution used by `auth.ts` (signing key) and `SecretStore`
+ * (encrypted-file fallback).
+ */
+export function appDataDir(): string {
+  const home = homedir();
+  const plat = platform();
+  const appDir = serverEnv.channel === "dev" ? "Revv Dev" : "Revv";
+  const xdgDir = serverEnv.channel === "dev" ? "revv-dev" : "revv";
+  if (plat === "darwin") {
+    return join(home, "Library", "Application Support", appDir);
+  }
+  if (plat === "win32") {
+    const appData = process.env.APPDATA ?? join(home, "AppData", "Roaming");
+    return join(appData, appDir);
+  }
+  const xdg = process.env.XDG_DATA_HOME ?? join(home, ".local", "share");
+  return join(xdg, xdgDir);
+}
+
+/**
+ * OS keyring service name under which GitHub tokens are stored. Channel-keyed
+ * so dev and prod installs on the same machine don't collide on keychain
+ * entries.
+ */
+export function keyringServiceName(): string {
+  return serverEnv.channel === "dev" ? "Revv Dev" : "Revv";
+}

--- a/apps/server/src/routes/device-auth.ts
+++ b/apps/server/src/routes/device-auth.ts
@@ -1,7 +1,7 @@
 import { and, eq, gt, inArray } from "drizzle-orm";
 import { Effect } from "effect";
 import { Elysia, t } from "elysia";
-import { db, GITHUB_CLIENT_ID, GITHUB_CLIENT_ID_PUBLIC } from "../auth";
+import { db, GITHUB_CLIENT_ID } from "../auth";
 import { serverEnv } from "../config";
 import { account, session, user } from "../db/schema";
 import { remoteUsers } from "../db/schema/remote-users";
@@ -614,40 +614,19 @@ const protectedAuthRoutes = new Elysia()
       const providerId = `github:${host}`;
       const userId = ctx.session.user.id;
 
-      // Fetch the account row id, then read its token from the secure store to
-      // attempt revocation on GitHub before deletion.
+      // We cannot revoke the grant on GitHub's side: the only OAuth flow Revv
+      // uses is the device-code flow, which never collects a client secret
+      // (see auth.ts), and GitHub's `DELETE /applications/{id}/token`
+      // endpoint requires HTTP Basic auth with that secret. Attempting it would
+      // just send an empty secret and silently 401. So disconnect is a local
+      // operation: delete the account row and wipe its stored tokens. Users who
+      // want to revoke the grant upstream do so from their GitHub app
+      // connections page (linked from the settings UI).
       const accountRow = await db
         .select({ id: account.id })
         .from(account)
         .where(and(eq(account.providerId, providerId), eq(account.userId, userId)))
         .then((r) => r[0] ?? null);
-
-      const accessToken = accountRow
-        ? await AppRuntime.runPromise(
-            Effect.flatMap(TokenProvider, (provider) =>
-              provider.getTokenByAccountId(accountRow.id),
-            ).pipe(Effect.orElseSucceed(() => null)),
-          )
-        : null;
-
-      if (accessToken) {
-        const isPublic = host === "github.com";
-        const clientId = isPublic ? (GITHUB_CLIENT_ID_PUBLIC ?? "") : GITHUB_CLIENT_ID;
-        const apiBase = isPublic ? "https://api.github.com" : `https://api.${host}`;
-        const clientSecret = process.env.GITHUB_CLIENT_SECRET ?? "";
-        try {
-          await fetch(`${apiBase}/applications/${clientId}/token`, {
-            method: "DELETE",
-            headers: {
-              Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
-              Accept: "application/vnd.github+json",
-            },
-            body: JSON.stringify({ access_token: accessToken }),
-          });
-        } catch {
-          // Best-effort — proceed with local deletion regardless
-        }
-      }
 
       await db
         .delete(account)

--- a/apps/server/src/routes/device-auth.ts
+++ b/apps/server/src/routes/device-auth.ts
@@ -5,10 +5,12 @@ import { db, GITHUB_CLIENT_ID, GITHUB_CLIENT_ID_PUBLIC } from "../auth";
 import { serverEnv } from "../config";
 import { account, session, user } from "../db/schema";
 import { remoteUsers } from "../db/schema/remote-users";
+import { clientIdForHost, isPublicGitHub, tokenUrlForHost } from "../github-oauth";
 import { logError } from "../logger";
 import { AppRuntime } from "../runtime";
 import { RemoteUserService } from "../services/RemoteUser";
 import { SettingsService } from "../services/Settings";
+import { TokenProvider } from "../services/TokenProvider";
 import { withAuth } from "./middleware";
 
 // The device-code flow needs `client_id` only — no client_secret. If the
@@ -50,29 +52,13 @@ async function resolveGithubUrls(hostOverride?: string): Promise<{
     Effect.flatMap(SettingsService, (s) => s.getSettings()).pipe(Effect.orElseSucceed(() => null)),
   );
   const host = hostOverride?.trim() || settings?.githubHost?.trim() || serverEnv.githubHost;
-  const isPublicGitHub = host === "github.com";
-  // Use the public client_id when targeting github.com; fail fast if it is
-  // not configured so the user gets a clear error instead of a confusing
-  // "invalid client" response from GitHub.
-  let clientId: string;
-  if (isPublicGitHub) {
-    if (!GITHUB_CLIENT_ID_PUBLIC) {
-      throw new Error(
-        "Public GitHub sign-in requires GITHUB_CLIENT_ID_PUBLIC to be set. " +
-          "Register an OAuth App on github.com and add GITHUB_CLIENT_ID_PUBLIC=<id> to your .env file.",
-      );
-    }
-    clientId = GITHUB_CLIENT_ID_PUBLIC;
-  } else {
-    clientId = GITHUB_CLIENT_ID;
-  }
   const githubBase = `https://${host}`;
-  const apiBase = isPublicGitHub ? "https://api.github.com" : `https://api.${host}`;
+  const apiBase = isPublicGitHub(host) ? "https://api.github.com" : `https://api.${host}`;
   return {
     host,
-    clientId,
+    clientId: clientIdForHost(host),
     deviceCodeUrl: `${githubBase}/login/device/code`,
-    tokenUrl: `${githubBase}/login/oauth/access_token`,
+    tokenUrl: tokenUrlForHost(host),
     userUrl: `${apiBase}/user`,
     emailsUrl: `${apiBase}/user/emails`,
   };
@@ -88,8 +74,47 @@ interface GitHubDeviceCodeResponse {
 
 interface GitHubTokenResponse {
   access_token?: string;
+  /**
+   * Present only when the OAuth App has "Expire user authorization tokens"
+   * enabled (common on GitHub Enterprise). When present, `access_token`
+   * expires in `expires_in` seconds and is renewable with this refresh token
+   * until `refresh_token_expires_in` seconds elapse.
+   */
+  refresh_token?: string;
+  expires_in?: number;
+  refresh_token_expires_in?: number;
   error?: string;
   interval?: number;
+}
+
+interface ResolvedTokens {
+  accessToken: string;
+  refreshToken: string | null;
+  accessTokenExpiresAt: Date | null;
+  refreshTokenExpiresAt: Date | null;
+}
+
+function resolveTokens(data: GitHubTokenResponse, now: Date): ResolvedTokens {
+  return {
+    accessToken: data.access_token ?? "",
+    refreshToken: data.refresh_token ?? null,
+    accessTokenExpiresAt: data.expires_in ? new Date(now.getTime() + data.expires_in * 1000) : null,
+    refreshTokenExpiresAt: data.refresh_token_expires_in
+      ? new Date(now.getTime() + data.refresh_token_expires_in * 1000)
+      : null,
+  };
+}
+
+async function persistTokens(
+  accountRowId: string,
+  host: string,
+  tokens: { accessToken: string | null; refreshToken: string | null },
+): Promise<void> {
+  await AppRuntime.runPromise(
+    Effect.flatMap(TokenProvider, (provider) =>
+      provider.storeAccountTokens(accountRowId, host, tokens),
+    ),
+  );
 }
 
 interface GitHubUser {
@@ -167,9 +192,10 @@ async function retryFetch<T>(
 }
 
 async function upsertUserAndSession(
-  accessToken: string,
+  tokens: ResolvedTokens,
   urls: { host: string; userUrl: string; emailsUrl: string },
 ): Promise<string> {
+  const { accessToken } = tokens;
   const githubUser = await retryFetch(() => fetchGitHubUser(accessToken, urls), 2, 1000);
   const primaryEmail = await fetchPrimaryEmail(accessToken, urls);
   const email = primaryEmail ?? githubUser.email;
@@ -237,36 +263,47 @@ async function upsertUserAndSession(
     });
   }
 
-  // Upsert account by providerId + accountId
+  // Upsert account by providerId + accountId. Token bytes go to the secure
+  // store keyed on the account row id — never the DB columns. Expiry
+  // timestamps and the cleared `reauthRequiredAt` flag stay on the row.
   const providerId = `github:${urls.host}`;
   const existingAccounts = await db.select().from(account).where(eq(account.accountId, accountId));
   const existingAccount = existingAccounts.find((a) => a.providerId === providerId);
+  const accountRowId = existingAccount?.id ?? crypto.randomUUID();
 
   if (existingAccount) {
     await db
       .update(account)
       .set({
-        accessToken,
         updatedAt: now,
         userId,
         githubLogin: githubUser.login,
         avatarUrl: githubUser.avatar_url,
+        accessTokenExpiresAt: tokens.accessTokenExpiresAt,
+        refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
+        reauthRequiredAt: null,
       })
-      .where(eq(account.id, existingAccount.id));
+      .where(eq(account.id, accountRowId));
   } else {
     await db.insert(account).values({
-      id: crypto.randomUUID(),
+      id: accountRowId,
       accountId,
       providerId,
       userId,
-      accessToken,
       githubLogin: githubUser.login,
       avatarUrl: githubUser.avatar_url,
       scope: DEVICE_FLOW_SCOPE,
+      accessTokenExpiresAt: tokens.accessTokenExpiresAt,
+      refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
       createdAt: now,
       updatedAt: now,
     });
   }
+
+  await persistTokens(accountRowId, urls.host, {
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+  });
 
   // Create new session
   const sessionToken = generateSecureToken();
@@ -285,11 +322,11 @@ async function upsertUserAndSession(
 }
 
 async function upsertAccountForUser(
-  accessToken: string,
+  tokens: ResolvedTokens,
   urls: { host: string; userUrl: string },
   userId: string,
 ): Promise<void> {
-  const githubUser = await retryFetch(() => fetchGitHubUser(accessToken, urls), 2, 1000);
+  const githubUser = await retryFetch(() => fetchGitHubUser(tokens.accessToken, urls), 2, 1000);
   const providerId = `github:${urls.host}`;
   const accountId = githubUser.id.toString();
   const now = new Date();
@@ -299,31 +336,40 @@ async function upsertAccountForUser(
     .from(account)
     .where(and(eq(account.providerId, providerId), eq(account.userId, userId)))
     .then((r) => r[0] ?? null);
+  const accountRowId = existing?.id ?? crypto.randomUUID();
 
   if (existing) {
     await db
       .update(account)
       .set({
-        accessToken,
         githubLogin: githubUser.login,
         avatarUrl: githubUser.avatar_url,
         updatedAt: now,
+        accessTokenExpiresAt: tokens.accessTokenExpiresAt,
+        refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
+        reauthRequiredAt: null,
       })
-      .where(eq(account.id, existing.id));
+      .where(eq(account.id, accountRowId));
   } else {
     await db.insert(account).values({
-      id: crypto.randomUUID(),
+      id: accountRowId,
       accountId,
       providerId,
       userId,
-      accessToken,
       githubLogin: githubUser.login,
       avatarUrl: githubUser.avatar_url,
       scope: DEVICE_FLOW_SCOPE,
+      accessTokenExpiresAt: tokens.accessTokenExpiresAt,
+      refreshTokenExpiresAt: tokens.refreshTokenExpiresAt,
       createdAt: now,
       updatedAt: now,
     });
   }
+
+  await persistTokens(accountRowId, urls.host, {
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+  });
 }
 
 const KNOWN_HOSTS = ["nocturlab.ghe.com", "github.com"] as const;
@@ -493,9 +539,12 @@ const publicAuthRoutes = new Elysia()
       const data = (await res.json()) as GitHubTokenResponse;
 
       if (data.access_token && existingUserId) {
-        // Link path: user is already signed in — only upsert the account row
+        // Link path: user is already signed in — only upsert the account row.
+        // Also the re-auth path: re-signing-in the active account lands here
+        // (the client sends its session_token), refreshing the stored token
+        // and clearing `reauthRequiredAt` on the existing row.
         try {
-          await upsertAccountForUser(data.access_token, urls, existingUserId);
+          await upsertAccountForUser(resolveTokens(data, new Date()), urls, existingUserId);
           return { status: "linked" as const };
         } catch (e) {
           logError("device-auth", "account link failed:", e);
@@ -506,7 +555,7 @@ const publicAuthRoutes = new Elysia()
 
       if (data.access_token) {
         try {
-          const token = await upsertUserAndSession(data.access_token, urls);
+          const token = await upsertUserAndSession(resolveTokens(data, new Date()), urls);
           return { status: "success" as const, token };
         } catch (e) {
           logError("device-auth", "session creation failed:", e);
@@ -565,14 +614,23 @@ const protectedAuthRoutes = new Elysia()
       const providerId = `github:${host}`;
       const userId = ctx.session.user.id;
 
-      // Fetch the account row to attempt token revocation before deletion
+      // Fetch the account row id, then read its token from the secure store to
+      // attempt revocation on GitHub before deletion.
       const accountRow = await db
-        .select({ accessToken: account.accessToken })
+        .select({ id: account.id })
         .from(account)
         .where(and(eq(account.providerId, providerId), eq(account.userId, userId)))
         .then((r) => r[0] ?? null);
 
-      if (accountRow?.accessToken) {
+      const accessToken = accountRow
+        ? await AppRuntime.runPromise(
+            Effect.flatMap(TokenProvider, (provider) =>
+              provider.getTokenByAccountId(accountRow.id),
+            ).pipe(Effect.orElseSucceed(() => null)),
+          )
+        : null;
+
+      if (accessToken) {
         const isPublic = host === "github.com";
         const clientId = isPublic ? (GITHUB_CLIENT_ID_PUBLIC ?? "") : GITHUB_CLIENT_ID;
         const apiBase = isPublic ? "https://api.github.com" : `https://api.${host}`;
@@ -584,7 +642,7 @@ const protectedAuthRoutes = new Elysia()
               Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
               Accept: "application/vnd.github+json",
             },
-            body: JSON.stringify({ access_token: accountRow.accessToken }),
+            body: JSON.stringify({ access_token: accessToken }),
           });
         } catch {
           // Best-effort — proceed with local deletion regardless
@@ -594,6 +652,11 @@ const protectedAuthRoutes = new Elysia()
       await db
         .delete(account)
         .where(and(eq(account.providerId, providerId), eq(account.userId, userId)));
+      if (accountRow) {
+        await AppRuntime.runPromise(
+          Effect.flatMap(TokenProvider, (provider) => provider.deleteAccountTokens(accountRow.id)),
+        );
+      }
       return { ok: true };
     },
     { body: t.Object({ host: t.String() }) },

--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -130,11 +130,42 @@ export const userRoutes = new Elysia({ prefix: "/api/user" })
           if (pr) role = pr.authorLogin === login ? "coder" : "reviewer";
         }
 
+        // Resolve the active account's re-auth state so the client can gate
+        // the app behind the re-sign-in modal on boot, reconciling any
+        // `auth:reauth-required` WS signal missed while disconnected.
+        const reauth = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const tokenProvider = yield* TokenProvider;
+            const settingsService = yield* SettingsService;
+            const settings = yield* settingsService
+              .getSettings()
+              .pipe(Effect.orElseSucceed(() => null));
+            const hostPref = settings?.githubHost?.trim() || undefined;
+            const resolved = yield* tokenProvider.resolveAccount(userId, hostPref);
+            const accountRow = db
+              .select({ reauthRequiredAt: account.reauthRequiredAt })
+              .from(account)
+              .where(eq(account.id, resolved.accountId))
+              .get();
+            return {
+              reauthRequired: accountRow?.reauthRequiredAt != null,
+              host: resolved.providerId.split(":")[1] ?? null,
+            };
+          }).pipe(
+            Effect.orElseSucceed(() => ({
+              reauthRequired: false,
+              host: null as string | null,
+            })),
+          ),
+        );
+
         const identity: UserIdentity = {
           login,
           role,
           avatarContent,
           isMaintainer: isMaintainerLogin(login),
+          reauthRequired: reauth.reauthRequired,
+          host: reauth.host,
         };
         return {
           ...identity,

--- a/apps/server/src/services/AppLayer.ts
+++ b/apps/server/src/services/AppLayer.ts
@@ -28,6 +28,7 @@ import { RemoteWalkthroughCacheLive } from "./RemoteWalkthroughCache";
 import { RepoCloneServiceLive } from "./RepoClone";
 import { RepositoryServiceLive } from "./Repository";
 import { ReviewServiceLive } from "./Review";
+import { SecretStoreLive } from "./SecretStore";
 import { SettingsServiceLive } from "./Settings";
 import { SyncServiceLive } from "./Sync";
 import { TokenProviderLive } from "./TokenProvider";
@@ -36,8 +37,13 @@ import { WalkthroughJobsLive } from "./WalkthroughJobs";
 import { WalkthroughSnapshotImporterLive } from "./WalkthroughSnapshotImporter";
 import { WebSocketHubLive } from "./WebSocketHub";
 
-// TokenProvider now needs DbService
-const TokenProviderWithDeps = TokenProviderLive.pipe(Layer.provide(DbServiceLive));
+// TokenProvider reads token bytes from SecretStore, resolves account rows via
+// DbService, and broadcasts re-auth signals via WebSocketHub (token refresh
+// success/failure). WebSocketHub is a leaf layer, so providing it here as well
+// as in BaseLayers is a no-op dedupe.
+const TokenProviderWithDeps = TokenProviderLive.pipe(
+  Layer.provide(Layer.mergeAll(DbServiceLive, SecretStoreLive, WebSocketHubLive)),
+);
 
 // SettingsService now reads/writes via DbService instead of JSON file
 const SettingsServiceWithDeps = SettingsServiceLive.pipe(Layer.provide(DbServiceLive));
@@ -65,6 +71,7 @@ const RemoteUserServiceWithDeps = RemoteUserServiceLive.pipe(Layer.provide(DbSer
 // Base layer: all services that have no deps or only depend on DbService
 const BaseLayers = Layer.mergeAll(
   DbServiceLive,
+  SecretStoreLive,
   TokenProviderWithDeps,
   GitHubEtagCacheLive,
   GitHubServiceWithDeps,

--- a/apps/server/src/services/PollScheduler.ts
+++ b/apps/server/src/services/PollScheduler.ts
@@ -16,6 +16,7 @@ import { RemoteUserService } from "./RemoteUser";
 import { RepositoryService } from "./Repository";
 import { SettingsService } from "./Settings";
 import { SyncService } from "./Sync";
+import { TokenProvider } from "./TokenProvider";
 import { WalkthroughService } from "./Walkthrough";
 import { WalkthroughJobs } from "./WalkthroughJobs";
 import { WebSocketHub } from "./WebSocketHub";
@@ -38,6 +39,11 @@ function hostToApiBase(host: string): string {
   return host === "github.com" ? "https://api.github.com" : `https://api.${host}`;
 }
 
+/** Derive the GitHub host from a `github:{host}` (or legacy `github`) providerId. */
+function hostFromProviderId(providerId: string): string {
+  return providerId.split(":")[1] ?? "github.com";
+}
+
 export const PollSchedulerLive = Layer.effect(
   PollScheduler,
   Effect.gen(function* () {
@@ -53,6 +59,7 @@ export const PollSchedulerLive = Layer.effect(
     const etagCache = yield* GitHubEtagCache;
     const walkthroughJobs = yield* WalkthroughJobs;
     const walkthroughService = yield* WalkthroughService;
+    const tokenProvider = yield* TokenProvider;
     const { db } = yield* DbService;
 
     // Layer-scope guard tracking accounts whose access token returned a 401.
@@ -138,21 +145,55 @@ export const PollSchedulerLive = Layer.effect(
             .all();
           const repoToAccountId = new Map(repoRowsForAccount.map((r) => [r.id, r.accountId]));
           const accountIdSet = Array.from(new Set(repoRowsForAccount.map((r) => r.accountId)));
-          const accountRows: AccountCtx[] =
+          // Token bytes live behind TokenProvider, not the DB. Fetch only the
+          // metadata the scheduler needs, then let TokenProvider resolve and
+          // refresh the usable access token.
+          const accountMetaRows =
             accountIdSet.length > 0
               ? db
                   .select({
                     id: account.id,
                     userId: account.userId,
-                    accessToken: account.accessToken,
+                    providerId: account.providerId,
                     githubLogin: account.githubLogin,
                     avatarUrl: account.avatarUrl,
+                    reauthRequiredAt: account.reauthRequiredAt,
                   })
                   .from(account)
                   .where(inArray(account.id, accountIdSet))
                   .all()
               : [];
+          const accountRows: AccountCtx[] = [];
+          for (const meta of accountMetaRows) {
+            const token = yield* tokenProvider
+              .getTokenByAccountId(meta.id)
+              .pipe(Effect.orElseSucceed(() => null));
+            // Reconcile: a client that reconnected after missing the live
+            // envelope learns it still needs to re-auth. Broadcast-only (no
+            // DB re-stamp) since the row already carries the flag.
+            if (meta.reauthRequiredAt) {
+              yield* hub
+                .broadcastToAccount(meta.id, {
+                  type: "auth:reauth-required",
+                  data: {
+                    host: hostFromProviderId(meta.providerId),
+                    githubLogin: meta.githubLogin,
+                  },
+                })
+                .pipe(Effect.orElseSucceed(() => undefined));
+            }
+            accountRows.push({
+              id: meta.id,
+              userId: meta.userId,
+              accessToken: token,
+              githubLogin: meta.githubLogin,
+              avatarUrl: meta.avatarUrl,
+            });
+          }
           const accountById = new Map(accountRows.map((a) => [a.id, a]));
+          // Accounts whose token was already refreshed this cycle — bounds the
+          // reactive 401 path to one refresh attempt per account per cycle.
+          const refreshedThisCycle = new Set<string>();
 
           // First-time-only log when a token is observed to 401; subsequent
           // calls in this or future cycles are silent until the token rotates.
@@ -196,6 +237,28 @@ export const PollSchedulerLive = Layer.effect(
           // tap/catch boilerplate. Pass `expectedAuthError: true` to suppress
           // the noise after the cycle's first 401 (the per-account log line
           // already covered it).
+          // On a 401, try once to silently refresh the account's token; if it
+          // rotates, update the in-memory ctx so later calls this cycle use it
+          // and the account is NOT paused. If refresh is impossible/failed,
+          // pause the account and stamp+broadcast the re-auth requirement.
+          const handleAuthError = (acc: AccountCtx): Effect.Effect<void> =>
+            Effect.gen(function* () {
+              if (refreshedThisCycle.has(acc.id)) return; // already attempted this cycle
+              refreshedThisCycle.add(acc.id);
+              const refreshed = yield* tokenProvider.refreshAccountToken(acc.id).pipe(
+                Effect.map((t): string | null => t),
+                Effect.orElseSucceed(() => null),
+              );
+              if (refreshed) {
+                const cur = accountById.get(acc.id);
+                if (cur) accountById.set(acc.id, { ...cur, accessToken: refreshed });
+                knownBadTokensByAccountId.delete(acc.id);
+                return;
+              }
+              markTokenBad(acc);
+              yield* tokenProvider.markReauthRequired(acc.id);
+            });
+
           const tryGuarded = <A, E, R>(
             acc: AccountCtx,
             eff: Effect.Effect<A, E, R>,
@@ -203,15 +266,13 @@ export const PollSchedulerLive = Layer.effect(
           ): Effect.Effect<A | null, never, R> =>
             eff.pipe(
               Effect.tapError((err) =>
-                Effect.sync(() => {
-                  if (err instanceof GitHubAuthError) {
-                    markTokenBad(acc);
-                    return;
-                  }
-                  if (opts?.errorLabel) {
-                    logError("PollScheduler", `${opts.errorLabel}:`, err);
-                  }
-                }),
+                err instanceof GitHubAuthError
+                  ? handleAuthError(acc)
+                  : Effect.sync(() => {
+                      if (opts?.errorLabel) {
+                        logError("PollScheduler", `${opts.errorLabel}:`, err);
+                      }
+                    }),
               ),
               Effect.catchAll(() => Effect.succeed(null as A | null)),
             );

--- a/apps/server/src/services/SecretStore.test.ts
+++ b/apps/server/src/services/SecretStore.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test";
+import { eq } from "drizzle-orm";
+import { Effect, Layer } from "effect";
+import { createDb, type Db } from "../db/index";
+import { account, user } from "../db/schema";
+import { DbService } from "./Db";
+import {
+  deserialize,
+  migrateLegacyTokens,
+  SecretStore,
+  serialize,
+  type TokenPair,
+} from "./SecretStore";
+
+/** In-memory stand-in for the OS secure store, exposing its backing map. */
+function makeFakeStore(initial?: Record<string, TokenPair>) {
+  const map = new Map<string, TokenPair>(Object.entries(initial ?? {}));
+  const layer = Layer.succeed(SecretStore, {
+    setTokens: (id: string, tokens: TokenPair) =>
+      Effect.sync(() => {
+        map.set(id, tokens);
+      }),
+    getTokens: (id: string) => Effect.sync(() => map.get(id) ?? null),
+    deleteTokens: (id: string) =>
+      Effect.sync(() => {
+        map.delete(id);
+      }),
+  });
+  return { layer, map };
+}
+
+function seedAccount(
+  db: Db,
+  opts: { id: string; accessToken: string | null; refreshToken: string | null },
+) {
+  const now = new Date();
+  db.insert(user)
+    .values({
+      id: `user-${opts.id}`,
+      name: "Test",
+      email: `${opts.id}@example.com`,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(account)
+    .values({
+      id: opts.id,
+      accountId: `gh-${opts.id}`,
+      providerId: "github:github.com",
+      userId: `user-${opts.id}`,
+      accessToken: opts.accessToken,
+      refreshToken: opts.refreshToken,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+describe("SecretStore serialize/deserialize", () => {
+  it("round-trips a full token pair", () => {
+    const pair: TokenPair = { accessToken: "gho_abc", refreshToken: "ghr_def" };
+    expect(deserialize(serialize(pair))).toEqual(pair);
+  });
+
+  it("normalizes a missing refresh token to null", () => {
+    expect(deserialize(serialize({ accessToken: "a", refreshToken: null }))).toEqual({
+      accessToken: "a",
+      refreshToken: null,
+    });
+  });
+
+  it("tolerates a legacy raw-string access token (non-JSON)", () => {
+    expect(deserialize("gho_legacy")).toEqual({ accessToken: "gho_legacy", refreshToken: null });
+  });
+});
+
+describe("migrateLegacyTokens", () => {
+  it("moves plaintext tokens into the store, nulls the columns, and is idempotent", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db, { id: "acc-1", accessToken: "gho_plain", refreshToken: "ghr_plain" });
+    // Already-migrated row (null columns) must be skipped.
+    seedAccount(db, { id: "acc-2", accessToken: null, refreshToken: null });
+
+    const { layer, map } = makeFakeStore();
+    const provided = Layer.merge(Layer.succeed(DbService, { db }), layer);
+
+    const migrated = await Effect.runPromise(migrateLegacyTokens.pipe(Effect.provide(provided)));
+    expect(migrated).toBe(1);
+    expect(map.get("acc-1")).toEqual({ accessToken: "gho_plain", refreshToken: "ghr_plain" });
+    expect(map.has("acc-2")).toBe(false);
+
+    const row = db
+      .select({ accessToken: account.accessToken, refreshToken: account.refreshToken })
+      .from(account)
+      .where(eq(account.id, "acc-1"))
+      .get();
+    expect(row?.accessToken).toBeNull();
+    expect(row?.refreshToken).toBeNull();
+
+    // Second boot: columns are already null, nothing left to migrate.
+    const again = await Effect.runPromise(migrateLegacyTokens.pipe(Effect.provide(provided)));
+    expect(again).toBe(0);
+  });
+});

--- a/apps/server/src/services/SecretStore.ts
+++ b/apps/server/src/services/SecretStore.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { Entry } from "@napi-rs/keyring";
@@ -28,9 +28,17 @@ export interface TokenPair {
  *
  * When the OS keyring is unavailable (e.g. a Linux session with no Secret
  * Service daemon), the store degrades to an AES-256-GCM encrypted file under
- * the app data dir, keyed by a `0600` key file — the same trust model the
- * better-auth signing secret already uses (`auth.ts`). This is a fallback to
- * avoid a hard failure, not the intended path; it is logged loudly on entry.
+ * the app data dir. This is a fallback to avoid a hard failure, not the
+ * intended path; it is logged loudly on entry.
+ *
+ * The fallback encryption key is *derived* (scrypt) from a secret plus a
+ * persisted random salt, rather than read verbatim from a key file sitting
+ * next to the ciphertext. When `BETTER_AUTH_SECRET` is configured in the
+ * environment (the recommended deployment path), that secret never lands on
+ * disk, so an attacker with only filesystem read of the app-support dir holds
+ * the ciphertext and a useless salt — not the key. Absent an env secret we
+ * fall back to a persisted `0600` key file, matching the trust model the
+ * better-auth signing secret already uses (`auth.ts`).
  */
 export class SecretStore extends Context.Tag("SecretStore")<
   SecretStore,
@@ -70,6 +78,9 @@ function deserialize(raw: string): TokenPair {
 function fallbackKeyPath(): string {
   return join(appDataDir(), "secret-store.key");
 }
+function fallbackSaltPath(): string {
+  return join(appDataDir(), "secret-store.salt");
+}
 function fallbackDataPath(): string {
   return join(appDataDir(), "secret-store.enc");
 }
@@ -79,16 +90,42 @@ function ensureAppDir(): void {
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
 }
 
-function loadFallbackKey(): Buffer {
-  const p = fallbackKeyPath();
+/** Load (or generate) the non-secret random salt persisted beside the data. */
+function loadFallbackSalt(): Buffer {
+  const p = fallbackSaltPath();
   if (existsSync(p)) {
     const hex = readFileSync(p, "utf8").trim();
-    if (hex.length >= 64) return Buffer.from(hex.slice(0, 64), "hex");
+    if (hex.length >= 32) return Buffer.from(hex.slice(0, 32), "hex");
   }
   ensureAppDir();
-  const key = randomBytes(32);
-  writeFileSync(p, key.toString("hex"), { mode: 0o600 });
-  return key;
+  const salt = randomBytes(16);
+  writeFileSync(p, salt.toString("hex"), { mode: 0o600 });
+  return salt;
+}
+
+/**
+ * Resolve the input secret for key derivation. Prefers `BETTER_AUTH_SECRET`
+ * from the environment (kept off disk); otherwise falls back to a persisted
+ * `0600` random key file, generated on first use.
+ */
+function loadFallbackSecret(): string {
+  const envSecret = process.env.BETTER_AUTH_SECRET;
+  if (envSecret && envSecret.length > 0) return envSecret;
+
+  const p = fallbackKeyPath();
+  if (existsSync(p)) {
+    const existing = readFileSync(p, "utf8").trim();
+    if (existing.length > 0) return existing;
+  }
+  ensureAppDir();
+  const secret = randomBytes(32).toString("hex");
+  writeFileSync(p, secret, { mode: 0o600 });
+  return secret;
+}
+
+/** Derive the AES-256 key from the resolved secret + persisted salt (scrypt). */
+function deriveFallbackKey(): Buffer {
+  return scryptSync(loadFallbackSecret(), loadFallbackSalt(), 32);
 }
 
 function readFallbackMap(): Record<string, TokenPair> {
@@ -99,7 +136,7 @@ function readFallbackMap(): Record<string, TokenPair> {
     const iv = raw.subarray(0, 12);
     const tag = raw.subarray(12, 28);
     const ct = raw.subarray(28);
-    const decipher = createDecipheriv("aes-256-gcm", loadFallbackKey(), iv);
+    const decipher = createDecipheriv("aes-256-gcm", deriveFallbackKey(), iv);
     decipher.setAuthTag(tag);
     const json = Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
     return JSON.parse(json) as Record<string, TokenPair>;
@@ -112,7 +149,7 @@ function readFallbackMap(): Record<string, TokenPair> {
 function writeFallbackMap(map: Record<string, TokenPair>): void {
   ensureAppDir();
   const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", loadFallbackKey(), iv);
+  const cipher = createCipheriv("aes-256-gcm", deriveFallbackKey(), iv);
   const ct = Buffer.concat([cipher.update(JSON.stringify(map), "utf8"), cipher.final()]);
   const tag = cipher.getAuthTag();
   writeFileSync(fallbackDataPath(), Buffer.concat([iv, tag, ct]), { mode: 0o600 });

--- a/apps/server/src/services/SecretStore.ts
+++ b/apps/server/src/services/SecretStore.ts
@@ -1,0 +1,219 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Entry } from "@napi-rs/keyring";
+import { eq } from "drizzle-orm";
+import { Context, Effect, Layer } from "effect";
+import { account } from "../db/schema";
+import { logError } from "../logger";
+import { appDataDir, keyringServiceName } from "../paths";
+import { DbService } from "./Db";
+
+/**
+ * GitHub OAuth tokens for a single linked account. Both rotate together, so
+ * they are stored as one keyring entry (a JSON blob).
+ */
+export interface TokenPair {
+  readonly accessToken: string | null;
+  readonly refreshToken: string | null;
+}
+
+/**
+ * Secure store for GitHub OAuth token bytes.
+ *
+ * The OS secure element (macOS Keychain / Windows Credential Manager / Linux
+ * Secret Service, via `@napi-rs/keyring`) is the authoritative home for the
+ * token material — the `account` row keeps everything non-secret (which
+ * accounts exist, provider/host, expiries, `reauthRequiredAt`, login/avatar).
+ *
+ * When the OS keyring is unavailable (e.g. a Linux session with no Secret
+ * Service daemon), the store degrades to an AES-256-GCM encrypted file under
+ * the app data dir, keyed by a `0600` key file — the same trust model the
+ * better-auth signing secret already uses (`auth.ts`). This is a fallback to
+ * avoid a hard failure, not the intended path; it is logged loudly on entry.
+ */
+export class SecretStore extends Context.Tag("SecretStore")<
+  SecretStore,
+  {
+    readonly setTokens: (accountId: string, tokens: TokenPair) => Effect.Effect<void>;
+    readonly getTokens: (accountId: string) => Effect.Effect<TokenPair | null>;
+    readonly deleteTokens: (accountId: string) => Effect.Effect<void>;
+  }
+>() {}
+
+const KEYRING_USER_PREFIX = "github-tokens:";
+
+function entryFor(accountId: string): Entry {
+  return new Entry(keyringServiceName(), `${KEYRING_USER_PREFIX}${accountId}`);
+}
+
+function serialize(tokens: TokenPair): string {
+  return JSON.stringify({
+    accessToken: tokens.accessToken ?? null,
+    refreshToken: tokens.refreshToken ?? null,
+  });
+}
+
+function deserialize(raw: string): TokenPair {
+  try {
+    const o = JSON.parse(raw) as Partial<TokenPair>;
+    return { accessToken: o.accessToken ?? null, refreshToken: o.refreshToken ?? null };
+  } catch {
+    // Tolerate a legacy raw-string access token (defensive — current writes
+    // always JSON-encode).
+    return { accessToken: raw, refreshToken: null };
+  }
+}
+
+// ── Encrypted-file fallback ────────────────────────────────────────────────
+
+function fallbackKeyPath(): string {
+  return join(appDataDir(), "secret-store.key");
+}
+function fallbackDataPath(): string {
+  return join(appDataDir(), "secret-store.enc");
+}
+
+function ensureAppDir(): void {
+  const dir = appDataDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+}
+
+function loadFallbackKey(): Buffer {
+  const p = fallbackKeyPath();
+  if (existsSync(p)) {
+    const hex = readFileSync(p, "utf8").trim();
+    if (hex.length >= 64) return Buffer.from(hex.slice(0, 64), "hex");
+  }
+  ensureAppDir();
+  const key = randomBytes(32);
+  writeFileSync(p, key.toString("hex"), { mode: 0o600 });
+  return key;
+}
+
+function readFallbackMap(): Record<string, TokenPair> {
+  try {
+    if (!existsSync(fallbackDataPath())) return {};
+    const raw = readFileSync(fallbackDataPath());
+    // Layout: iv(12) | authTag(16) | ciphertext
+    const iv = raw.subarray(0, 12);
+    const tag = raw.subarray(12, 28);
+    const ct = raw.subarray(28);
+    const decipher = createDecipheriv("aes-256-gcm", loadFallbackKey(), iv);
+    decipher.setAuthTag(tag);
+    const json = Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
+    return JSON.parse(json) as Record<string, TokenPair>;
+  } catch (e) {
+    logError("SecretStore", "fallback store read failed:", e);
+    return {};
+  }
+}
+
+function writeFallbackMap(map: Record<string, TokenPair>): void {
+  ensureAppDir();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", loadFallbackKey(), iv);
+  const ct = Buffer.concat([cipher.update(JSON.stringify(map), "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  writeFileSync(fallbackDataPath(), Buffer.concat([iv, tag, ct]), { mode: 0o600 });
+}
+
+export const SecretStoreLive = Layer.sync(SecretStore, () => {
+  // Probe once: getPassword returns null when the entry is absent and throws
+  // only when the backend itself is unreachable, so it's a clean availability
+  // check. All ops route consistently to keyring or fallback to avoid a
+  // split-brain where a token lands in one store and is read from the other.
+  let useKeyring = true;
+  try {
+    new Entry(keyringServiceName(), "__revv_probe__").getPassword();
+  } catch (e) {
+    useKeyring = false;
+    logError(
+      "SecretStore",
+      "OS keyring unavailable — falling back to encrypted-file token store:",
+      e,
+    );
+  }
+
+  return {
+    setTokens: (accountId, tokens) =>
+      Effect.sync(() => {
+        const json = serialize(tokens);
+        if (useKeyring) {
+          try {
+            entryFor(accountId).setPassword(json);
+            return;
+          } catch (e) {
+            logError("SecretStore", `keyring set failed for ${accountId}; using fallback:`, e);
+          }
+        }
+        const map = readFallbackMap();
+        map[accountId] = deserialize(json);
+        writeFallbackMap(map);
+      }),
+
+    getTokens: (accountId) =>
+      Effect.sync((): TokenPair | null => {
+        if (useKeyring) {
+          try {
+            const v = entryFor(accountId).getPassword();
+            if (v) return deserialize(v);
+          } catch (e) {
+            logError("SecretStore", `keyring get failed for ${accountId}; using fallback:`, e);
+          }
+        }
+        const map = readFallbackMap();
+        return map[accountId] ?? null;
+      }),
+
+    deleteTokens: (accountId) =>
+      Effect.sync(() => {
+        if (useKeyring) {
+          try {
+            entryFor(accountId).deletePassword();
+          } catch {
+            // No matching entry / backend hiccup — nothing to clean up.
+          }
+        }
+        const map = readFallbackMap();
+        if (accountId in map) {
+          delete map[accountId];
+          writeFallbackMap(map);
+        }
+      }),
+  };
+});
+
+/**
+ * One-time boot migration: copy any plaintext tokens still living in the
+ * `account.access_token` / `refresh_token` columns into the secure store, then
+ * null the columns. Idempotent — rows already migrated have null columns and
+ * are skipped. Returns the number of accounts migrated.
+ */
+export const migrateLegacyTokens: Effect.Effect<number, never, SecretStore | DbService> =
+  Effect.gen(function* () {
+    const store = yield* SecretStore;
+    const { db } = yield* DbService;
+    const rows = db
+      .select({
+        id: account.id,
+        accessToken: account.accessToken,
+        refreshToken: account.refreshToken,
+      })
+      .from(account)
+      .all();
+    let migrated = 0;
+    for (const r of rows) {
+      if (!r.accessToken && !r.refreshToken) continue;
+      yield* store.setTokens(r.id, {
+        accessToken: r.accessToken ?? null,
+        refreshToken: r.refreshToken ?? null,
+      });
+      db.update(account)
+        .set({ accessToken: null, refreshToken: null, updatedAt: new Date() })
+        .where(eq(account.id, r.id))
+        .run();
+      migrated++;
+    }
+    return migrated;
+  });

--- a/apps/server/src/services/SecretStore.ts
+++ b/apps/server/src/services/SecretStore.ts
@@ -55,14 +55,14 @@ function entryFor(accountId: string): Entry {
   return new Entry(keyringServiceName(), `${KEYRING_USER_PREFIX}${accountId}`);
 }
 
-function serialize(tokens: TokenPair): string {
+export function serialize(tokens: TokenPair): string {
   return JSON.stringify({
     accessToken: tokens.accessToken ?? null,
     refreshToken: tokens.refreshToken ?? null,
   });
 }
 
-function deserialize(raw: string): TokenPair {
+export function deserialize(raw: string): TokenPair {
   try {
     const o = JSON.parse(raw) as Partial<TokenPair>;
     return { accessToken: o.accessToken ?? null, refreshToken: o.refreshToken ?? null };

--- a/apps/server/src/services/TokenProvider.test.ts
+++ b/apps/server/src/services/TokenProvider.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { WsServerMessage } from "@revv/shared";
+import { eq } from "drizzle-orm";
+import { Effect, Either, Layer } from "effect";
+import { createDb, type Db } from "../db/index";
+import { account, user } from "../db/schema";
+import { DbService } from "./Db";
+import { SecretStore, type TokenPair } from "./SecretStore";
+import { TokenProvider, TokenProviderLive } from "./TokenProvider";
+import { WebSocketHub } from "./WebSocketHub";
+
+// ── Fakes ──────────────────────────────────────────────────────────────────
+
+function makeFakeStore(initial?: Record<string, TokenPair>) {
+  const map = new Map<string, TokenPair>(Object.entries(initial ?? {}));
+  const layer = Layer.succeed(SecretStore, {
+    setTokens: (id: string, tokens: TokenPair) =>
+      Effect.sync(() => {
+        map.set(id, tokens);
+      }),
+    getTokens: (id: string) => Effect.sync(() => map.get(id) ?? null),
+    deleteTokens: (id: string) =>
+      Effect.sync(() => {
+        map.delete(id);
+      }),
+  });
+  return { layer, map };
+}
+
+function makeFakeHub() {
+  const events: Array<{ accountId: string | null; msg: WsServerMessage }> = [];
+  const layer = Layer.succeed(WebSocketHub, {
+    register: () => Effect.void,
+    unregister: () => Effect.void,
+    broadcast: (msg: WsServerMessage) =>
+      Effect.sync(() => {
+        events.push({ accountId: null, msg });
+      }),
+    broadcastToAccount: (accountId: string, msg: WsServerMessage) =>
+      Effect.sync(() => {
+        events.push({ accountId, msg });
+      }),
+    clientCount: Effect.succeed(0),
+  });
+  return { layer, events };
+}
+
+function seedAccount(
+  db: Db,
+  opts: {
+    id: string;
+    accessTokenExpiresAt?: Date | null;
+    refreshTokenExpiresAt?: Date | null;
+  },
+) {
+  const now = new Date();
+  db.insert(user)
+    .values({
+      id: `user-${opts.id}`,
+      name: "Test",
+      email: `${opts.id}@example.com`,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(account)
+    .values({
+      id: opts.id,
+      accountId: `gh-${opts.id}`,
+      providerId: "github:github.com",
+      userId: `user-${opts.id}`,
+      accessTokenExpiresAt: opts.accessTokenExpiresAt ?? null,
+      refreshTokenExpiresAt: opts.refreshTokenExpiresAt ?? null,
+      reauthRequiredAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function buildLayer(
+  db: Db,
+  store: ReturnType<typeof makeFakeStore>,
+  hub: ReturnType<typeof makeFakeHub>,
+) {
+  return TokenProviderLive.pipe(
+    Layer.provide(Layer.succeed(DbService, { db })),
+    Layer.provide(store.layer),
+    Layer.provide(hub.layer),
+  );
+}
+
+// Replace global fetch with a recording stub returning a fixed JSON payload.
+function stubFetch(payload: unknown, status = 200) {
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls += 1;
+    return new Response(JSON.stringify(payload), { status });
+  }) as unknown as typeof fetch;
+  return { calls: () => calls };
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+const HOUR = 60 * 60 * 1000;
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("TokenProvider.refreshAccountToken", () => {
+  it("rotates the access + refresh token, clears reauth, and broadcasts cleared", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db, { id: "acc", refreshTokenExpiresAt: new Date(Date.now() + HOUR) });
+    const store = makeFakeStore({ acc: { accessToken: "old", refreshToken: "r1" } });
+    const hub = makeFakeHub();
+    const fetchStub = stubFetch({
+      access_token: "new",
+      refresh_token: "r2",
+      expires_in: 3600,
+      refresh_token_expires_in: 7200,
+    });
+
+    const token = await Effect.runPromise(
+      Effect.gen(function* () {
+        const p = yield* TokenProvider;
+        return yield* p.refreshAccountToken("acc");
+      }).pipe(Effect.provide(buildLayer(db, store, hub))),
+    );
+
+    expect(token).toBe("new");
+    expect(fetchStub.calls()).toBe(1);
+    expect(store.map.get("acc")).toEqual({ accessToken: "new", refreshToken: "r2" });
+
+    const row = db
+      .select({ reauthRequiredAt: account.reauthRequiredAt })
+      .from(account)
+      .where(eq(account.id, "acc"))
+      .get();
+    expect(row?.reauthRequiredAt).toBeNull();
+    expect(
+      hub.events.some((e) => e.msg.type === "auth:reauth-cleared" && e.accountId === "acc"),
+    ).toBe(true);
+  });
+
+  it("fails without issuing a grant when no refresh token is stored", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db, { id: "acc" });
+    const store = makeFakeStore({ acc: { accessToken: "old", refreshToken: null } });
+    const hub = makeFakeHub();
+    const fetchStub = stubFetch({ access_token: "new" });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const p = yield* TokenProvider;
+        return yield* p.refreshAccountToken("acc").pipe(Effect.either);
+      }).pipe(Effect.provide(buildLayer(db, store, hub))),
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    expect(fetchStub.calls()).toBe(0);
+  });
+
+  it("fails without issuing a grant when the refresh token is expired", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db, { id: "acc", refreshTokenExpiresAt: new Date(Date.now() - HOUR) });
+    const store = makeFakeStore({ acc: { accessToken: "old", refreshToken: "r1" } });
+    const hub = makeFakeHub();
+    const fetchStub = stubFetch({ access_token: "new" });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const p = yield* TokenProvider;
+        return yield* p.refreshAccountToken("acc").pipe(Effect.either);
+      }).pipe(Effect.provide(buildLayer(db, store, hub))),
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    expect(fetchStub.calls()).toBe(0);
+  });
+
+  it("fails and leaves the stored token untouched when GitHub rejects the grant", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db, { id: "acc", refreshTokenExpiresAt: new Date(Date.now() + HOUR) });
+    const store = makeFakeStore({ acc: { accessToken: "old", refreshToken: "r1" } });
+    const hub = makeFakeHub();
+    stubFetch({ error: "bad_refresh_token" });
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const p = yield* TokenProvider;
+        return yield* p.refreshAccountToken("acc").pipe(Effect.either);
+      }).pipe(Effect.provide(buildLayer(db, store, hub))),
+    );
+
+    expect(Either.isLeft(result)).toBe(true);
+    expect(store.map.get("acc")).toEqual({ accessToken: "old", refreshToken: "r1" });
+  });
+
+  it("collapses concurrent refreshes of the same account into a single grant", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db, { id: "acc", refreshTokenExpiresAt: new Date(Date.now() + HOUR) });
+    const store = makeFakeStore({ acc: { accessToken: "old", refreshToken: "r1" } });
+    const hub = makeFakeHub();
+    const fetchStub = stubFetch({ access_token: "new", refresh_token: "r2", expires_in: 3600 });
+
+    const results = await Effect.runPromise(
+      Effect.gen(function* () {
+        const p = yield* TokenProvider;
+        return yield* Effect.all([p.refreshAccountToken("acc"), p.refreshAccountToken("acc")], {
+          concurrency: "unbounded",
+        });
+      }).pipe(Effect.provide(buildLayer(db, store, hub))),
+    );
+
+    expect(results).toEqual(["new", "new"]);
+    expect(fetchStub.calls()).toBe(1);
+  });
+});
+
+describe("TokenProvider.markReauthRequired", () => {
+  it("stamps reauthRequiredAt and broadcasts auth:reauth-required", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db, { id: "acc" });
+    const store = makeFakeStore();
+    const hub = makeFakeHub();
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const p = yield* TokenProvider;
+        yield* p.markReauthRequired("acc");
+      }).pipe(Effect.provide(buildLayer(db, store, hub))),
+    );
+
+    const row = db
+      .select({ reauthRequiredAt: account.reauthRequiredAt })
+      .from(account)
+      .where(eq(account.id, "acc"))
+      .get();
+    expect(row?.reauthRequiredAt).not.toBeNull();
+
+    const evt = hub.events.find((e) => e.msg.type === "auth:reauth-required");
+    expect(evt?.accountId).toBe("acc");
+    expect(evt?.msg.type === "auth:reauth-required" && evt.msg.data.host).toBe("github.com");
+  });
+});
+
+describe("TokenProvider.getTokenByAccountId", () => {
+  it("returns the stored token unchanged when it is not near expiry", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db, { id: "acc", accessTokenExpiresAt: new Date(Date.now() + HOUR) });
+    const store = makeFakeStore({ acc: { accessToken: "current", refreshToken: "r1" } });
+    const hub = makeFakeHub();
+    const fetchStub = stubFetch({ access_token: "new" });
+
+    const token = await Effect.runPromise(
+      Effect.gen(function* () {
+        const p = yield* TokenProvider;
+        return yield* p.getTokenByAccountId("acc");
+      }).pipe(Effect.provide(buildLayer(db, store, hub))),
+    );
+
+    expect(token).toBe("current");
+    expect(fetchStub.calls()).toBe(0);
+  });
+
+  it("transparently refreshes a near-expiry token before returning it", async () => {
+    const db = createDb(":memory:");
+    // Expires in 1 minute — inside the 5-minute refresh skew.
+    seedAccount(db, {
+      id: "acc",
+      accessTokenExpiresAt: new Date(Date.now() + 60 * 1000),
+      refreshTokenExpiresAt: new Date(Date.now() + HOUR),
+    });
+    const store = makeFakeStore({ acc: { accessToken: "current", refreshToken: "r1" } });
+    const hub = makeFakeHub();
+    const fetchStub = stubFetch({ access_token: "new", refresh_token: "r2", expires_in: 3600 });
+
+    const token = await Effect.runPromise(
+      Effect.gen(function* () {
+        const p = yield* TokenProvider;
+        return yield* p.getTokenByAccountId("acc");
+      }).pipe(Effect.provide(buildLayer(db, store, hub))),
+    );
+
+    expect(token).toBe("new");
+    expect(fetchStub.calls()).toBe(1);
+    expect(store.map.get("acc")).toEqual({ accessToken: "new", refreshToken: "r2" });
+  });
+});

--- a/apps/server/src/services/TokenProvider.ts
+++ b/apps/server/src/services/TokenProvider.ts
@@ -3,17 +3,34 @@ import { Context, Effect, Layer } from "effect";
 import { serverEnv } from "../config";
 import { account, user } from "../db/schema";
 import { GitHubAuthError } from "../domain/errors";
+import { clientIdForHost, tokenUrlForHost } from "../github-oauth";
 import { DbService } from "./Db";
+import { SecretStore, type TokenPair } from "./SecretStore";
+import { WebSocketHub } from "./WebSocketHub";
+
+const REFRESH_SKEW_MS = 5 * 60 * 1000;
+
+interface RefreshResponse {
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  refresh_token_expires_in?: number;
+  error?: string;
+}
 
 /**
- * Fetches the GitHub access token stored on the user's linked GitHub account.
+ * Fetches and maintains the GitHub access token for a user's linked account.
  *
- * We read from the `account` table directly rather than going through
- * `better-auth`'s `getAccessToken` API because Revv's only auth path is the
- * device-code flow (see `routes/device-auth.ts`), which writes the token to
- * this table itself. Keeping the dependency local also means we don't need
- * better-auth's `socialProviders.github` to be configured — which it no
- * longer is, since `client_secret` was removed.
+ * Token *bytes* live in {@link SecretStore} (the OS secure element); the
+ * `account` row holds only non-secret metadata (provider/host, expiry
+ * timestamps, `reauthRequiredAt`). We read the `account` table directly rather
+ * than via better-auth because Revv's only auth path is the device-code flow
+ * (see `routes/device-auth.ts`), which now also captures a refresh token when
+ * the OAuth App issues one.
+ *
+ * The provider transparently refreshes a near-expiry access token on read, and
+ * exposes `refreshAccountToken` / `markReauthRequired` for the reactive 401
+ * recovery path driven by `PollScheduler`.
  */
 export class TokenProvider extends Context.Tag("TokenProvider")<
   TokenProvider,
@@ -43,6 +60,31 @@ export class TokenProvider extends Context.Tag("TokenProvider")<
      * accounts per host are present on the machine.
      */
     readonly getTokenByAccountId: (accountId: string) => Effect.Effect<string, GitHubAuthError>;
+    /**
+     * Persist freshly issued token material for an account and notify clients
+     * that any re-auth gate for this account can be cleared.
+     */
+    readonly storeAccountTokens: (
+      accountId: string,
+      host: string,
+      tokens: TokenPair,
+    ) => Effect.Effect<void>;
+    /** Delete token material for a locally disconnected account. */
+    readonly deleteAccountTokens: (accountId: string) => Effect.Effect<void>;
+    /**
+     * Exchange the account's stored refresh token for a fresh access token,
+     * persisting both to the secure store and clearing `reauthRequiredAt`.
+     * Fails with `GitHubAuthError` when no usable refresh token exists or
+     * GitHub rejects the grant — the caller then routes to
+     * `markReauthRequired`.
+     */
+    readonly refreshAccountToken: (accountId: string) => Effect.Effect<string, GitHubAuthError>;
+    /**
+     * Stamp `reauthRequiredAt` on the account and broadcast
+     * `auth:reauth-required` to its connected clients. Called when a token is
+     * invalid and could not be refreshed.
+     */
+    readonly markReauthRequired: (accountId: string) => Effect.Effect<void>;
   }
 >() {}
 
@@ -50,100 +92,234 @@ export const TokenProviderLive = Layer.effect(
   TokenProvider,
   Effect.gen(function* () {
     const { db } = yield* DbService;
+    const secretStore = yield* SecretStore;
+    const hub = yield* WebSocketHub;
 
-    async function findAccount(
-      userId: string,
-      host?: string,
-    ): Promise<{ id: string; accessToken: string; providerId: string }> {
-      // 'single-user' is a placeholder — resolve to the actual user ID
-      let resolvedId = userId;
-      if (userId === "single-user" || !userId) {
-        const rows = await db.select({ id: user.id }).from(user).limit(1);
-        const firstRow = rows[0];
-        if (!firstRow) throw new Error("No user found");
-        resolvedId = firstRow.id;
-      }
+    // De-dupe concurrent refreshes of the same account — PollScheduler fans
+    // out per-repo and would otherwise fire N parallel refresh grants, each
+    // invalidating the previous one's rotated refresh token.
+    const refreshInFlight = new Map<string, Promise<string>>();
 
-      // Build ordered list of providerIds to try: specific host first, legacy fallback last.
-      // Legacy 'github' rows exist for users who signed in before the host-keyed migration.
-      const providerIds = host
-        ? [`github:${host}`, "github"]
-        : ["github:github.com", `github:${serverEnv.githubHost}`, "github"];
-
-      const rows = await db
-        .select({
-          id: account.id,
-          accessToken: account.accessToken,
-          providerId: account.providerId,
-        })
-        .from(account)
-        .where(eq(account.userId, resolvedId));
-
-      for (const pid of providerIds) {
-        const match = rows.find((r) => r.providerId === pid);
-        if (match?.accessToken) {
-          return match as { id: string; accessToken: string; providerId: string };
-        }
-      }
-
-      // Fallback: the priority list above is keyed on host=github.com, the
-      // configured GHE host, and the legacy 'github' provider. A user who
-      // signed in only against a *different* GHE host (e.g. nocturlab.ghe.com)
-      // and whose WS opens without a `host=` query param — which happens
-      // during account-switch, since settings.githubHost is reset to null
-      // before the WS reconnect — would miss every entry above and we'd
-      // hand back accountId='unresolved'. The WS then binds to no account
-      // and never receives the `broadcastToAccount(...)` PR updates the
-      // PollScheduler emits. Falling back to any account this user actually
-      // owns keeps single-account users always correct and gives multi-
-      // account users a deterministic-but-arbitrary pick that an explicit
-      // host param still overrides.
-      const anyAccount = rows.find((r) => r.accessToken);
-      if (anyAccount) {
-        return anyAccount as { id: string; accessToken: string; providerId: string };
-      }
-
-      throw new Error("No access token found");
+    /** Derive the GitHub host from a `github:{host}` (or legacy `github`) providerId. */
+    function hostFromProviderId(providerId: string): string {
+      return providerId.split(":")[1] ?? serverEnv.githubHost;
     }
 
+    async function doRefresh(accountId: string): Promise<string> {
+      const row = db
+        .select({
+          providerId: account.providerId,
+          refreshTokenExpiresAt: account.refreshTokenExpiresAt,
+        })
+        .from(account)
+        .where(eq(account.id, accountId))
+        .get();
+      if (!row) throw new Error(`account ${accountId} not found`);
+
+      const stored = await Effect.runPromise(secretStore.getTokens(accountId));
+      const refreshToken = stored?.refreshToken ?? null;
+      if (!refreshToken) throw new Error("no refresh token available");
+      if (row.refreshTokenExpiresAt && row.refreshTokenExpiresAt.getTime() < Date.now()) {
+        throw new Error("refresh token expired");
+      }
+
+      const host = hostFromProviderId(row.providerId);
+      const res = await fetch(tokenUrlForHost(host), {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: clientIdForHost(host),
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+        }),
+      });
+      const data = (await res.json()) as RefreshResponse;
+      if (!data.access_token) {
+        throw new Error(data.error ?? `refresh failed (HTTP ${res.status})`);
+      }
+
+      const now = new Date();
+      const newRefresh = data.refresh_token ?? refreshToken;
+      await Effect.runPromise(
+        secretStore.setTokens(accountId, {
+          accessToken: data.access_token,
+          refreshToken: newRefresh,
+        }),
+      );
+      db.update(account)
+        .set({
+          accessTokenExpiresAt: data.expires_in
+            ? new Date(now.getTime() + data.expires_in * 1000)
+            : null,
+          refreshTokenExpiresAt: data.refresh_token_expires_in
+            ? new Date(now.getTime() + data.refresh_token_expires_in * 1000)
+            : row.refreshTokenExpiresAt,
+          reauthRequiredAt: null,
+          updatedAt: now,
+        })
+        .where(eq(account.id, accountId))
+        .run();
+
+      await Effect.runPromise(
+        hub.broadcastToAccount(accountId, { type: "auth:reauth-cleared", data: { host } }),
+      );
+      return data.access_token;
+    }
+
+    const refreshAccountToken = (accountId: string): Effect.Effect<string, GitHubAuthError> =>
+      Effect.tryPromise({
+        try: () => {
+          const existing = refreshInFlight.get(accountId);
+          if (existing) return existing;
+          const p = doRefresh(accountId).finally(() => refreshInFlight.delete(accountId));
+          refreshInFlight.set(accountId, p);
+          return p;
+        },
+        catch: (e) => new GitHubAuthError({ message: String(e) }),
+      });
+
+    const markReauthRequired = (accountId: string): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const row = db
+          .select({ providerId: account.providerId, githubLogin: account.githubLogin })
+          .from(account)
+          .where(eq(account.id, accountId))
+          .get();
+        if (!row) return;
+        yield* Effect.sync(() =>
+          db
+            .update(account)
+            .set({ reauthRequiredAt: new Date(), updatedAt: new Date() })
+            .where(eq(account.id, accountId))
+            .run(),
+        );
+        yield* hub.broadcastToAccount(accountId, {
+          type: "auth:reauth-required",
+          data: { host: hostFromProviderId(row.providerId), githubLogin: row.githubLogin ?? null },
+        });
+      });
+
+    const storeAccountTokens = (
+      accountId: string,
+      host: string,
+      tokens: TokenPair,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        yield* secretStore.setTokens(accountId, tokens);
+        yield* hub.broadcastToAccount(accountId, {
+          type: "auth:reauth-cleared",
+          data: { host },
+        });
+      });
+
+    const deleteAccountTokens = (accountId: string): Effect.Effect<void> =>
+      secretStore.deleteTokens(accountId);
+
+    /** Refresh `accessToken` if it's within {@link REFRESH_SKEW_MS} of expiry
+     * and a refresh token exists. Best-effort: on refresh failure, return the
+     * existing token and let the eventual 401 drive `markReauthRequired`. */
+    const maybeRefresh = (
+      accountId: string,
+      accessTokenExpiresAt: Date | null,
+      accessToken: string,
+      refreshToken: string | null,
+    ): Effect.Effect<string> => {
+      const exp = accessTokenExpiresAt?.getTime();
+      const nearExpiry = exp != null && exp - Date.now() < REFRESH_SKEW_MS;
+      if (!nearExpiry || !refreshToken) return Effect.succeed(accessToken);
+      return refreshAccountToken(accountId).pipe(Effect.orElseSucceed(() => accessToken));
+    };
+
+    function resolveUserId(userId: string): string {
+      if (userId && userId !== "single-user") return userId;
+      const firstRow = db.select({ id: user.id }).from(user).limit(1).get();
+      if (!firstRow) throw new Error("No user found");
+      return firstRow.id;
+    }
+
+    /** Resolve the active account (id + provider + a valid token) for a user. */
+    const resolveValid = (
+      userId: string,
+      host?: string,
+    ): Effect.Effect<
+      { accountId: string; accessToken: string; providerId: string },
+      GitHubAuthError
+    > =>
+      Effect.gen(function* () {
+        const resolvedId = yield* Effect.try({
+          try: () => resolveUserId(userId),
+          catch: (e) => new GitHubAuthError({ message: String(e) }),
+        });
+
+        const rows = db
+          .select({
+            id: account.id,
+            providerId: account.providerId,
+            accessTokenExpiresAt: account.accessTokenExpiresAt,
+          })
+          .from(account)
+          .where(eq(account.userId, resolvedId))
+          .all();
+
+        // Priority order: requested host first, then defaults, then the
+        // legacy 'github' provider. Falls back to any remaining account the
+        // user owns (mirrors the prior behavior for non-default GHE hosts that
+        // open a WS without a `host=` param — see git history).
+        const providerIds = host
+          ? [`github:${host}`, "github"]
+          : ["github:github.com", `github:${serverEnv.githubHost}`, "github"];
+        const ordered: typeof rows = [];
+        for (const pid of providerIds) {
+          const m = rows.find((r) => r.providerId === pid);
+          if (m && !ordered.includes(m)) ordered.push(m);
+        }
+        for (const r of rows) if (!ordered.includes(r)) ordered.push(r);
+
+        for (const meta of ordered) {
+          const stored = yield* secretStore.getTokens(meta.id);
+          if (!stored?.accessToken) continue;
+          const token = yield* maybeRefresh(
+            meta.id,
+            meta.accessTokenExpiresAt,
+            stored.accessToken,
+            stored.refreshToken,
+          );
+          return { accountId: meta.id, accessToken: token, providerId: meta.providerId };
+        }
+        return yield* Effect.fail(new GitHubAuthError({ message: "No access token found" }));
+      });
+
     return {
-      getGitHubToken: (userId: string, host?: string) =>
-        Effect.tryPromise({
-          try: async () => {
-            const match = await findAccount(userId, host);
-            return match.accessToken;
-          },
-          catch: (e) => new GitHubAuthError({ message: String(e) }),
+      getGitHubToken: (userId, host) =>
+        resolveValid(userId, host).pipe(Effect.map((r) => r.accessToken)),
+
+      resolveAccount: (userId, host) => resolveValid(userId, host),
+
+      getTokenByAccountId: (accountId) =>
+        Effect.gen(function* () {
+          const row = db
+            .select({ accessTokenExpiresAt: account.accessTokenExpiresAt })
+            .from(account)
+            .where(eq(account.id, accountId))
+            .get();
+          const stored = yield* secretStore.getTokens(accountId);
+          if (!stored?.accessToken) {
+            return yield* Effect.fail(
+              new GitHubAuthError({ message: `No access token for account ${accountId}` }),
+            );
+          }
+          return yield* maybeRefresh(
+            accountId,
+            row?.accessTokenExpiresAt ?? null,
+            stored.accessToken,
+            stored.refreshToken,
+          );
         }),
 
-      resolveAccount: (userId: string, host?: string) =>
-        Effect.tryPromise({
-          try: async () => {
-            const match = await findAccount(userId, host);
-            return {
-              accountId: match.id,
-              accessToken: match.accessToken,
-              providerId: match.providerId,
-            };
-          },
-          catch: (e) => new GitHubAuthError({ message: String(e) }),
-        }),
-
-      getTokenByAccountId: (accountId: string) =>
-        Effect.tryPromise({
-          try: async () => {
-            const row = await db
-              .select({ accessToken: account.accessToken })
-              .from(account)
-              .where(eq(account.id, accountId))
-              .then((r) => r[0] ?? null);
-            if (!row?.accessToken) {
-              throw new Error(`No access token for account ${accountId}`);
-            }
-            return row.accessToken;
-          },
-          catch: (e) => new GitHubAuthError({ message: String(e) }),
-        }),
+      storeAccountTokens,
+      deleteAccountTokens,
+      refreshAccountToken,
+      markReauthRequired,
     };
   }),
 );

--- a/apps/server/src/services/TokenProvider.ts
+++ b/apps/server/src/services/TokenProvider.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import { Context, Effect, Layer } from "effect";
+import { Context, Deferred, Effect, Layer, Ref } from "effect";
 import { serverEnv } from "../config";
 import { account, user } from "../db/schema";
 import { GitHubAuthError } from "../domain/errors";
@@ -97,85 +97,113 @@ export const TokenProviderLive = Layer.effect(
 
     // De-dupe concurrent refreshes of the same account — PollScheduler fans
     // out per-repo and would otherwise fire N parallel refresh grants, each
-    // invalidating the previous one's rotated refresh token.
-    const refreshInFlight = new Map<string, Promise<string>>();
+    // invalidating the previous one's rotated refresh token. Holds the
+    // in-flight grant per account as a Deferred so followers await the leader.
+    const refreshInFlight = yield* Ref.make(
+      new Map<string, Deferred.Deferred<string, GitHubAuthError>>(),
+    );
 
     /** Derive the GitHub host from a `github:{host}` (or legacy `github`) providerId. */
     function hostFromProviderId(providerId: string): string {
       return providerId.split(":")[1] ?? serverEnv.githubHost;
     }
 
-    async function doRefresh(accountId: string): Promise<string> {
-      const row = db
-        .select({
-          providerId: account.providerId,
-          refreshTokenExpiresAt: account.refreshTokenExpiresAt,
-        })
-        .from(account)
-        .where(eq(account.id, accountId))
-        .get();
-      if (!row) throw new Error(`account ${accountId} not found`);
+    /** Exchange the stored refresh token for a fresh access token. Composed as
+     * an Effect end-to-end — secret-store reads/writes and the WS broadcast are
+     * `yield*`-ed rather than escaped via `Effect.runPromise` (CLAUDE.md §2). */
+    const doRefresh = (accountId: string): Effect.Effect<string, GitHubAuthError> =>
+      Effect.gen(function* () {
+        const row = db
+          .select({
+            providerId: account.providerId,
+            refreshTokenExpiresAt: account.refreshTokenExpiresAt,
+          })
+          .from(account)
+          .where(eq(account.id, accountId))
+          .get();
+        if (!row) {
+          return yield* Effect.fail(
+            new GitHubAuthError({ message: `account ${accountId} not found` }),
+          );
+        }
 
-      const stored = await Effect.runPromise(secretStore.getTokens(accountId));
-      const refreshToken = stored?.refreshToken ?? null;
-      if (!refreshToken) throw new Error("no refresh token available");
-      if (row.refreshTokenExpiresAt && row.refreshTokenExpiresAt.getTime() < Date.now()) {
-        throw new Error("refresh token expired");
-      }
+        const stored = yield* secretStore.getTokens(accountId);
+        const refreshToken = stored?.refreshToken ?? null;
+        if (!refreshToken) {
+          return yield* Effect.fail(new GitHubAuthError({ message: "no refresh token available" }));
+        }
+        if (row.refreshTokenExpiresAt && row.refreshTokenExpiresAt.getTime() < Date.now()) {
+          return yield* Effect.fail(new GitHubAuthError({ message: "refresh token expired" }));
+        }
 
-      const host = hostFromProviderId(row.providerId);
-      const res = await fetch(tokenUrlForHost(host), {
-        method: "POST",
-        headers: { Accept: "application/json", "Content-Type": "application/json" },
-        body: JSON.stringify({
-          client_id: clientIdForHost(host),
-          grant_type: "refresh_token",
-          refresh_token: refreshToken,
-        }),
+        const host = hostFromProviderId(row.providerId);
+        const { status, data } = yield* Effect.tryPromise({
+          try: async () => {
+            const res = await fetch(tokenUrlForHost(host), {
+              method: "POST",
+              headers: { Accept: "application/json", "Content-Type": "application/json" },
+              body: JSON.stringify({
+                client_id: clientIdForHost(host),
+                grant_type: "refresh_token",
+                refresh_token: refreshToken,
+              }),
+            });
+            return { status: res.status, data: (await res.json()) as RefreshResponse };
+          },
+          catch: (e) => new GitHubAuthError({ message: String(e) }),
+        });
+        if (!data.access_token) {
+          return yield* Effect.fail(
+            new GitHubAuthError({ message: data.error ?? `refresh failed (HTTP ${status})` }),
+          );
+        }
+
+        const now = new Date();
+        const accessToken = data.access_token;
+        const newRefresh = data.refresh_token ?? refreshToken;
+        yield* secretStore.setTokens(accountId, { accessToken, refreshToken: newRefresh });
+        yield* Effect.sync(() =>
+          db
+            .update(account)
+            .set({
+              accessTokenExpiresAt: data.expires_in
+                ? new Date(now.getTime() + data.expires_in * 1000)
+                : null,
+              refreshTokenExpiresAt: data.refresh_token_expires_in
+                ? new Date(now.getTime() + data.refresh_token_expires_in * 1000)
+                : row.refreshTokenExpiresAt,
+              reauthRequiredAt: null,
+              updatedAt: now,
+            })
+            .where(eq(account.id, accountId))
+            .run(),
+        );
+
+        yield* hub.broadcastToAccount(accountId, { type: "auth:reauth-cleared", data: { host } });
+        return accessToken;
       });
-      const data = (await res.json()) as RefreshResponse;
-      if (!data.access_token) {
-        throw new Error(data.error ?? `refresh failed (HTTP ${res.status})`);
-      }
-
-      const now = new Date();
-      const newRefresh = data.refresh_token ?? refreshToken;
-      await Effect.runPromise(
-        secretStore.setTokens(accountId, {
-          accessToken: data.access_token,
-          refreshToken: newRefresh,
-        }),
-      );
-      db.update(account)
-        .set({
-          accessTokenExpiresAt: data.expires_in
-            ? new Date(now.getTime() + data.expires_in * 1000)
-            : null,
-          refreshTokenExpiresAt: data.refresh_token_expires_in
-            ? new Date(now.getTime() + data.refresh_token_expires_in * 1000)
-            : row.refreshTokenExpiresAt,
-          reauthRequiredAt: null,
-          updatedAt: now,
-        })
-        .where(eq(account.id, accountId))
-        .run();
-
-      await Effect.runPromise(
-        hub.broadcastToAccount(accountId, { type: "auth:reauth-cleared", data: { host } }),
-      );
-      return data.access_token;
-    }
 
     const refreshAccountToken = (accountId: string): Effect.Effect<string, GitHubAuthError> =>
-      Effect.tryPromise({
-        try: () => {
-          const existing = refreshInFlight.get(accountId);
-          if (existing) return existing;
-          const p = doRefresh(accountId).finally(() => refreshInFlight.delete(accountId));
-          refreshInFlight.set(accountId, p);
-          return p;
-        },
-        catch: (e) => new GitHubAuthError({ message: String(e) }),
+      Effect.gen(function* () {
+        // Atomically claim the in-flight slot: the leader installs its own
+        // Deferred and runs the grant; followers receive the leader's Deferred
+        // and await its outcome instead of issuing a second grant.
+        const own = yield* Deferred.make<string, GitHubAuthError>();
+        const leader = yield* Ref.modify(refreshInFlight, (m) => {
+          const existing = m.get(accountId);
+          if (existing) return [existing, m] as const;
+          return [own, new Map(m).set(accountId, own)] as const;
+        });
+        if (leader !== own) return yield* Deferred.await(leader);
+
+        const exit = yield* Effect.exit(doRefresh(accountId));
+        yield* Ref.update(refreshInFlight, (m) => {
+          const next = new Map(m);
+          next.delete(accountId);
+          return next;
+        });
+        yield* Deferred.done(own, exit);
+        return yield* Deferred.await(own);
       });
 
     const markReauthRequired = (accountId: string): Effect.Effect<void> =>

--- a/apps/server/src/services/cache-eligibility.ts
+++ b/apps/server/src/services/cache-eligibility.ts
@@ -20,6 +20,7 @@ import { debug } from "../logger";
 import { DbService } from "./Db";
 import { GitHubService } from "./GitHub";
 import { SettingsService } from "./Settings";
+import { TokenProvider } from "./TokenProvider";
 
 type PermLevel = "admin" | "maintain" | "write" | "triage" | "read" | "none";
 
@@ -73,6 +74,7 @@ export const CacheEligibilityLive = Layer.effect(
     const settingsSvc = yield* SettingsService;
     const githubSvc = yield* GitHubService;
     const { db } = yield* DbService;
+    const tokenProvider = yield* TokenProvider;
 
     const permCache = new Map<string, CacheEntry>();
 
@@ -89,25 +91,27 @@ export const CacheEligibilityLive = Layer.effect(
       return null;
     }
 
-    function getLocalAccountsForHost(targetHost: string): { login: string; token: string } | null {
+    function getLocalAccountForHost(
+      targetHost: string,
+    ): { accountId: string; login: string } | null {
       const firstUser = db.select({ id: user.id }).from(user).limit(1).get();
       if (!firstUser) return null;
 
       const rows = db
         .select({
+          id: account.id,
           providerId: account.providerId,
           githubLogin: account.githubLogin,
-          accessToken: account.accessToken,
         })
         .from(account)
         .where(eq(account.userId, firstUser.id))
         .all();
 
       for (const row of rows) {
-        if (!row.githubLogin || !row.accessToken) continue;
+        if (!row.githubLogin) continue;
         const host = extractHostFromProviderId(row.providerId);
         if (host === targetHost) {
-          return { login: row.githubLogin, token: row.accessToken };
+          return { accountId: row.id, login: row.githubLogin };
         }
       }
       return null;
@@ -177,19 +181,17 @@ export const CacheEligibilityLive = Layer.effect(
           const host = settings?.githubHost ?? "github.com";
 
           const localAcct = yield* Effect.try({
-            try: () => getLocalAccountsForHost(host),
+            try: () => getLocalAccountForHost(host),
             catch: () => null,
           }).pipe(Effect.catchAll(() => Effect.succeed(null)));
 
           if (!localAcct) return false;
+          const token = yield* tokenProvider
+            .getTokenByAccountId(localAcct.accountId)
+            .pipe(Effect.catchAll(() => Effect.succeed(null)));
+          if (!token) return false;
 
-          const perm = yield* resolvePermission(
-            host,
-            owner,
-            repo,
-            localAcct.login,
-            localAcct.token,
-          );
+          const perm = yield* resolvePermission(host, owner, repo, localAcct.login, token);
           return isEligible(perm);
         }).pipe(Effect.catchAll(() => Effect.succeed(false))),
 
@@ -209,19 +211,17 @@ export const CacheEligibilityLive = Layer.effect(
 
           // Use the local user's token for this host to query the signer's permission.
           const localAcct = yield* Effect.try({
-            try: () => getLocalAccountsForHost(signerHost),
+            try: () => getLocalAccountForHost(signerHost),
             catch: () => null,
           }).pipe(Effect.catchAll(() => Effect.succeed(null)));
 
           if (!localAcct) return false;
+          const token = yield* tokenProvider
+            .getTokenByAccountId(localAcct.accountId)
+            .pipe(Effect.catchAll(() => Effect.succeed(null)));
+          if (!token) return false;
 
-          const perm = yield* resolvePermission(
-            signerHost,
-            owner,
-            repo,
-            signerLogin,
-            localAcct.token,
-          );
+          const perm = yield* resolvePermission(signerHost, owner, repo, signerLogin, token);
           return isEligible(perm);
         }).pipe(Effect.catchAll(() => Effect.succeed(false))),
     });

--- a/apps/server/src/services/cache-signing/index.ts
+++ b/apps/server/src/services/cache-signing/index.ts
@@ -56,7 +56,7 @@ const SSH_KEY_PATTERNS = /^id_(ed25519|ecdsa|rsa)$/;
 
 function findAccountWithLoginSync(
   db: Db,
-): { host: string; login: string; githubUserId: string; accessToken: string } | null {
+): { host: string; login: string; githubUserId: string } | null {
   const firstUser = db.select({ id: user.id }).from(user).limit(1).get();
   if (!firstUser) return null;
 
@@ -65,19 +65,20 @@ function findAccountWithLoginSync(
       providerId: account.providerId,
       githubLogin: account.githubLogin,
       accountId: account.accountId,
-      accessToken: account.accessToken,
     })
     .from(account)
     .where(eq(account.userId, firstUser.id))
     .all();
 
+  // A linked account always carries `githubLogin` + `accountId`; the access
+  // token (now held in the OS secure store, not the DB) isn't needed here —
+  // SSH cache signing uses the local SSH key, not the GitHub token.
   for (const row of rows) {
-    if (row.githubLogin && row.accessToken && row.accountId) {
+    if (row.githubLogin && row.accountId) {
       return {
         host: extractHostFromProviderId(row.providerId),
         login: row.githubLogin,
         githubUserId: row.accountId,
-        accessToken: row.accessToken,
       };
     }
   }

--- a/apps/web/src/lib/components/auth/ReauthModal.svelte
+++ b/apps/web/src/lib/components/auth/ReauthModal.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+import { GithubLogo, WarningCircle } from "phosphor-svelte";
+import { gsapFade, gsapFadeY, tokens } from "$lib/motion";
+import {
+  cancelSignIn,
+  getDeviceFlow,
+  getError,
+  getIsLoading,
+  getReauthRequired,
+  signIn,
+} from "$lib/stores/auth.svelte";
+
+const reauth = $derived(getReauthRequired());
+const deviceFlow = $derived(getDeviceFlow());
+const error = $derived(getError());
+const isLoading = $derived(getIsLoading());
+
+let copied = $state(false);
+
+async function copyCode(): Promise<void> {
+  if (!deviceFlow) return;
+  await navigator.clipboard.writeText(deviceFlow.userCode);
+  copied = true;
+  setTimeout(() => (copied = false), 2000);
+}
+
+function startReauth(): void {
+  // Re-auth against the same GitHub host the expired account belongs to so
+  // GHE accounts land on the right instance.
+  void signIn(reauth?.host ?? undefined);
+}
+</script>
+
+{#if reauth}
+	<div
+		class="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-6 supports-backdrop-filter:backdrop-blur-sm"
+		in:gsapFade={{ duration: tokens.smooth }}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="reauth-title"
+	>
+		<div
+			class="flex w-full max-w-md flex-col items-center gap-5 rounded-xl border border-border bg-bg-elevated p-8 text-center shadow-xl"
+			in:gsapFadeY={{ y: 12, duration: tokens.smooth }}
+		>
+			<div class="flex size-12 items-center justify-center rounded-full bg-warning/10 text-warning">
+				<WarningCircle size={28} weight="duotone" />
+			</div>
+
+			<div class="flex flex-col gap-1.5">
+				<h2 id="reauth-title" class="text-lg font-semibold text-text-primary">
+					GitHub session expired
+				</h2>
+				<p class="text-sm text-text-secondary">
+					{#if reauth.githubLogin}
+						Your token for <span class="font-medium text-text-primary">{reauth.githubLogin}</span>
+						{#if reauth.host}on {reauth.host}{/if} is no longer valid.
+					{:else}
+						Your GitHub token is no longer valid.
+					{/if}
+					Sign in again to keep syncing pull requests.
+				</p>
+			</div>
+
+			{#if deviceFlow}
+				<div class="flex flex-col items-center gap-4">
+					<p class="text-sm text-text-secondary">Enter this code on GitHub:</p>
+					<div
+						class="flex items-center gap-2 rounded-lg border border-border bg-bg-tertiary px-6 py-3"
+					>
+						<span class="font-mono text-2xl font-bold tracking-widest text-text-primary">
+							{deviceFlow.userCode}
+						</span>
+						<button
+							onclick={copyCode}
+							class="ml-1 cursor-pointer rounded p-1 text-text-muted transition-colors hover:bg-bg-elevated hover:text-text-primary"
+							aria-label="Copy code"
+						>
+							{copied ? "Copied" : "Copy"}
+						</button>
+					</div>
+					<a
+						href={deviceFlow.verificationUri}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="text-xs text-accent hover:underline"
+					>
+						{deviceFlow.verificationUri}
+					</a>
+					<p class="text-xs text-text-muted">Waiting for authorization…</p>
+					<button
+						class="cursor-pointer text-xs text-text-muted underline hover:text-text-secondary"
+						onclick={cancelSignIn}
+					>
+						Cancel
+					</button>
+				</div>
+			{:else}
+				{#if error}
+					<p class="text-sm text-danger">{error}</p>
+				{/if}
+				<button
+					class="flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-bg-tertiary px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+					onclick={startReauth}
+					disabled={isLoading}
+				>
+					<GithubLogo size={18} weight="fill" />
+					Sign in again
+				</button>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/apps/web/src/lib/components/onboarding/OnboardingGate.svelte
+++ b/apps/web/src/lib/components/onboarding/OnboardingGate.svelte
@@ -11,6 +11,7 @@ import {
   getUser,
   resetForceOnboardingFlow,
 } from "$lib/stores/auth.svelte";
+import ReauthModal from "../auth/ReauthModal.svelte";
 import AccountPicker from "./AccountPicker.svelte";
 import OnboardingFlow from "./OnboardingFlow.svelte";
 
@@ -76,6 +77,9 @@ function handleNewAccount() {
 		<div class="root" in:gsapFade={{ duration: tokens.slow }}>
 			{@render children()}
 		</div>
+		<!-- Blocking re-auth gate: overlays the app (kept mounted) when the
+		     active account's GitHub token expired and couldn't be refreshed. -->
+		<ReauthModal />
 	{:else if showPicker && !pickerDismissed}
 		<AccountPicker onNewAccount={handleNewAccount} />
 	{:else}

--- a/apps/web/src/lib/components/sidebar/UserMenu.svelte
+++ b/apps/web/src/lib/components/sidebar/UserMenu.svelte
@@ -285,10 +285,6 @@ async function handleSignOut(): Promise<void> {
 		flex-shrink: 0;
 	}
 
-	.user-avatar--collapsed {
-		/* No size change — parent shrink handles the visual effect */
-	}
-
 	.user-avatar--fallback {
 		display: inline-flex;
 		align-items: center;

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -61,6 +61,29 @@ let _connectedAccounts = $state<ConnectedAccount[]>([]);
 let localAccounts = $state<LocalAccount[]>([]);
 let accountJustRemoved = $state(false);
 
+/**
+ * Set when the active account's GitHub token is invalid and could not be
+ * silently refreshed. Drives the blocking re-sign-in modal. Hydrated from
+ * `/api/user/identity` on boot and updated live by the `auth:reauth-required`
+ * / `auth:reauth-cleared` WS handlers. Cleared on successful re-auth.
+ */
+let reauthRequired = $state<{ host: string | null; githubLogin: string | null } | null>(null);
+
+export function getReauthRequired(): { host: string | null; githubLogin: string | null } | null {
+  return reauthRequired;
+}
+
+export function setReauthRequired(value: {
+  host: string | null;
+  githubLogin: string | null;
+}): void {
+  reauthRequired = value;
+}
+
+export function clearReauthRequired(): void {
+  reauthRequired = null;
+}
+
 export function getLocalAccounts(): LocalAccount[] {
   return localAccounts;
 }
@@ -230,6 +253,10 @@ async function poll(): Promise<void> {
     if (data.status === "linked") {
       deviceFlow = null;
       _isPolling = false;
+      // Re-auth of the active account lands here (session_token was sent).
+      // Clear the gate immediately; the server also broadcasts
+      // `auth:reauth-cleared`, but clearing here avoids modal flicker.
+      reauthRequired = null;
       await fetchConnectedAccounts();
       await focusWindow();
       return;
@@ -239,6 +266,7 @@ async function poll(): Promise<void> {
       setToken(data.token);
       deviceFlow = null;
       _isPolling = false;
+      reauthRequired = null;
       await loadUser();
       await focusWindow();
       // Auto-open-add-repo on sign-in used to live here. The onboarding
@@ -303,6 +331,8 @@ export async function loadUser(): Promise<void> {
             login: string | null;
             avatarContent?: string | null;
             onboardedAt?: string | null;
+            reauthRequired?: boolean;
+            host?: string | null;
           };
           if (user) {
             const next: typeof user = {
@@ -317,6 +347,10 @@ export async function loadUser(): Promise<void> {
             user = next;
             accountJustRemoved = false;
           }
+          // Reconcile the re-auth gate from the authoritative server state.
+          reauthRequired = data.reauthRequired
+            ? { host: data.host ?? null, githubLogin: data.login }
+            : null;
         }
       } catch {
         // best-effort

--- a/apps/web/src/lib/stores/ws.svelte.ts
+++ b/apps/web/src/lib/stores/ws.svelte.ts
@@ -1,7 +1,7 @@
 import type { SyncChange, WsServerMessage } from "@revv/shared";
 import { toast } from "svelte-sonner";
 import { WS_BASE_URL } from "$lib/api/base-url";
-import { applyUserUpdate } from "./auth.svelte";
+import { applyUserUpdate, clearReauthRequired, setReauthRequired } from "./auth.svelte";
 import { onChatQuestionResolved } from "./chat.svelte";
 import { setError } from "./errors.svelte";
 import {
@@ -125,6 +125,12 @@ function dispatchMessage(msg: WsServerMessage): void {
       break;
     case "error":
       setError(msg.data);
+      break;
+    case "auth:reauth-required":
+      setReauthRequired({ host: msg.data.host, githubLogin: msg.data.githubLogin });
+      break;
+    case "auth:reauth-cleared":
+      clearReauthRequired();
       break;
     case "thread:created":
       onThreadCreated(msg.data.thread, msg.data.message);

--- a/bun.lock
+++ b/bun.lock
@@ -15,13 +15,14 @@
     },
     "apps/server": {
       "name": "@revv/server",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.142",
         "@effect/opentelemetry": "^0.63.0",
         "@effect/platform": "^0.96.0",
         "@elysiajs/cors": "^1",
         "@google-cloud/storage": "^7.13.0",
+        "@napi-rs/keyring": "^1.3.0",
         "@opencode-ai/sdk": "1.15.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/core": "^2.7.1",
@@ -49,7 +50,7 @@
     },
     "apps/web": {
       "name": "@revv/web",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@elysiajs/eden": "^1.4.9",
         "@internationalized/date": "^3.12.0",
@@ -91,7 +92,7 @@
     },
     "packages/app": {
       "name": "@revv/app",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@revv/ui": "workspace:*",
         "@tanstack/react-router": "^1.168.0",
@@ -112,14 +113,14 @@
     },
     "packages/shared": {
       "name": "@revv/shared",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "typescript": "^5.7.0",
       },
     },
     "packages/ui": {
       "name": "@revv/ui",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.4",
@@ -370,6 +371,32 @@
     "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
+    "@napi-rs/keyring": ["@napi-rs/keyring@1.3.0", "", { "optionalDependencies": { "@napi-rs/keyring-darwin-arm64": "1.3.0", "@napi-rs/keyring-darwin-x64": "1.3.0", "@napi-rs/keyring-freebsd-x64": "1.3.0", "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0", "@napi-rs/keyring-linux-arm64-gnu": "1.3.0", "@napi-rs/keyring-linux-arm64-musl": "1.3.0", "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0", "@napi-rs/keyring-linux-x64-gnu": "1.3.0", "@napi-rs/keyring-linux-x64-musl": "1.3.0", "@napi-rs/keyring-win32-arm64-msvc": "1.3.0", "@napi-rs/keyring-win32-ia32-msvc": "1.3.0", "@napi-rs/keyring-win32-x64-msvc": "1.3.0" } }, "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA=="],
+
+    "@napi-rs/keyring-darwin-arm64": ["@napi-rs/keyring-darwin-arm64@1.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ=="],
+
+    "@napi-rs/keyring-darwin-x64": ["@napi-rs/keyring-darwin-x64@1.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw=="],
+
+    "@napi-rs/keyring-freebsd-x64": ["@napi-rs/keyring-freebsd-x64@1.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw=="],
+
+    "@napi-rs/keyring-linux-arm-gnueabihf": ["@napi-rs/keyring-linux-arm-gnueabihf@1.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ=="],
+
+    "@napi-rs/keyring-linux-arm64-gnu": ["@napi-rs/keyring-linux-arm64-gnu@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg=="],
+
+    "@napi-rs/keyring-linux-arm64-musl": ["@napi-rs/keyring-linux-arm64-musl@1.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw=="],
+
+    "@napi-rs/keyring-linux-riscv64-gnu": ["@napi-rs/keyring-linux-riscv64-gnu@1.3.0", "", { "os": "linux", "cpu": "none" }, "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ=="],
+
+    "@napi-rs/keyring-linux-x64-gnu": ["@napi-rs/keyring-linux-x64-gnu@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A=="],
+
+    "@napi-rs/keyring-linux-x64-musl": ["@napi-rs/keyring-linux-x64-musl@1.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw=="],
+
+    "@napi-rs/keyring-win32-arm64-msvc": ["@napi-rs/keyring-win32-arm64-msvc@1.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw=="],
+
+    "@napi-rs/keyring-win32-ia32-msvc": ["@napi-rs/keyring-win32-ia32-msvc@1.3.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ=="],
+
+    "@napi-rs/keyring-win32-x64-msvc": ["@napi-rs/keyring-win32-x64-msvc@1.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -8,21 +8,28 @@ for the same `(repo, headSha)`, every other teammate skips the agent run and
 hydrates from the bucket instead — instant, zero token spend.
 
 Off by default. Enable per-machine in **Settings → Team Cache**. Each teammate
-points their Revv at the same bucket and pastes a service-account JSON.
+points their Revv at the same bucket and authenticates with Google Cloud's
+Application Default Credentials (see [Per-machine setup](#per-machine-setup)) —
+no service-account JSON to copy around.
 
 ## Architecture in one paragraph
 
 The cache key is content-addressable on `<owner>/<repo>/<headSha>.json.gz`. The
 local server gzips a `WalkthroughSnapshotV1` (see
 `packages/shared/src/cache.ts`) and uploads it to the bucket on every
-successful generation. Before kicking off the agent for any PR, the server
-asks the bucket whether that key exists; on a hit it downloads, verifies the
-integrity metadata (`schemaVersion`, `contentSha256`), runs the snapshot
-through the same validation gate as `complete_walkthrough`, then bulk-imports
-into a fresh row in one transaction. The orchestrator then flips status to
-`'complete'` and the existing `walkthrough:complete` broadcast does the rest.
-On any error, fall back to running the agent normally — no half-imported rows
-ever exist.
+successful generation — but only after an eligibility check (the local user
+must currently hold `write` on the repo) and, unless signing is `off`, after
+SSHSIG-signing the payload with the user's GitHub SSH key. Before kicking off
+the agent for any PR, the server asks the bucket whether that key exists; on a
+hit it downloads, verifies the integrity metadata (`schemaVersion`,
+`contentSha256`), then verifies the **signature** (signer host is trusted, the
+SSHSIG matches the signer's published GitHub keys, and the signer still holds
+`write` on the repo), runs the snapshot through the same validation gate as
+`complete_walkthrough`, and finally bulk-imports into a fresh row in one
+transaction. The orchestrator then flips status to `'complete'` and the
+existing `walkthrough:complete` broadcast does the rest. On any error — or any
+failed signature check in `strict` mode — fall back to running the agent
+normally (treated as a cache miss); no half-imported rows ever exist.
 
 ## Bucket setup
 
@@ -73,22 +80,92 @@ Then open Revv → Settings → Team Cache, enter the bucket name, and click **T
 
 ## Threat model
 
-**What this protects.** Confidentiality and integrity of the cached payloads
-are gated by GCS IAM. Bucket access = team membership. The `contentSha256`
-metadata is cross-checked on every download, so silent corruption of the
-gzipped body is caught and downgraded to a cache miss.
+The cache rests on **two independent layers**: GCS IAM (who can read/write the
+bucket at all) and SSHSIG artifact signing (who is allowed to *author* an
+entry your machine will trust). IAM is the confidentiality boundary; signing is
+the authenticity/integrity boundary.
 
-**What this does NOT protect.** Anyone with read access to the bucket can
-read *every* walkthrough in it, regardless of which GitHub repositories they
-have access to. **This is acceptable because the bucket IAM grant list is
-the team boundary** — teammates with bucket access are already trusted with
-all the repos the team is working on. If you need per-repo ACL enforcement
-(e.g. a contractor who can read repo A but not repo B), do not enable the
-cache for cross-trust-boundary teammates; let them run the agent locally.
+### Layer 1 — confidentiality (GCS IAM)
 
-A future hosted variant could reintroduce per-request GitHub-token-based
+Read/write access to the cached payloads is gated by GCS IAM. Bucket access =
+team membership. Anyone with read access to the bucket can read *every*
+walkthrough in it, regardless of which GitHub repositories they have access to.
+**This is acceptable because the bucket IAM grant list is the team boundary** —
+teammates with bucket access are already trusted with all the repos the team is
+working on. If you need per-repo *read* ACL enforcement (e.g. a contractor who
+can read repo A but not repo B), do not enable the cache for cross-trust-
+boundary teammates; let them run the agent locally.
+
+A future hosted variant could reintroduce per-request GitHub-token-based read
 ACL enforcement via a tiny Cloud Function fronting the bucket. The client
 abstraction (`BlobStore`) doesn't change.
+
+### Layer 2 — authenticity & integrity (SSHSIG signing)
+
+IAM alone says nothing about *whether the content you downloaded is genuine*.
+A teammate with bucket write access (or a leaked/over-broad service account)
+could otherwise overwrite any key with a poisoned walkthrough, and every other
+machine would import it. Signing closes that gap: a cache entry is only trusted
+if it was authored by a GitHub identity that **currently holds `write` on the
+target repo**, proven cryptographically.
+
+**On push** (`RemoteWalkthroughCache.push`):
+
+1. **Eligibility gate** — `CacheEligibility.canPush` checks, via the GitHub
+   collaborator-permission API, that the local user has at least `write` on the
+   repo. Read-only contributors still get cache *hits*; they simply never push.
+2. **Sign** (when `mode != 'off'`) — the server signs the canonical message
+   `revv-cache:v1\n<repoFullName>\n<headSha>\n<contentSha256>` (see
+   `cacheSigningMessage` in `packages/shared/src/cache.ts`) with SSHSIG via
+   `ssh-keygen -Y sign`, namespace `revv-cache@<host>`. The signing key is the
+   user's local SSH private key — auto-detected by matching `~/.ssh/id_*`
+   against the keys the user has published at `https://<host>/<login>.keys`, or
+   set explicitly via `cache.signing.keyPath`. The signature binds the entry to
+   `(repo, headSha, content hash)`; the body bytes are already covered by
+   `contentSha256`, so the signed message stays tiny.
+3. The signature plus signer identity (`signerHost`, `signerLogin`,
+   `signerGithubUserId`, `signatureNamespace`) ride along as GCS custom
+   metadata (`CACHE_METADATA_KEYS`).
+
+**On fetch** (`RemoteWalkthroughCache.fetch`), when `mode != 'off'`, every
+entry must clear, in order:
+
+1. `schemaVersion` matches `CACHE_SCHEMA_VERSION`.
+2. `contentSha256` matches a fresh hash of the gzipped body (catches silent
+   corruption).
+3. Signature, `signerHost`, and `signerLogin` are all present (else the blob is
+   "unsigned" — see modes below).
+4. `signerHost` is in the local `cache.signing.trustedSignerHosts` allow-list.
+   **An untrusted host is always a miss, in every mode** (this check sits ahead
+   of the network round-trip).
+5. The SSHSIG verifies against the signer's currently-published keys at
+   `https://<signerHost>/<signerLogin>.keys` (via `ssh-keygen -Y verify`).
+6. `CacheEligibility.isSignerEligible` confirms the signer *still* holds
+   `write` on the repo. Revoking a teammate's repo access revokes their cache
+   authority on the next verification (subject to a short permission-cache TTL).
+
+Steps 3, 5, and 6 are the ones whose *severity* depends on the mode.
+
+### Signing modes (`cache.signing.mode`, default `strict`)
+
+| Mode | On push | On fetch |
+|---|---|---|
+| `strict` *(default)* | Sign every upload. | Reject (treat as miss) any blob that is unsigned, fails verification, comes from an untrusted host, or whose signer lacks `write`. |
+| `permissive` | Sign every upload. | Verify, but **downgrade failures to warnings and import anyway** — *except* an untrusted `signerHost`, which is still a hard miss. Useful for rollout while teammates publish keys / populate trusted hosts. |
+| `off` | Do not sign. | Do not verify — trust IAM alone. |
+
+> **Gotcha — trusted hosts start empty.** `cache.signing.trustedSignerHosts`
+> defaults to `[]`. Because an untrusted host is a miss in *every* mode, a fresh
+> install left in `strict` with no hosts added will treat **every** signed entry
+> as a miss. Add your GitHub host (e.g. `github.com` or your Enterprise host) to
+> the trusted list in **Settings → Team Cache** before expecting hits.
+
+**What signing does NOT protect.** It is an *authenticity* control, not a read
+ACL — it doesn't stop a bucket reader from seeing content (that's Layer 1).
+It also trusts GitHub's published-keys endpoint and the collaborator-permission
+API as the source of truth for identity and authority; if those are
+compromised, so is signing. And `off`/`permissive` modes are exactly as strong
+as you'd expect — only `strict` gives the full guarantee.
 
 ### What we never put in the bucket
 
@@ -106,6 +183,14 @@ OAuth token is stored by the Google Cloud SDK in the standard OS location
 never sees or stores the credential itself — the `@google-cloud/storage`
 SDK reads it directly from that location. This removes the need for manual
 service-account keys entirely.
+
+**SSH signing key.** Artifact signing uses your existing local SSH private key
+— the same one you push to GitHub with. Revv never reads, copies, or transmits
+the private key: signing happens by shelling out to `ssh-keygen -Y sign`, which
+reads the key from disk itself. The matching *public* key must be published on
+your GitHub host (`https://<host>/<login>.keys`) so teammates can verify your
+signatures. Revv auto-detects which `~/.ssh/id_*` to use by matching against
+your published keys; override with `cache.signing.keyPath` if needed.
 
 ## Troubleshooting
 
@@ -138,8 +223,36 @@ Open Settings → Team Cache and verify:
 - Application Default Credentials are detected (green dot in Settings).
 
 If those all look right, check `[remote-cache]` log lines on the local server
-console — failures (corrupt blob, schemaVersion mismatch, sha256 mismatch)
-log there and are treated as misses.
+console — failures (corrupt blob, schemaVersion mismatch, sha256 mismatch,
+signature/eligibility rejections) log there and are treated as misses.
+
+### Cache hits never happen even though teammates are signing correctly
+
+In `strict` mode (the default), an entry from a host that isn't in your
+**trusted signer hosts** list is always a miss — and that list starts empty.
+Open **Settings → Team Cache** and add your GitHub host (`github.com`, or your
+Enterprise host) to it. Look for `signerHost=… not in trusted hosts` in the
+`[remote-cache]` logs as the smoking gun.
+
+### "signing failed" / pushes never reach the bucket
+
+Signing requires three things on the pushing machine:
+- `ssh-keygen` on `PATH` (ships with OpenSSH; install it if missing).
+- An SSH private key in `~/.ssh` whose public half is published at
+  `https://<host>/<login>.keys`. If none matches, auto-detection fails — add the
+  key to GitHub or set `cache.signing.keyPath` explicitly.
+- A signed-in GitHub account with a resolvable login.
+
+You can sidestep signing entirely by setting **signing mode** to `off`, but then
+you fall back to IAM-only trust (Layer 1) — anyone with bucket write access can
+poison entries. Prefer fixing the key over disabling signing.
+
+### A teammate's entries are rejected after they lost repo access
+
+Working as intended. Eligibility is re-checked on every fetch against the
+*current* GitHub permission, so once someone drops below `write` on the repo,
+their previously-cached entries stop being trusted (after a short permission-
+cache TTL). Regenerate locally, or have a current writer repopulate the entry.
 
 ### A walkthrough renders with the wrong "Generated by …" badge
 

--- a/knip.json
+++ b/knip.json
@@ -29,7 +29,7 @@
       ]
     },
     "apps/server": {
-      "entry": ["src/index.ts"],
+      "entry": ["src/index.ts", "src/**/*.test.ts"],
       "ignoreDependencies": ["bun-types", "drizzle-kit"]
     },
     "packages/shared": {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -248,6 +248,15 @@ export interface UserIdentity {
    * the moment CI publishes them — the 48h stable cooldown is bypassed.
    */
   isMaintainer: boolean;
+  /**
+   * `true` when the active account's GitHub token is invalid and could not be
+   * silently refreshed — the client gates the app behind a re-sign-in modal.
+   * Authoritative reconcile source for `auth:reauth-required` WS signals on
+   * boot / WS reconnect. `host` is the account's GitHub host, used to drive
+   * the re-auth device flow against the right instance.
+   */
+  reauthRequired: boolean;
+  host: string | null;
 }
 
 export interface Org {

--- a/packages/shared/src/ws.ts
+++ b/packages/shared/src/ws.ts
@@ -71,6 +71,21 @@ export type WsServerMessage =
     }
   /** signal — Fatal server error (e.g. rate-limited). Show toast; `retryAfter` optional. */
   | { type: "error"; data: { code: string; message: string; retryAfter?: number } }
+  /**
+   * signal — The account's GitHub token is invalid and could not be silently
+   * refreshed (revoked / no or expired refresh token). The client gates the
+   * app behind a blocking re-sign-in modal. Account-scoped. Re-broadcast each
+   * poll cycle while the account stays flagged, so a client that missed it
+   * while disconnected reconciles; the authoritative state is
+   * `account.reauthRequiredAt`, surfaced on `GET /api/user/identity`.
+   */
+  | { type: "auth:reauth-required"; data: { host: string; githubLogin: string | null } }
+  /**
+   * signal — The account's GitHub token is valid again (successful refresh or
+   * device-flow re-auth). The client dismisses the re-sign-in modal.
+   * Account-scoped.
+   */
+  | { type: "auth:reauth-cleared"; data: { host: string } }
   /** delta — New comment thread created. Append to thread list. */
   | {
       type: "thread:created";


### PR DESCRIPTION
## Summary

- Migrates GitHub OAuth token bytes out of the `account` DB column and into the OS secure store (`@napi-rs/keyring` — macOS Keychain, Windows Credential Manager, Linux Secret Service) with an AES-256-GCM encrypted-file fallback when the keyring is unavailable.
- `TokenProvider` now transparently refreshes near-expiry access tokens using a stored refresh token; on a 401 `PollScheduler` attempts one silent refresh per account per cycle, and stamps `reauthRequiredAt` + broadcasts `auth:reauth-required` if the refresh fails.
- The web app shows a blocking `ReauthModal` when the token can't be refreshed, reconciling the flag from `GET /api/user/identity` on boot to handle WS signals missed while disconnected; the flag clears on successful re-auth or a live `auth:reauth-cleared` event.
- A one-time boot migration nulls any plaintext tokens still in the DB and moves them into the secure store.

## Test plan

- [ ] Sign in, restart the server — token is read from keyring, no re-auth prompt
- [ ] Simulate a 401 (revoke token on GitHub) — modal appears, re-sign-in clears it
- [ ] Simulate a refresh (GHE with expiring tokens) — PollScheduler rotates token silently
- [ ] Boot with an existing DB containing plaintext tokens — migration runs once, columns nulled

🤖 Generated with [Claude Code](https://claude.com/claude-code)