### PR TITLE
fix: handle GitHub rate limits and ETag caching

### DIFF
--- a/apps/server/src/domain/errors.ts
+++ b/apps/server/src/domain/errors.ts
@@ -3,6 +3,9 @@ import { Data } from "effect";
 // GitHub API errors
 export class GitHubRateLimitError extends Data.TaggedError("GitHubRateLimitError")<{
   readonly resetAt: Date;
+  readonly retryAfter?: number;
+  readonly kind?: "primary" | "secondary";
+  readonly resource?: string;
 }> {}
 
 export class GitHubAuthError extends Data.TaggedError("GitHubAuthError")<{

--- a/apps/server/src/services/GitHub.test.ts
+++ b/apps/server/src/services/GitHub.test.ts
@@ -115,13 +115,13 @@ describe("GitHubGateway rate-limit handling", () => {
 });
 
 describe("GitHubGateway conditional pagination", () => {
-  it("ETag-caches review comments and ignores the since parameter", async () => {
+  it("keeps review comments incremental and uncached", async () => {
     const db = createDb(":memory:");
     const calls = stubFetch((_call, index) => {
       if (index === 0) {
         return responseJson([rawComment(1)], { headers: { ETag: '"comments-v1"' } });
       }
-      return new Response(null, { status: 304 });
+      return responseJson([rawComment(2)], { headers: { ETag: '"comments-v2"' } });
     });
 
     const comments = await Effect.runPromise(
@@ -133,13 +133,15 @@ describe("GitHubGateway conditional pagination", () => {
     );
 
     expect(comments).toHaveLength(1);
-    expect(comments[0]?.id).toBe(1);
+    expect(comments[0]?.id).toBe(2);
     expect(calls).toHaveLength(2);
     expect(calls[0]?.url).toBe(
-      "https://api.github.com/repos/octo/repo/pulls/1/comments?per_page=100",
+      "https://api.github.com/repos/octo/repo/pulls/1/comments?per_page=100&since=2026-01-01T00%3A00%3A00Z",
     );
-    expect(calls[0]?.url.includes("since=")).toBe(false);
-    expect(calls[1]?.headers.get("If-None-Match")).toBe('"comments-v1"');
+    expect(calls[1]?.url).toBe(
+      "https://api.github.com/repos/octo/repo/pulls/1/comments?per_page=100&since=2026-01-02T00%3A00%3A00Z",
+    );
+    expect(calls[1]?.headers.get("If-None-Match")).toBeNull();
   });
 
   it("replays cached open PRs on 304 only when the cached set fit on one page", async () => {
@@ -172,6 +174,25 @@ describe("GitHubGateway conditional pagination", () => {
     expect(prs[0]?.externalId).toBe(101);
     expect(calls).toHaveLength(3);
     expect(calls[1]?.headers.get("If-None-Match")).toBe('"prs-v1"');
+    expect(calls[2]?.headers.get("If-None-Match")).toBeNull();
+  });
+
+  it("separates ETag cache entries by API base and token", async () => {
+    const db = createDb(":memory:");
+    const calls = stubFetch(() => responseJson([rawPr(1)], { headers: { ETag: '"prs-v1"' } }));
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        yield* github.prs.listOpen("octo/repo", "repo-1", "token-a", "https://api.github.test");
+        yield* github.prs.listOpen("octo/repo", "repo-1", "token-a", "https://api.github.example");
+        yield* github.prs.listOpen("octo/repo", "repo-1", "token-b", "https://api.github.test");
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0]?.headers.get("If-None-Match")).toBeNull();
+    expect(calls[1]?.headers.get("If-None-Match")).toBeNull();
     expect(calls[2]?.headers.get("If-None-Match")).toBeNull();
   });
 });

--- a/apps/server/src/services/GitHub.test.ts
+++ b/apps/server/src/services/GitHub.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Effect, Either, Layer } from "effect";
+import { createDb, type Db } from "../db/index";
+import { GitHubRateLimitError } from "../domain/errors";
+import { DbService } from "./Db";
+import { GitHubGateway, GitHubGatewayLive } from "./GitHub";
+import { GitHubEtagCacheLive } from "./GitHubEtagCache";
+import { SettingsServiceLive } from "./Settings";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+interface FetchCall {
+  readonly url: string;
+  readonly headers: Headers;
+}
+
+function gatewayLayer(db: Db) {
+  const dbLayer = Layer.succeed(DbService, { db });
+  const dependent = Layer.mergeAll(GitHubEtagCacheLive, SettingsServiceLive).pipe(
+    Layer.provide(dbLayer),
+  );
+  return Layer.mergeAll(GitHubGatewayLive, dbLayer, dependent);
+}
+
+function responseJson(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), init);
+}
+
+function stubFetch(respond: (call: FetchCall, index: number) => Response) {
+  const calls: FetchCall[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const call = {
+      url: String(input),
+      headers: new Headers(init?.headers),
+    };
+    calls.push(call);
+    return respond(call, calls.length - 1);
+  }) as typeof fetch;
+  return calls;
+}
+
+function rawComment(id: number): Record<string, unknown> {
+  return {
+    id,
+    in_reply_to_id: null,
+    path: "src/app.ts",
+    line: 10,
+    start_line: null,
+    side: "RIGHT",
+    body: `comment ${id}`,
+    user: { login: "reviewer", avatar_url: null },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    html_url: `https://github.test/comment/${id}`,
+  };
+}
+
+function rawPr(number: number): Record<string, unknown> {
+  return {
+    number,
+    user: { login: "author", avatar_url: null },
+    head: { ref: "feature", sha: `head-${number}` },
+    base: { ref: "main", sha: "base" },
+    requested_reviewers: [],
+    title: `PR ${number}`,
+    body: null,
+    state: "open",
+    merged_at: null,
+    draft: false,
+    html_url: `https://github.test/pull/${number}`,
+    additions: 1,
+    deletions: 1,
+    changed_files: 1,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    closed_at: null,
+  };
+}
+
+describe("GitHubGateway rate-limit handling", () => {
+  it("classifies Retry-After responses as rate limits without retrying", async () => {
+    const db = createDb(":memory:");
+    const calls = stubFetch(
+      () =>
+        new Response("rate limited", {
+          status: 429,
+          headers: { "Retry-After": "30" },
+        }),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        return yield* github.prs
+          .listOpen("octo/repo", "repo-1", "token", "https://api.github.test")
+          .pipe(Effect.either);
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(GitHubRateLimitError);
+      expect(result.left._tag).toBe("GitHubRateLimitError");
+      if (result.left._tag === "GitHubRateLimitError") {
+        expect(result.left.kind).toBe("secondary");
+        expect(result.left.retryAfter).toBe(30);
+      }
+    }
+  });
+});
+
+describe("GitHubGateway conditional pagination", () => {
+  it("ETag-caches review comments and ignores the since parameter", async () => {
+    const db = createDb(":memory:");
+    const calls = stubFetch((_call, index) => {
+      if (index === 0) {
+        return responseJson([rawComment(1)], { headers: { ETag: '"comments-v1"' } });
+      }
+      return new Response(null, { status: 304 });
+    });
+
+    const comments = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        yield* github.reviews.listComments("octo/repo", 1, "2026-01-01T00:00:00Z", "token");
+        return yield* github.reviews.listComments("octo/repo", 1, "2026-01-02T00:00:00Z", "token");
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.id).toBe(1);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.url).toBe(
+      "https://api.github.com/repos/octo/repo/pulls/1/comments?per_page=100",
+    );
+    expect(calls[0]?.url.includes("since=")).toBe(false);
+    expect(calls[1]?.headers.get("If-None-Match")).toBe('"comments-v1"');
+  });
+
+  it("replays cached open PRs on 304 only when the cached set fit on one page", async () => {
+    const db = createDb(":memory:");
+    const firstPage = Array.from({ length: 100 }, (_, i) => rawPr(i + 1));
+    const calls = stubFetch((_call, index) => {
+      if (index === 0) {
+        return responseJson(firstPage, { headers: { ETag: '"prs-v1"' } });
+      }
+      if (index === 1) {
+        return new Response(null, { status: 304 });
+      }
+      return responseJson([rawPr(101)], { headers: { ETag: '"prs-v2"' } });
+    });
+
+    const prs = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        yield* github.prs.listOpen("octo/repo", "repo-1", "token", "https://api.github.test");
+        return yield* github.prs.listOpen(
+          "octo/repo",
+          "repo-1",
+          "token",
+          "https://api.github.test",
+        );
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(prs).toHaveLength(1);
+    expect(prs[0]?.externalId).toBe(101);
+    expect(calls).toHaveLength(3);
+    expect(calls[1]?.headers.get("If-None-Match")).toBe('"prs-v1"');
+    expect(calls[2]?.headers.get("If-None-Match")).toBeNull();
+  });
+});

--- a/apps/server/src/services/GitHub.ts
+++ b/apps/server/src/services/GitHub.ts
@@ -28,6 +28,13 @@ const resolveApiBase: Effect.Effect<string, never, SettingsService> = Effect.gen
 
 const retrySchedule = Schedule.intersect(Schedule.exponential("2 seconds"), Schedule.recurs(3));
 
+const isTransientGitHubError = (e: GitHubError): boolean => e instanceof GitHubNetworkError;
+
+const retryTransient = <A, R>(
+  effect: Effect.Effect<A, GitHubError, R>,
+): Effect.Effect<A, GitHubError, R> =>
+  effect.pipe(Effect.retry({ schedule: retrySchedule, while: isTransientGitHubError }));
+
 /** Build the REST API base URL for an explicit host (no settings lookup needed). */
 function resolveApiBaseForHost(host: string): string {
   return host === "github.com" ? "https://api.github.com" : `https://api.${host}`;
@@ -71,13 +78,37 @@ function assertGitHubOk(res: Response, path: string): void {
   if (res.status === 401) {
     throw new GitHubAuthError({ message: "Invalid or expired GitHub token" });
   }
-  if (res.status === 403) {
+  if (res.status === 403 || res.status === 429) {
+    const retryAfter = parseRetryAfter(res.headers.get("Retry-After"));
+    if (retryAfter !== null) {
+      throw new GitHubRateLimitError({
+        resetAt: new Date(Date.now() + retryAfter * 1000),
+        retryAfter,
+        kind: "secondary",
+      });
+    }
+
     const remaining = res.headers.get("X-RateLimit-Remaining");
-    if (remaining === "0") {
+    if (res.status === 403 && remaining === "0") {
       const resetHeader = res.headers.get("X-RateLimit-Reset");
       const resetAt = resetHeader ? new Date(Number(resetHeader) * 1000) : new Date();
-      throw new GitHubRateLimitError({ resetAt });
+      const resource = res.headers.get("X-RateLimit-Resource");
+      throw new GitHubRateLimitError({
+        resetAt,
+        kind: "primary",
+        ...(resource ? { resource } : {}),
+      });
     }
+
+    if (res.status === 429) {
+      const defaultRetryAfter = 60;
+      throw new GitHubRateLimitError({
+        resetAt: new Date(Date.now() + defaultRetryAfter * 1000),
+        retryAfter: defaultRetryAfter,
+        kind: "secondary",
+      });
+    }
+
     // Not a rate limit — likely org access restriction or insufficient permissions
     throw new GitHubNetworkError({
       cause: `HTTP 403 – access denied for ${path} (check GitHub org OAuth app policies)`,
@@ -89,6 +120,17 @@ function assertGitHubOk(res: Response, path: string): void {
   if (!res.ok) {
     throw new GitHubNetworkError({ cause: `HTTP ${res.status}` });
   }
+}
+
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.ceil(seconds);
+  }
+  const retryAt = Date.parse(header);
+  if (Number.isNaN(retryAt)) return null;
+  return Math.max(0, Math.ceil((retryAt - Date.now()) / 1000));
 }
 
 function githubFetch(
@@ -119,9 +161,9 @@ function githubFetch(
  * and we replay the stored body — zero bytes of real payload, zero rate-limit
  * cost. On `200`, we refresh the stored ETag + body for next time.
  *
- * Only use this for endpoints that return a single page. Paginated endpoints
- * (`listUserRepos`, `listReviewComments`) still call `githubFetchPaginated`
- * directly; per-page ETag caching can be added later.
+ * Only use this for endpoints that return a single page. Paginated list
+ * endpoints need `conditionalFetchPaginated` so the cached body represents the
+ * assembled result.
  */
 function conditionalFetch(
   path: string,
@@ -182,6 +224,109 @@ function conditionalFetch(
     }
     return result.body;
   });
+}
+
+/**
+ * Fetch a paginated GitHub REST list endpoint with page-1 conditional caching.
+ *
+ * The cached body is the assembled array from all fetched pages, but the ETag
+ * comes from page 1 because GitHub ETags are response-scoped. Callers can
+ * decide when a page-1 304 is safe to replay; `listPrs` only does so when the
+ * cached open set fit on one page.
+ */
+function conditionalFetchPaginated(
+  path: string,
+  token: string,
+  maxPages: number = 3,
+  apiBase: string,
+  options: {
+    readonly canReplayCached?: (cached: readonly unknown[]) => boolean;
+  } = {},
+): Effect.Effect<unknown[], GitHubError, DbService | GitHubEtagCache> {
+  return Effect.withSpan("GitHub.fetchPaginated.conditional", {
+    attributes: { path, maxPages },
+  })(
+    Effect.gen(function* () {
+      const cache = yield* GitHubEtagCache;
+      const cacheKey = buildCacheKey("GET", path);
+      const cached = yield* cache.get(cacheKey);
+
+      const result = yield* Effect.tryPromise({
+        try: async () => {
+          const headers: Record<string, string> = githubHeaders(token);
+          if (cached) {
+            headers["If-None-Match"] = cached.etag;
+          }
+
+          const firstUrl = `${apiBase}${path}`;
+          let firstResponse = await fetch(firstUrl, { headers });
+
+          if (firstResponse.status === 304 && cached) {
+            if (Array.isArray(cached.body)) {
+              const replayAllowed = options.canReplayCached?.(cached.body) ?? true;
+              if (replayAllowed) {
+                return { kind: "hit" as const, body: cached.body };
+              }
+            }
+
+            firstResponse = await fetch(firstUrl, { headers: githubHeaders(token) });
+          }
+
+          const results: unknown[] = [];
+          let url: string | null = firstUrl;
+          let etag: string | null = null;
+          let lastModified: string | null = null;
+          let bytes = 0;
+
+          for (let page = 0; page < maxPages && url; page++) {
+            const res =
+              page === 0 ? firstResponse : await fetch(url, { headers: githubHeaders(token) });
+            assertGitHubOk(res, path);
+
+            if (page === 0) {
+              etag = res.headers.get("ETag");
+              lastModified = res.headers.get("Last-Modified");
+            }
+
+            const bodyText = await res.text();
+            bytes += bodyText.length;
+            const data = bodyText ? JSON.parse(bodyText) : [];
+            if (Array.isArray(data)) {
+              results.push(...data);
+            }
+
+            url = parseLinkNext(res.headers.get("Link"));
+          }
+
+          return {
+            kind: "miss" as const,
+            body: results,
+            bytes,
+            etag,
+            lastModified,
+          };
+        },
+        catch: toGitHubError,
+      });
+
+      if (result.kind === "hit") {
+        let saved = 0;
+        try {
+          saved = JSON.stringify(result.body).length;
+        } catch {
+          /* swallow — stats are best-effort */
+        }
+        cache.recordHit(saved);
+        return [...result.body];
+      }
+
+      cache.recordMiss();
+      if (result.etag) {
+        yield* cache.put(cacheKey, result.etag, result.lastModified, result.body);
+      }
+      return result.body;
+    }),
+  );
 }
 
 function githubPost(
@@ -592,7 +737,7 @@ interface GitHubGatewayFlatService {
     prNumber: number,
     since: string | null,
     token: string,
-  ) => Effect.Effect<GhReviewComment[], GitHubError, SettingsService>;
+  ) => Effect.Effect<GhReviewComment[], GitHubError, DbService | GitHubEtagCache | SettingsService>;
   readonly listReviewThreads: (
     repoFullName: string,
     prNumber: number,
@@ -769,14 +914,15 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
     Effect.gen(function* () {
       const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
-      const data = yield* githubFetchPaginated(
+      const data = yield* conditionalFetchPaginated(
         `/repos/${owner}/${repo}/pulls?state=open&sort=updated&direction=desc&per_page=100`,
         token,
         10,
         apiBase,
+        { canReplayCached: (cached) => cached.length < 100 },
       );
       return (data as Record<string, unknown>[]).map((pr) => mapPr(pr, repositoryId));
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   getPr: (repoFullName, prNumber, token) =>
     Effect.gen(function* () {
@@ -788,7 +934,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         apiBase,
       );
       return mapPr(data as Record<string, unknown>, `${owner}/${repo}`);
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   searchClosedPrsInWindow: (repoFullName, sinceIso, untilIso, token) =>
     Effect.gen(function* () {
@@ -839,7 +985,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         readonly closedAt: string;
         readonly merged: boolean;
       }>;
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   getRepo: (fullName, token) =>
     Effect.gen(function* () {
@@ -847,7 +993,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       const { owner, repo } = yield* parseRepoFullName(fullName);
       const data = yield* conditionalFetch(`/repos/${owner}/${repo}`, token, apiBase);
       return mapRepo(data as Record<string, unknown>);
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   getRepoFresh: (fullName, token, explicitApiBase) =>
     Effect.gen(function* () {
@@ -855,7 +1001,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       const { owner, repo } = yield* parseRepoFullName(fullName);
       const data = yield* githubFetch(`/repos/${owner}/${repo}`, token, apiBase);
       return mapRepo(data as Record<string, unknown>);
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   listUserRepos: (token) =>
     Effect.gen(function* () {
@@ -867,7 +1013,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         apiBase,
       );
       return (data as Record<string, unknown>[]).map((raw) => mapRepo(raw));
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   getOpenPrCounts: (fullNames, token) =>
     Effect.gen(function* () {
@@ -933,7 +1079,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       }
 
       return result;
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   listUserOrgs: (token) =>
     Effect.gen(function* () {
@@ -943,7 +1089,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         login: raw.login as string,
         avatarUrl: (raw.avatar_url as string | null) ?? null,
       }));
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   getPrMeta: (repoFullName, prNumber, token) =>
     Effect.gen(function* () {
@@ -958,7 +1104,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       const base = raw.base as Record<string, unknown>;
       const head = raw.head as Record<string, unknown>;
       return { baseSha: base.sha as string, headSha: head.sha as string };
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   getPrFiles: (repoFullName, prNumber, token) =>
     Effect.gen(function* () {
@@ -977,7 +1123,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         deletions: (f.deletions as number | undefined) ?? 0,
         patch: (f.patch as string | undefined) ?? null,
       }));
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   listPrCommits: (repoFullName, prNumber, token) =>
     Effect.gen(function* () {
@@ -1056,7 +1202,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
           date: c.date,
         }),
       );
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   getFileContent: (repoFullName, path, ref, token) =>
     Effect.gen(function* () {
@@ -1074,7 +1220,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       }
       // Binary or unsupported encoding
       return "";
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   getFileRawBytes: (repoFullName, path, ref, token) =>
     Effect.gen(function* () {
@@ -1099,7 +1245,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         },
         catch: toGitHubError,
       });
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   postReview: (repoFullName, prNumber, review, token) =>
     Effect.gen(function* () {
@@ -1203,13 +1349,12 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
-  listReviewComments: (repoFullName, prNumber, since, token) =>
+  listReviewComments: (repoFullName, prNumber, _since, token) =>
     Effect.gen(function* () {
       const apiBase = yield* resolveApiBase;
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
-      const sinceQ = since ? `&since=${encodeURIComponent(since)}` : "";
-      const data = yield* githubFetchPaginated(
-        `/repos/${owner}/${repo}/pulls/${prNumber}/comments?per_page=100${sinceQ}`,
+      const data = yield* conditionalFetchPaginated(
+        `/repos/${owner}/${repo}/pulls/${prNumber}/comments?per_page=100`,
         token,
         5,
         apiBase,
@@ -1231,7 +1376,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
           htmlUrl: (raw.html_url as string | undefined) ?? "",
         };
       });
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   listReviewThreads: (repoFullName, prNumber, token) =>
     Effect.gen(function* () {
@@ -1293,7 +1438,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         cursor = page.pageInfo.endCursor;
       }
       return out;
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   resolveReviewThread: (threadNodeId, token) =>
     Effect.gen(function* () {
@@ -1327,7 +1472,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         id: raw.id as number,
         avatarUrl: (raw.avatar_url as string | null) ?? null,
       };
-    }).pipe(Effect.retry(retrySchedule)),
+    }).pipe(retryTransient),
 
   convertPrToDraft: (repoFullName, prNumber, token) =>
     Effect.gen(function* () {
@@ -1481,15 +1626,10 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
     Effect.tryPromise({
       try: async () => {
         const apiBase = resolveApiBaseForHost(host);
-        const res = await fetch(
-          `${apiBase}/repos/${owner}/${repo}/collaborators/${username}/permission`,
-          { headers: githubHeaders(token) },
-        );
+        const path = `/repos/${owner}/${repo}/collaborators/${username}/permission`;
+        const res = await fetch(`${apiBase}${path}`, { headers: githubHeaders(token) });
         if (res.status === 404) return "none" as const;
-        if (res.status === 401) throw new GitHubAuthError({ message: "Invalid or expired token" });
-        if (res.status === 403)
-          throw new GitHubNetworkError({ cause: `HTTP 403 on ${owner}/${repo}` });
-        if (!res.ok) throw new GitHubNetworkError({ cause: `HTTP ${res.status}` });
+        assertGitHubOk(res, path);
         const body = (await res.json()) as { role_name?: string };
         const roleName = body.role_name ?? "none";
         if (

--- a/apps/server/src/services/GitHub.ts
+++ b/apps/server/src/services/GitHub.ts
@@ -1,15 +1,24 @@
 import type { MergeEligibility, MergeMethod, Org, PullRequest, Repository } from "@revv/shared";
-import { Context, Effect, Layer, Schedule } from "effect";
+import { Context, Effect, Layer } from "effect";
 import { serverEnv } from "../config";
-import {
-  GitHubAuthError,
-  type GitHubError,
-  GitHubNetworkError,
-  GitHubNotFoundError,
-  GitHubRateLimitError,
-} from "../domain/errors";
+import { type GitHubError, GitHubNotFoundError } from "../domain/errors";
 import type { DbService } from "./Db";
-import { buildCacheKey, GitHubEtagCache } from "./GitHubEtagCache";
+import type { GitHubEtagCache } from "./GitHubEtagCache";
+import {
+  assertGitHubOk,
+  conditionalFetch,
+  conditionalFetchPaginated,
+  githubFetch,
+  githubFetchPaginated,
+  githubGraphql,
+  githubHeaders,
+  githubPatch,
+  githubPost,
+  githubPut,
+  parseLinkNext,
+  retryTransient,
+  toGitHubError,
+} from "./github-rest";
 import { SettingsService } from "./Settings";
 
 /**
@@ -26,15 +35,6 @@ const resolveApiBase: Effect.Effect<string, never, SettingsService> = Effect.gen
   return host === "github.com" ? "https://api.github.com" : `https://api.${host}`;
 });
 
-const retrySchedule = Schedule.intersect(Schedule.exponential("2 seconds"), Schedule.recurs(3));
-
-const isTransientGitHubError = (e: GitHubError): boolean => e instanceof GitHubNetworkError;
-
-const retryTransient = <A, R>(
-  effect: Effect.Effect<A, GitHubError, R>,
-): Effect.Effect<A, GitHubError, R> =>
-  effect.pipe(Effect.retry({ schedule: retrySchedule, while: isTransientGitHubError }));
-
 /** Build the REST API base URL for an explicit host (no settings lookup needed). */
 function resolveApiBaseForHost(host: string): string {
   return host === "github.com" ? "https://api.github.com" : `https://api.${host}`;
@@ -49,448 +49,6 @@ function parseRepoFullName(
     return Effect.fail(new GitHubNotFoundError({ resource: "repo", id: fullName }));
   }
   return Effect.succeed({ owner, repo });
-}
-
-/** Pass through known GitHub errors; wrap unknown ones in GitHubNetworkError. */
-function toGitHubError(e: unknown): GitHubError {
-  if (
-    e instanceof GitHubAuthError ||
-    e instanceof GitHubRateLimitError ||
-    e instanceof GitHubNotFoundError ||
-    e instanceof GitHubNetworkError
-  ) {
-    return e;
-  }
-  return new GitHubNetworkError({ cause: e });
-}
-
-/** Build the standard headers for GitHub API requests. */
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github.v3+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
-}
-
-/** Assert a fetch response is successful, throwing the appropriate domain error on failure. */
-function assertGitHubOk(res: Response, path: string): void {
-  if (res.status === 401) {
-    throw new GitHubAuthError({ message: "Invalid or expired GitHub token" });
-  }
-  if (res.status === 403 || res.status === 429) {
-    const retryAfter = parseRetryAfter(res.headers.get("Retry-After"));
-    if (retryAfter !== null) {
-      throw new GitHubRateLimitError({
-        resetAt: new Date(Date.now() + retryAfter * 1000),
-        retryAfter,
-        kind: "secondary",
-      });
-    }
-
-    const remaining = res.headers.get("X-RateLimit-Remaining");
-    if (res.status === 403 && remaining === "0") {
-      const resetHeader = res.headers.get("X-RateLimit-Reset");
-      const resetAt = resetHeader ? new Date(Number(resetHeader) * 1000) : new Date();
-      const resource = res.headers.get("X-RateLimit-Resource");
-      throw new GitHubRateLimitError({
-        resetAt,
-        kind: "primary",
-        ...(resource ? { resource } : {}),
-      });
-    }
-
-    if (res.status === 429) {
-      const defaultRetryAfter = 60;
-      throw new GitHubRateLimitError({
-        resetAt: new Date(Date.now() + defaultRetryAfter * 1000),
-        retryAfter: defaultRetryAfter,
-        kind: "secondary",
-      });
-    }
-
-    // Not a rate limit — likely org access restriction or insufficient permissions
-    throw new GitHubNetworkError({
-      cause: `HTTP 403 – access denied for ${path} (check GitHub org OAuth app policies)`,
-    });
-  }
-  if (res.status === 404) {
-    throw new GitHubNotFoundError({ resource: path, id: path });
-  }
-  if (!res.ok) {
-    throw new GitHubNetworkError({ cause: `HTTP ${res.status}` });
-  }
-}
-
-function parseRetryAfter(header: string | null): number | null {
-  if (!header) return null;
-  const seconds = Number(header);
-  if (Number.isFinite(seconds) && seconds >= 0) {
-    return Math.ceil(seconds);
-  }
-  const retryAt = Date.parse(header);
-  if (Number.isNaN(retryAt)) return null;
-  return Math.max(0, Math.ceil((retryAt - Date.now()) / 1000));
-}
-
-function githubFetch(
-  path: string,
-  token: string,
-  apiBase: string,
-): Effect.Effect<unknown, GitHubError> {
-  return Effect.withSpan("GitHub.fetch", {
-    attributes: { path, method: "GET" },
-  })(
-    Effect.tryPromise({
-      try: async () => {
-        const res = await fetch(`${apiBase}${path}`, {
-          headers: githubHeaders(token),
-        });
-        assertGitHubOk(res, path);
-        return res.json();
-      },
-      catch: toGitHubError,
-    }),
-  );
-}
-
-/**
- * Fetch a single-page GitHub REST endpoint with conditional-request caching.
- *
- * On cache hit with unchanged server state, GitHub responds `304 Not Modified`
- * and we replay the stored body — zero bytes of real payload, zero rate-limit
- * cost. On `200`, we refresh the stored ETag + body for next time.
- *
- * Only use this for endpoints that return a single page. Paginated list
- * endpoints need `conditionalFetchPaginated` so the cached body represents the
- * assembled result.
- */
-function conditionalFetch(
-  path: string,
-  token: string,
-  apiBase: string,
-): Effect.Effect<unknown, GitHubError, DbService | GitHubEtagCache> {
-  return Effect.gen(function* () {
-    const cache = yield* GitHubEtagCache;
-    const cacheKey = buildCacheKey("GET", path);
-    const cached = yield* cache.get(cacheKey);
-
-    const result = yield* Effect.tryPromise({
-      try: async () => {
-        const headers: Record<string, string> = githubHeaders(token);
-        if (cached) {
-          headers["If-None-Match"] = cached.etag;
-        }
-        const res = await fetch(`${apiBase}${path}`, { headers });
-
-        if (res.status === 304 && cached) {
-          // Server confirms our cached body is still fresh.
-          return { kind: "hit" as const, body: cached.body, bytes: 0 };
-        }
-
-        // For any other status code, fall through to normal error handling.
-        assertGitHubOk(res, path);
-
-        const bodyText = await res.text();
-        const body = bodyText ? JSON.parse(bodyText) : null;
-        const etag = res.headers.get("ETag");
-        const lastModified = res.headers.get("Last-Modified");
-        return {
-          kind: "miss" as const,
-          body,
-          bytes: bodyText.length,
-          etag,
-          lastModified,
-        };
-      },
-      catch: toGitHubError,
-    });
-
-    if (result.kind === "hit") {
-      // Approximate bytes saved = size of the body we'd have downloaded.
-      let saved = 0;
-      try {
-        saved = JSON.stringify(result.body).length;
-      } catch {
-        /* swallow — stats are best-effort */
-      }
-      cache.recordHit(saved);
-      return result.body;
-    }
-
-    cache.recordMiss();
-    if (result.etag) {
-      yield* cache.put(cacheKey, result.etag, result.lastModified ?? null, result.body);
-    }
-    return result.body;
-  });
-}
-
-/**
- * Fetch a paginated GitHub REST list endpoint with page-1 conditional caching.
- *
- * The cached body is the assembled array from all fetched pages, but the ETag
- * comes from page 1 because GitHub ETags are response-scoped. Callers can
- * decide when a page-1 304 is safe to replay; `listPrs` only does so when the
- * cached open set fit on one page.
- */
-function conditionalFetchPaginated(
-  path: string,
-  token: string,
-  maxPages: number = 3,
-  apiBase: string,
-  options: {
-    readonly canReplayCached?: (cached: readonly unknown[]) => boolean;
-  } = {},
-): Effect.Effect<unknown[], GitHubError, DbService | GitHubEtagCache> {
-  return Effect.withSpan("GitHub.fetchPaginated.conditional", {
-    attributes: { path, maxPages },
-  })(
-    Effect.gen(function* () {
-      const cache = yield* GitHubEtagCache;
-      const cacheKey = buildCacheKey("GET", path);
-      const cached = yield* cache.get(cacheKey);
-
-      const result = yield* Effect.tryPromise({
-        try: async () => {
-          const headers: Record<string, string> = githubHeaders(token);
-          if (cached) {
-            headers["If-None-Match"] = cached.etag;
-          }
-
-          const firstUrl = `${apiBase}${path}`;
-          let firstResponse = await fetch(firstUrl, { headers });
-
-          if (firstResponse.status === 304 && cached) {
-            if (Array.isArray(cached.body)) {
-              const replayAllowed = options.canReplayCached?.(cached.body) ?? true;
-              if (replayAllowed) {
-                return { kind: "hit" as const, body: cached.body };
-              }
-            }
-
-            firstResponse = await fetch(firstUrl, { headers: githubHeaders(token) });
-          }
-
-          const results: unknown[] = [];
-          let url: string | null = firstUrl;
-          let etag: string | null = null;
-          let lastModified: string | null = null;
-          let bytes = 0;
-
-          for (let page = 0; page < maxPages && url; page++) {
-            const res =
-              page === 0 ? firstResponse : await fetch(url, { headers: githubHeaders(token) });
-            assertGitHubOk(res, path);
-
-            if (page === 0) {
-              etag = res.headers.get("ETag");
-              lastModified = res.headers.get("Last-Modified");
-            }
-
-            const bodyText = await res.text();
-            bytes += bodyText.length;
-            const data = bodyText ? JSON.parse(bodyText) : [];
-            if (Array.isArray(data)) {
-              results.push(...data);
-            }
-
-            url = parseLinkNext(res.headers.get("Link"));
-          }
-
-          return {
-            kind: "miss" as const,
-            body: results,
-            bytes,
-            etag,
-            lastModified,
-          };
-        },
-        catch: toGitHubError,
-      });
-
-      if (result.kind === "hit") {
-        let saved = 0;
-        try {
-          saved = JSON.stringify(result.body).length;
-        } catch {
-          /* swallow — stats are best-effort */
-        }
-        cache.recordHit(saved);
-        return [...result.body];
-      }
-
-      cache.recordMiss();
-      if (result.etag) {
-        yield* cache.put(cacheKey, result.etag, result.lastModified, result.body);
-      }
-      return result.body;
-    }),
-  );
-}
-
-function githubPost(
-  path: string,
-  token: string,
-  body: Record<string, unknown>,
-  apiBase: string,
-): Effect.Effect<unknown, GitHubError> {
-  return Effect.withSpan("GitHub.post", {
-    attributes: { path, method: "POST" },
-  })(
-    Effect.tryPromise({
-      try: async () => {
-        const res = await fetch(`${apiBase}${path}`, {
-          method: "POST",
-          headers: { ...githubHeaders(token), "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        });
-        if (res.status === 422) {
-          const text = await res.text().catch(() => "");
-          throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
-        }
-        assertGitHubOk(res, path);
-        return res.json();
-      },
-      catch: toGitHubError,
-    }),
-  );
-}
-
-function githubPatch(
-  path: string,
-  token: string,
-  body: Record<string, unknown>,
-  apiBase: string,
-): Effect.Effect<unknown, GitHubError> {
-  return Effect.tryPromise({
-    try: async () => {
-      const res = await fetch(`${apiBase}${path}`, {
-        method: "PATCH",
-        headers: { ...githubHeaders(token), "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-      if (res.status === 422) {
-        const text = await res.text().catch(() => "");
-        throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
-      }
-      assertGitHubOk(res, path);
-      return res.json();
-    },
-    catch: toGitHubError,
-  });
-}
-
-function githubPut(
-  path: string,
-  token: string,
-  body: Record<string, unknown>,
-  apiBase: string,
-): Effect.Effect<unknown, GitHubError> {
-  return Effect.tryPromise({
-    try: async () => {
-      const res = await fetch(`${apiBase}${path}`, {
-        method: "PUT",
-        headers: { ...githubHeaders(token), "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
-      if (res.status === 405) {
-        const text = await res.text().catch(() => "");
-        throw new GitHubNetworkError({ cause: `HTTP 405 Method Not Allowed: ${text}` });
-      }
-      if (res.status === 422) {
-        const text = await res.text().catch(() => "");
-        throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
-      }
-      assertGitHubOk(res, path);
-      return res.json();
-    },
-    catch: toGitHubError,
-  });
-}
-
-/**
- * POST a GraphQL query/mutation. Throws on `errors[]` in the response body
- * even if the HTTP status is 200 (GitHub convention).
- */
-function githubGraphql<T = unknown>(
-  query: string,
-  variables: Record<string, unknown>,
-  token: string,
-  apiBase: string,
-): Effect.Effect<T, GitHubError> {
-  const operationName = query.match(/(?:query|mutation)\s+(\w+)/)?.[1] ?? "unknown";
-  return Effect.withSpan("GitHub.graphql", {
-    attributes: { operationName },
-  })(
-    Effect.tryPromise({
-      try: async () => {
-        const res = await fetch(`${apiBase}/graphql`, {
-          method: "POST",
-          headers: { ...githubHeaders(token), "Content-Type": "application/json" },
-          body: JSON.stringify({ query, variables }),
-        });
-        assertGitHubOk(res, "/graphql");
-        const payload = (await res.json()) as { data?: T; errors?: Array<{ message: string }> };
-        if (payload.errors && payload.errors.length > 0) {
-          throw new GitHubNetworkError({
-            cause: `GraphQL: ${payload.errors.map((e) => e.message).join("; ")}`,
-          });
-        }
-        if (!payload.data) {
-          throw new GitHubNetworkError({ cause: "GraphQL: empty data field" });
-        }
-        return payload.data;
-      },
-      catch: toGitHubError,
-    }),
-  );
-}
-
-/** Parse GitHub Link header to find the URL for rel="next". */
-function parseLinkNext(linkHeader: string | null): string | null {
-  if (!linkHeader) return null;
-  const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
-  return match?.[1] ?? null;
-}
-
-/**
- * Fetch a paginated GitHub API list endpoint, following Link rel="next" headers
- * up to `maxPages` pages. Returns the concatenated array of all results.
- */
-function githubFetchPaginated(
-  path: string,
-  token: string,
-  maxPages: number = 3,
-  apiBase: string,
-): Effect.Effect<unknown[], GitHubError> {
-  return Effect.withSpan("GitHub.fetchPaginated", {
-    attributes: { path, maxPages },
-  })(
-    Effect.tryPromise({
-      try: async () => {
-        const results: unknown[] = [];
-        let url: string | null = `${apiBase}${path}`;
-
-        for (let page = 0; page < maxPages && url; page++) {
-          const res = await fetch(url, {
-            headers: githubHeaders(token),
-          });
-          assertGitHubOk(res, path);
-
-          const data = await res.json();
-          if (Array.isArray(data)) {
-            results.push(...data);
-          }
-
-          url = parseLinkNext(res.headers.get("Link"));
-        }
-
-        return results;
-      },
-      catch: toGitHubError,
-    }),
-  );
 }
 
 function mapPr(raw: Record<string, unknown>, repositoryId: string): PullRequest {
@@ -737,7 +295,7 @@ interface GitHubGatewayFlatService {
     prNumber: number,
     since: string | null,
     token: string,
-  ) => Effect.Effect<GhReviewComment[], GitHubError, DbService | GitHubEtagCache | SettingsService>;
+  ) => Effect.Effect<GhReviewComment[], GitHubError, SettingsService>;
   readonly listReviewThreads: (
     repoFullName: string,
     prNumber: number,
@@ -1349,12 +907,13 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
-  listReviewComments: (repoFullName, prNumber, _since, token) =>
+  listReviewComments: (repoFullName, prNumber, since, token) =>
     Effect.gen(function* () {
       const apiBase = yield* resolveApiBase;
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
-      const data = yield* conditionalFetchPaginated(
-        `/repos/${owner}/${repo}/pulls/${prNumber}/comments?per_page=100`,
+      const sinceQ = since ? `&since=${encodeURIComponent(since)}` : "";
+      const data = yield* githubFetchPaginated(
+        `/repos/${owner}/${repo}/pulls/${prNumber}/comments?per_page=100${sinceQ}`,
         token,
         5,
         apiBase,

--- a/apps/server/src/services/Sync.ts
+++ b/apps/server/src/services/Sync.ts
@@ -6,6 +6,7 @@ import { SyncError } from "../domain/errors";
 import { Broadcaster } from "./Broadcaster";
 import { DbService } from "./Db";
 import { type GhReviewComment, GitHubGateway } from "./GitHub";
+import type { GitHubEtagCache } from "./GitHubEtagCache";
 import { PrContextService } from "./PrContext";
 import { PullRequestService } from "./PullRequest";
 import { RemoteUserService } from "./RemoteUser";
@@ -41,10 +42,10 @@ export class SyncService extends Context.Tag("SyncService")<
     ) => Effect.Effect<void, SyncError, DbService | SettingsService>;
     readonly pullComments: (
       prId: string,
-    ) => Effect.Effect<PullResult, SyncError, DbService | SettingsService>;
+    ) => Effect.Effect<PullResult, SyncError, DbService | GitHubEtagCache | SettingsService>;
     readonly syncThreads: (
       prId: string,
-    ) => Effect.Effect<SyncResult, SyncError, DbService | SettingsService>;
+    ) => Effect.Effect<SyncResult, SyncError, DbService | GitHubEtagCache | SettingsService>;
     readonly getThreadSummary: (
       prId: string,
       userLogin: string | null,
@@ -267,7 +268,7 @@ export const SyncServiceLive = Layer.effect(
 
     const pullComments = (
       prId: string,
-    ): Effect.Effect<PullResult, SyncError, DbService | SettingsService> =>
+    ): Effect.Effect<PullResult, SyncError, DbService | GitHubEtagCache | SettingsService> =>
       Effect.gen(function* () {
         const { pr, repo, token } = yield* resolvePrContext(prId);
         const accountId = yield* repoService.getAccountIdForRepo(repo.id);
@@ -438,7 +439,7 @@ export const SyncServiceLive = Layer.effect(
 
     const syncThreads = (
       prId: string,
-    ): Effect.Effect<SyncResult, SyncError, DbService | SettingsService> =>
+    ): Effect.Effect<SyncResult, SyncError, DbService | GitHubEtagCache | SettingsService> =>
       Effect.gen(function* () {
         const pulled = yield* pullComments(prId);
         const summary = yield* getThreadSummary(prId, null);

--- a/apps/server/src/services/Sync.ts
+++ b/apps/server/src/services/Sync.ts
@@ -6,7 +6,6 @@ import { SyncError } from "../domain/errors";
 import { Broadcaster } from "./Broadcaster";
 import { DbService } from "./Db";
 import { type GhReviewComment, GitHubGateway } from "./GitHub";
-import type { GitHubEtagCache } from "./GitHubEtagCache";
 import { PrContextService } from "./PrContext";
 import { PullRequestService } from "./PullRequest";
 import { RemoteUserService } from "./RemoteUser";
@@ -42,10 +41,10 @@ export class SyncService extends Context.Tag("SyncService")<
     ) => Effect.Effect<void, SyncError, DbService | SettingsService>;
     readonly pullComments: (
       prId: string,
-    ) => Effect.Effect<PullResult, SyncError, DbService | GitHubEtagCache | SettingsService>;
+    ) => Effect.Effect<PullResult, SyncError, DbService | SettingsService>;
     readonly syncThreads: (
       prId: string,
-    ) => Effect.Effect<SyncResult, SyncError, DbService | GitHubEtagCache | SettingsService>;
+    ) => Effect.Effect<SyncResult, SyncError, DbService | SettingsService>;
     readonly getThreadSummary: (
       prId: string,
       userLogin: string | null,
@@ -268,7 +267,7 @@ export const SyncServiceLive = Layer.effect(
 
     const pullComments = (
       prId: string,
-    ): Effect.Effect<PullResult, SyncError, DbService | GitHubEtagCache | SettingsService> =>
+    ): Effect.Effect<PullResult, SyncError, DbService | SettingsService> =>
       Effect.gen(function* () {
         const { pr, repo, token } = yield* resolvePrContext(prId);
         const accountId = yield* repoService.getAccountIdForRepo(repo.id);
@@ -439,7 +438,7 @@ export const SyncServiceLive = Layer.effect(
 
     const syncThreads = (
       prId: string,
-    ): Effect.Effect<SyncResult, SyncError, DbService | GitHubEtagCache | SettingsService> =>
+    ): Effect.Effect<SyncResult, SyncError, DbService | SettingsService> =>
       Effect.gen(function* () {
         const pulled = yield* pullComments(prId);
         const summary = yield* getThreadSummary(prId, null);

--- a/apps/server/src/services/github-rest.ts
+++ b/apps/server/src/services/github-rest.ts
@@ -1,0 +1,437 @@
+import { createHash } from "node:crypto";
+import { Effect, Schedule } from "effect";
+import {
+  GitHubAuthError,
+  type GitHubError,
+  GitHubNetworkError,
+  GitHubNotFoundError,
+  GitHubRateLimitError,
+} from "../domain/errors";
+import type { DbService } from "./Db";
+import { buildCacheKey, GitHubEtagCache } from "./GitHubEtagCache";
+
+const retrySchedule = Schedule.intersect(Schedule.exponential("2 seconds"), Schedule.recurs(3));
+
+const isTransientGitHubError = (e: GitHubError): boolean => e instanceof GitHubNetworkError;
+
+export const retryTransient = <A, R>(
+  effect: Effect.Effect<A, GitHubError, R>,
+): Effect.Effect<A, GitHubError, R> =>
+  effect.pipe(Effect.retry({ schedule: retrySchedule, while: isTransientGitHubError }));
+
+function cacheKeyForRequest(apiBase: string, path: string, token: string): string {
+  const separator = path.includes("?") ? "&" : "?";
+  const tokenScope = createHash("sha256").update(token).digest("hex");
+  return buildCacheKey("GET", `${apiBase}${path}${separator}viewer=${tokenScope}`);
+}
+
+/** Pass through known GitHub errors; wrap unknown ones in GitHubNetworkError. */
+export function toGitHubError(e: unknown): GitHubError {
+  if (
+    e instanceof GitHubAuthError ||
+    e instanceof GitHubRateLimitError ||
+    e instanceof GitHubNotFoundError ||
+    e instanceof GitHubNetworkError
+  ) {
+    return e;
+  }
+  return new GitHubNetworkError({ cause: e });
+}
+
+/** Build the standard headers for GitHub API requests. */
+export function githubHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github.v3+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+/** Assert a fetch response is successful, throwing the appropriate domain error on failure. */
+export function assertGitHubOk(res: Response, path: string): void {
+  if (res.status === 401) {
+    throw new GitHubAuthError({ message: "Invalid or expired GitHub token" });
+  }
+  if (res.status === 403 || res.status === 429) {
+    const retryAfter = parseRetryAfter(res.headers.get("Retry-After"));
+    if (retryAfter !== null) {
+      throw new GitHubRateLimitError({
+        resetAt: new Date(Date.now() + retryAfter * 1000),
+        retryAfter,
+        kind: "secondary",
+      });
+    }
+
+    const remaining = res.headers.get("X-RateLimit-Remaining");
+    if (res.status === 403 && remaining === "0") {
+      const resetHeader = res.headers.get("X-RateLimit-Reset");
+      const resetAt = resetHeader ? new Date(Number(resetHeader) * 1000) : new Date();
+      const resource = res.headers.get("X-RateLimit-Resource");
+      throw new GitHubRateLimitError({
+        resetAt,
+        kind: "primary",
+        ...(resource ? { resource } : {}),
+      });
+    }
+
+    if (res.status === 429) {
+      const defaultRetryAfter = 60;
+      throw new GitHubRateLimitError({
+        resetAt: new Date(Date.now() + defaultRetryAfter * 1000),
+        retryAfter: defaultRetryAfter,
+        kind: "secondary",
+      });
+    }
+
+    throw new GitHubNetworkError({
+      cause: `HTTP 403 - access denied for ${path} (check GitHub org OAuth app policies)`,
+    });
+  }
+  if (res.status === 404) {
+    throw new GitHubNotFoundError({ resource: path, id: path });
+  }
+  if (!res.ok) {
+    throw new GitHubNetworkError({ cause: `HTTP ${res.status}` });
+  }
+}
+
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.ceil(seconds);
+  }
+  const retryAt = Date.parse(header);
+  if (Number.isNaN(retryAt)) return null;
+  return Math.max(0, Math.ceil((retryAt - Date.now()) / 1000));
+}
+
+export function githubFetch(
+  path: string,
+  token: string,
+  apiBase: string,
+): Effect.Effect<unknown, GitHubError> {
+  return Effect.withSpan("GitHub.fetch", {
+    attributes: { path, method: "GET" },
+  })(
+    Effect.tryPromise({
+      try: async () => {
+        const res = await fetch(`${apiBase}${path}`, {
+          headers: githubHeaders(token),
+        });
+        assertGitHubOk(res, path);
+        return res.json();
+      },
+      catch: toGitHubError,
+    }),
+  );
+}
+
+export function conditionalFetch(
+  path: string,
+  token: string,
+  apiBase: string,
+): Effect.Effect<unknown, GitHubError, DbService | GitHubEtagCache> {
+  return Effect.gen(function* () {
+    const cache = yield* GitHubEtagCache;
+    const cacheKey = cacheKeyForRequest(apiBase, path, token);
+    const cached = yield* cache.get(cacheKey);
+
+    const result = yield* Effect.tryPromise({
+      try: async () => {
+        const headers: Record<string, string> = githubHeaders(token);
+        if (cached) {
+          headers["If-None-Match"] = cached.etag;
+        }
+        const res = await fetch(`${apiBase}${path}`, { headers });
+
+        if (res.status === 304 && cached) {
+          return { kind: "hit" as const, body: cached.body, bytes: 0 };
+        }
+
+        assertGitHubOk(res, path);
+
+        const bodyText = await res.text();
+        const body = bodyText ? JSON.parse(bodyText) : null;
+        const etag = res.headers.get("ETag");
+        const lastModified = res.headers.get("Last-Modified");
+        return {
+          kind: "miss" as const,
+          body,
+          bytes: bodyText.length,
+          etag,
+          lastModified,
+        };
+      },
+      catch: toGitHubError,
+    });
+
+    if (result.kind === "hit") {
+      recordCacheHit(cache, result.body);
+      return result.body;
+    }
+
+    cache.recordMiss();
+    if (result.etag) {
+      yield* cache.put(cacheKey, result.etag, result.lastModified ?? null, result.body);
+    }
+    return result.body;
+  });
+}
+
+export function conditionalFetchPaginated(
+  path: string,
+  token: string,
+  maxPages: number = 3,
+  apiBase: string,
+  options: {
+    readonly canReplayCached?: (cached: readonly unknown[]) => boolean;
+  } = {},
+): Effect.Effect<unknown[], GitHubError, DbService | GitHubEtagCache> {
+  return Effect.withSpan("GitHub.fetchPaginated.conditional", {
+    attributes: { path, maxPages },
+  })(
+    Effect.gen(function* () {
+      const cache = yield* GitHubEtagCache;
+      const cacheKey = cacheKeyForRequest(apiBase, path, token);
+      const cached = yield* cache.get(cacheKey);
+
+      const result = yield* Effect.tryPromise({
+        try: async () => {
+          const headers: Record<string, string> = githubHeaders(token);
+          if (cached) {
+            headers["If-None-Match"] = cached.etag;
+          }
+
+          const firstUrl = `${apiBase}${path}`;
+          let firstResponse = await fetch(firstUrl, { headers });
+
+          if (firstResponse.status === 304 && cached) {
+            if (Array.isArray(cached.body)) {
+              const replayAllowed = options.canReplayCached?.(cached.body) ?? false;
+              if (replayAllowed) {
+                return { kind: "hit" as const, body: cached.body };
+              }
+            }
+
+            firstResponse = await fetch(firstUrl, { headers: githubHeaders(token) });
+          }
+
+          const results: unknown[] = [];
+          let url: string | null = firstUrl;
+          let etag: string | null = null;
+          let lastModified: string | null = null;
+          let bytes = 0;
+
+          for (let page = 0; page < maxPages && url; page++) {
+            const res =
+              page === 0 ? firstResponse : await fetch(url, { headers: githubHeaders(token) });
+            assertGitHubOk(res, path);
+
+            if (page === 0) {
+              etag = res.headers.get("ETag");
+              lastModified = res.headers.get("Last-Modified");
+            }
+
+            const bodyText = await res.text();
+            bytes += bodyText.length;
+            const data = bodyText ? JSON.parse(bodyText) : [];
+            if (Array.isArray(data)) {
+              results.push(...data);
+            }
+
+            url = parseLinkNext(res.headers.get("Link"));
+          }
+
+          return {
+            kind: "miss" as const,
+            body: results,
+            bytes,
+            etag,
+            lastModified,
+          };
+        },
+        catch: toGitHubError,
+      });
+
+      if (result.kind === "hit") {
+        recordCacheHit(cache, result.body);
+        return [...result.body];
+      }
+
+      cache.recordMiss();
+      if (result.etag) {
+        yield* cache.put(cacheKey, result.etag, result.lastModified, result.body);
+      }
+      return result.body;
+    }),
+  );
+}
+
+function recordCacheHit(
+  cache: { readonly recordHit: (bodyByteSize: number) => void },
+  body: unknown,
+): void {
+  let saved = 0;
+  try {
+    saved = JSON.stringify(body).length;
+  } catch {
+    /* stats are best-effort */
+  }
+  cache.recordHit(saved);
+}
+
+export function githubPost(
+  path: string,
+  token: string,
+  body: Record<string, unknown>,
+  apiBase: string,
+): Effect.Effect<unknown, GitHubError> {
+  return Effect.withSpan("GitHub.post", {
+    attributes: { path, method: "POST" },
+  })(
+    Effect.tryPromise({
+      try: async () => {
+        const res = await fetch(`${apiBase}${path}`, {
+          method: "POST",
+          headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (res.status === 422) {
+          const text = await res.text().catch(() => "");
+          throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
+        }
+        assertGitHubOk(res, path);
+        return res.json();
+      },
+      catch: toGitHubError,
+    }),
+  );
+}
+
+export function githubPatch(
+  path: string,
+  token: string,
+  body: Record<string, unknown>,
+  apiBase: string,
+): Effect.Effect<unknown, GitHubError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const res = await fetch(`${apiBase}${path}`, {
+        method: "PATCH",
+        headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (res.status === 422) {
+        const text = await res.text().catch(() => "");
+        throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
+      }
+      assertGitHubOk(res, path);
+      return res.json();
+    },
+    catch: toGitHubError,
+  });
+}
+
+export function githubPut(
+  path: string,
+  token: string,
+  body: Record<string, unknown>,
+  apiBase: string,
+): Effect.Effect<unknown, GitHubError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const res = await fetch(`${apiBase}${path}`, {
+        method: "PUT",
+        headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (res.status === 405) {
+        const text = await res.text().catch(() => "");
+        throw new GitHubNetworkError({ cause: `HTTP 405 Method Not Allowed: ${text}` });
+      }
+      if (res.status === 422) {
+        const text = await res.text().catch(() => "");
+        throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
+      }
+      assertGitHubOk(res, path);
+      return res.json();
+    },
+    catch: toGitHubError,
+  });
+}
+
+export function githubGraphql<T = unknown>(
+  query: string,
+  variables: Record<string, unknown>,
+  token: string,
+  apiBase: string,
+): Effect.Effect<T, GitHubError> {
+  const operationName = query.match(/(?:query|mutation)\s+(\w+)/)?.[1] ?? "unknown";
+  return Effect.withSpan("GitHub.graphql", {
+    attributes: { operationName },
+  })(
+    Effect.tryPromise({
+      try: async () => {
+        const res = await fetch(`${apiBase}/graphql`, {
+          method: "POST",
+          headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+          body: JSON.stringify({ query, variables }),
+        });
+        assertGitHubOk(res, "/graphql");
+        const payload = (await res.json()) as { data?: T; errors?: Array<{ message: string }> };
+        if (payload.errors && payload.errors.length > 0) {
+          throw new GitHubNetworkError({
+            cause: `GraphQL: ${payload.errors.map((e) => e.message).join("; ")}`,
+          });
+        }
+        if (!payload.data) {
+          throw new GitHubNetworkError({ cause: "GraphQL: empty data field" });
+        }
+        return payload.data;
+      },
+      catch: toGitHubError,
+    }),
+  );
+}
+
+export function parseLinkNext(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+  return match?.[1] ?? null;
+}
+
+export function githubFetchPaginated(
+  path: string,
+  token: string,
+  maxPages: number = 3,
+  apiBase: string,
+): Effect.Effect<unknown[], GitHubError> {
+  return Effect.withSpan("GitHub.fetchPaginated", {
+    attributes: { path, maxPages },
+  })(
+    Effect.tryPromise({
+      try: async () => {
+        const results: unknown[] = [];
+        let url: string | null = `${apiBase}${path}`;
+
+        for (let page = 0; page < maxPages && url; page++) {
+          const res = await fetch(url, {
+            headers: githubHeaders(token),
+          });
+          assertGitHubOk(res, path);
+
+          const data = await res.json();
+          if (Array.isArray(data)) {
+            results.push(...data);
+          }
+
+          url = parseLinkNext(res.headers.get("Link"));
+        }
+
+        return results;
+      },
+      catch: toGitHubError,
+    }),
+  );
+}


### PR DESCRIPTION
Adds typed GitHub rate-limit handling for primary and secondary limits, including Retry-After metadata.
Extracts REST transport helpers from the GitHub gateway and scopes ETag cache keys by API base and token.
Makes paginated ETag replay opt-in, preserves incremental review-comment sync, and adds gateway tests for rate limits, safe replay, and cache boundaries.

Checks: `bun test apps/server/src/services/GitHub.test.ts`; `bun run typecheck && bun run lint && bun run knip && bun run build`.