### PR TITLE
refactor: improve Pierre diff rendering

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/routes/prs.ts
+++ b/apps/server/src/routes/prs.ts
@@ -1,5 +1,10 @@
 import type { DiffLineAnnotation } from "@pierre/diffs";
-import { type CommentThread, guessImageContentType } from "@revv/shared";
+import {
+  buildGitPatchHeader,
+  type CommentThread,
+  guessImageContentType,
+  PR_DIFF_RENDER_OPTIONS,
+} from "@revv/shared";
 import { and, eq } from "drizzle-orm";
 import { Effect } from "effect";
 import { Elysia, t } from "elysia";
@@ -18,7 +23,12 @@ import { GitHubGateway } from "../services/GitHub";
 import { OpencodeSupervisor } from "../services/OpencodeSupervisor";
 import { PollScheduler } from "../services/PollScheduler";
 import { PrContextService } from "../services/PrContext";
-import { prerenderDiff, type SsrDiffOptions } from "../services/PrerenderCache";
+import {
+  prerenderDiff,
+  SSR_PATCH_BYTE_LIMIT,
+  SSR_PATCH_LINE_LIMIT,
+  type SsrDiffOptions,
+} from "../services/PrerenderCache";
 import { PullRequestService } from "../services/PullRequest";
 import { RepoCloneService } from "../services/RepoClone";
 import { RepositoryService } from "../services/Repository";
@@ -35,37 +45,23 @@ import { handleAppError, withAccount } from "./middleware";
 // and DOM-producing options stay client-side; only the layout-affecting
 // fields are mirrored here.
 
-const PR_DIFF_SSR_OPTIONS: SsrDiffOptions = {
-  diffStyle: "unified",
-  theme: { dark: "pierre-dark", light: "pierre-light" },
-  overflow: "scroll",
-  expansionLineCount: 20,
-  collapsedContextThreshold: 3,
-  diffIndicators: "bars",
-  expandUnchanged: true,
-  lineHoverHighlight: "both",
-  hunkSeparators: "line-info",
-};
+const PR_DIFF_SSR_OPTIONS: SsrDiffOptions = PR_DIFF_RENDER_OPTIONS;
 
 /** Build the full git patch the SSR call expects from a cached PR file row. */
 function buildPrFilePatch(file: CachedDiffFile): string {
-  const header = [
-    `diff --git a/${file.oldPath ?? file.path} b/${file.path}`,
-    ...(file.status === "added" ? ["new file mode 100644"] : []),
-    ...(file.status === "removed" ? ["deleted file mode 100644"] : []),
-    `--- ${file.status === "added" ? "/dev/null" : `a/${file.oldPath ?? file.path}`}`,
-    `+++ ${file.status === "removed" ? "/dev/null" : `b/${file.path}`}`,
-  ].join("\n");
+  const header = buildGitPatchHeader({
+    path: file.path,
+    oldPath: file.oldPath,
+    isNew: file.status === "added",
+    isDeleted: file.status === "removed",
+  });
   return file.patch !== null ? `${header}\n${file.patch}` : header;
 }
 
 /**
  * SSR a single PR file, returning the prerendered HTML or undefined if the
- * file has no patch (binary) or rendering failed. No size cap — the user's
- * "no wait on file switch" UX hinges on every file in the PR being
- * prerendered. First-visit cost is paid once per PR head sha (LRU-cached);
- * subsequent /files calls hit the cache. Failures only log — the client
- * always has a working render-path fallback.
+ * file has no patch (binary), exceeds the SSR guardrails, or rendering
+ * failed. The client always has a working render-path fallback.
  */
 function annotationsForFile(
   filePath: string,
@@ -93,6 +89,13 @@ async function prerenderPrFile(
     logError("pr-files-prerender", `prerender failed for ${file.path}:`, err);
     return undefined;
   }
+}
+
+function selectPrerenderPath(files: CachedDiffFile[], activePath?: string): string | null {
+  if (activePath !== undefined && files.some((file) => file.path === activePath)) {
+    return activePath;
+  }
+  return files[0]?.path ?? null;
 }
 
 // ── Routes ───────────────────────────────────────────────────────────────────
@@ -201,47 +204,64 @@ export const prRoutes = new Elysia({ prefix: "/api/prs" })
     },
     { query: t.Object({ repo: t.String() }) },
   )
-  .get("/:id/files", async (ctx) => {
-    try {
-      const { files, threads } = await AppRuntime.runPromise(
-        Effect.gen(function* () {
-          const prService = yield* PullRequestService;
-          const repoService = yield* RepositoryService;
-          const reviewService = yield* ReviewService;
-          const { accountId, accessToken: token } = ctx.account;
+  .get(
+    "/:id/files",
+    async (ctx) => {
+      try {
+        const { files, threads } = await AppRuntime.runPromise(
+          Effect.gen(function* () {
+            const prService = yield* PullRequestService;
+            const repoService = yield* RepositoryService;
+            const reviewService = yield* ReviewService;
+            const { accountId, accessToken: token } = ctx.account;
 
-          const pr = yield* prService.getPr(ctx.params.id, accountId);
-          const repo = yield* repoService.getRepoById(pr.repositoryId, accountId);
+            const pr = yield* prService.getPr(ctx.params.id, accountId);
+            const repo = yield* repoService.getRepoById(pr.repositoryId, accountId);
 
-          // Always the full PR diff (merge-base 3-dot, matching GitHub's
-          // "Files changed" tab). No per-commit selection anymore — the
-          // commits dropdown is read-only.
-          const files = yield* getOrFetchDiffFiles(pr.id, repo.fullName, pr.externalId, token);
-          const session = yield* reviewService.getActiveSession(pr.id);
-          const threads = session ? yield* reviewService.getThreadsForSession(session.id) : [];
-          return { files, threads };
-        }),
-      );
+            // Always the full PR diff (merge-base 3-dot, matching GitHub's
+            // "Files changed" tab). No per-commit selection anymore — the
+            // commits dropdown is read-only.
+            const files = yield* getOrFetchDiffFiles(pr.id, repo.fullName, pr.externalId, token);
+            const session = yield* reviewService.getActiveSession(pr.id);
+            const threads = session ? yield* reviewService.getThreadsForSession(session.id) : [];
+            return { files, threads };
+          }),
+        );
 
-      // SSR each file in parallel — Bun's JS thread interleaves the awaits,
-      // and Shiki's shared highlighter is already warm (preloaded at boot).
-      // Cache hits skip work entirely; misses are bounded by SSR_PATCH_BYTE_LIMIT.
-      return await Promise.all(
-        files.map(async (f) => ({
-          path: f.path,
-          oldPath: f.oldPath,
-          patch: f.patch,
-          additions: f.additions,
-          deletions: f.deletions,
-          isNew: f.status === "added",
-          isDeleted: f.status === "removed",
-          prerenderedHtml: await prerenderPrFile(f, threads),
-        })),
-      );
-    } catch (e) {
-      return handleAppError(e, ctx);
-    }
-  })
+        // SSR only the first visible file. Shiki tokenization is synchronous CPU
+        // work, so rendering every file before returning makes cold /files calls
+        // scale with total PR size. Oversized patches skip SSR entirely and use
+        // the client renderer instead.
+        const prerenderPath = selectPrerenderPath(files, ctx.query.active);
+        return await Promise.all(
+          files.map(async (f) => {
+            const prerenderedHtml =
+              f.path === prerenderPath ? await prerenderPrFile(f, threads) : undefined;
+            return {
+              path: f.path,
+              oldPath: f.oldPath,
+              patch: f.patch,
+              additions: f.additions,
+              deletions: f.deletions,
+              isNew: f.status === "added",
+              isDeleted: f.status === "removed",
+              ...(prerenderedHtml ? { prerenderedHtml } : {}),
+            };
+          }),
+        );
+      } catch (e) {
+        return handleAppError(e, ctx);
+      }
+    },
+    {
+      query: t.Object({
+        active: t.Optional(t.String()),
+      }),
+      detail: {
+        description: `Returns PR files and server-renders at most one diff, capped at ${SSR_PATCH_BYTE_LIMIT} bytes / ${SSR_PATCH_LINE_LIMIT} lines.`,
+      },
+    },
+  )
   .get(
     "/:id/repo-file",
     async (ctx) => {

--- a/apps/server/src/services/PrerenderCache.ts
+++ b/apps/server/src/services/PrerenderCache.ts
@@ -1,6 +1,8 @@
+import { Buffer } from "node:buffer";
 import type { DiffLineAnnotation, FileDiffOptions } from "@pierre/diffs";
 import { preloadHighlighter } from "@pierre/diffs";
 import { preloadPatchDiff, preloadPatchFile } from "@pierre/diffs/ssr";
+import { PIERRE_DIFF_PRELOAD_LANGS, PIERRE_THEMES } from "@revv/shared";
 
 /**
  * Server-side SSR cache for `@pierre/diffs`. Calls `preloadPatchFile` /
@@ -14,28 +16,26 @@ import { preloadPatchDiff, preloadPatchFile } from "@pierre/diffs/ssr";
 
 // ── Defaults ────────────────────────────────────────────────────────────────
 
-/**
- * Same languages the client worker pool preloads
- * (apps/web/src/lib/utils/worker-pool.ts:14-27). Keeping the lists in sync
- * means the SSR HTML lines up byte-for-byte with what the client would
- * produce on a cold render.
- */
-const PRELOAD_LANGS = [
-  "typescript",
-  "javascript",
-  "svelte",
-  "css",
-  "json",
-  "python",
-  "go",
-  "rust",
-  "html",
-  "shellscript",
-  "yaml",
-  "sql",
-] as const;
+export const SSR_PATCH_BYTE_LIMIT = 256 * 1024;
+export const SSR_PATCH_LINE_LIMIT = 6_000;
 
-const PRELOAD_THEMES = ["pierre-dark", "pierre-light"] as const;
+function lineCountWithinLimit(content: string, limit: number): boolean {
+  let lines = content.length === 0 ? 0 : 1;
+  for (let i = 0; i < content.length; i++) {
+    if (content.charCodeAt(i) === 10) {
+      lines++;
+      if (lines > limit) return false;
+    }
+  }
+  return true;
+}
+
+function canPrerenderPatch(patch: string): boolean {
+  return (
+    Buffer.byteLength(patch, "utf8") <= SSR_PATCH_BYTE_LIMIT &&
+    lineCountWithinLimit(patch, SSR_PATCH_LINE_LIMIT)
+  );
+}
 
 // ── Highlighter priming ─────────────────────────────────────────────────────
 
@@ -50,8 +50,8 @@ let highlighterReady: Promise<void> | null = null;
 export function ensureHighlighter(): Promise<void> {
   if (highlighterReady === null) {
     highlighterReady = preloadHighlighter({
-      themes: [...PRELOAD_THEMES],
-      langs: [...PRELOAD_LANGS],
+      themes: [...PIERRE_THEMES],
+      langs: [...PIERRE_DIFF_PRELOAD_LANGS],
     });
   }
   return highlighterReady;
@@ -127,6 +127,8 @@ export async function prerenderDiff(
   options: SsrDiffOptions,
   annotations?: DiffLineAnnotation<unknown>[],
 ): Promise<string | null> {
+  if (!canPrerenderPatch(patch)) return null;
+
   await ensureHighlighter();
 
   const optionsKey = stableOptionsKey(options);

--- a/apps/web/src/lib/components/review/DiffViewer.svelte
+++ b/apps/web/src/lib/components/review/DiffViewer.svelte
@@ -17,8 +17,9 @@ import {
   resolveThread,
 } from "$lib/stores/review.svelte";
 import type { CommentThread, ReviewFile, ThreadMessage } from "$lib/types/review";
-import type { ThreadMeta, TokenHoverInfo } from "./DiffViewerInner.svelte";
+import type { TokenHoverInfo } from "./DiffViewerInner.svelte";
 import DiffViewerInner from "./DiffViewerInner.svelte";
+import type { ThreadMeta } from "./pierre-diff-adapter";
 
 // ── Re-export for consumers ───────────────────────────────────────────────
 
@@ -38,6 +39,7 @@ interface Props {
   onLineClick?: (info: LineClickInfo) => void;
   onModeChange?: (mode: "unified" | "split") => void;
   onTokenHover?: (info: TokenHoverInfo | null) => void;
+  scrollRoot?: HTMLElement | null;
   /** When set, triggers opening a comment input at the given line range. */
   commentTrigger?: {
     startLine: number;
@@ -47,7 +49,14 @@ interface Props {
   } | null;
 }
 
-let { file, onLineClick, onModeChange, onTokenHover, commentTrigger = null }: Props = $props();
+let {
+  file,
+  onLineClick,
+  onModeChange,
+  onTokenHover,
+  commentTrigger = null,
+  scrollRoot = null,
+}: Props = $props();
 
 // ── Interaction state ─────────────────────────────────────────────────────
 
@@ -278,6 +287,7 @@ async function handleEditMessage(threadId: string, messageId: string, body: stri
 			{onTokenHover}
 			onApplySuggestion={handleApplySuggestion}
 			onEditMessage={handleEditMessage}
+			{scrollRoot}
 		/>
 	{/key}
 {/if}

--- a/apps/web/src/lib/components/review/DiffViewerInner.svelte
+++ b/apps/web/src/lib/components/review/DiffViewerInner.svelte
@@ -1,659 +1,661 @@
-<script lang="ts" module>
-// ── ThreadMeta ─────────────────────────────────────────────────────────────
-// Exported so DiffViewer can import and use the same type.
-export interface ThreadMeta {
-  threadId: string;
-  status: string;
-  messageCount: number;
-  isExpanded: boolean;
-  isInputActive: boolean;
-  isReplying: boolean;
-  isPending: boolean;
-}
-</script>
-
 <script lang="ts">
-	import {
-		DIFFS_TAG_NAME,
-		FileDiff,
-		HEADER_METADATA_SLOT_ID,
-		HEADER_PREFIX_SLOT_ID,
-		parsePatchFiles,
-		type DiffLineAnnotation,
-		type FileDiffMetadata,
-		type FileDiffOptions,
-		type DiffTokenEventBaseProps
-	} from '@pierre/diffs';
-	import type { ReviewFile, CommentThread, ThreadMessage } from '$lib/types/review';
-	import { workerManager } from '$lib/utils/worker-pool';
-	import { onMount, onDestroy } from 'svelte';
-	import { mountInto, cleanupAllMounted, pruneDetachedMounts } from '$lib/utils/annotation-mount';
-	import {
-		ANNOTATION_HOST_STYLE,
-		createMarkerDot,
-		mountAnnotationThread
-	} from './annotation-renderers';
-	import AnnotationCommentInput from './AnnotationCommentInput.svelte';
-	import type { LineClickInfo } from './DiffViewer.svelte';
-	import {
-		getActivePanel,
-		getCursorLineIndex,
-		getCursorSide,
-		getAnchorLineIndex,
-		setTotalLineCount,
-		isInLineCursorMode
-	} from '$lib/stores/focus-mode.svelte';
-	import { countPatchLines } from '$lib/utils/count-patch-lines';
-	import { getPendingDiffJump, clearPendingDiffJump } from '$lib/stores/review.svelte';
-
-	// ── Token hover info ──────────────────────────────────────────────────────
-
-	export interface TokenHoverInfo {
-		tokenText: string;
-		lineNumber: number;
-		side: string;
-		element: HTMLElement;
-	}
-
-	// ── Props ─────────────────────────────────────────────────────────────────
-
-	interface Props {
-		file: ReviewFile;
-		mode: 'unified' | 'split';
-		annotations: DiffLineAnnotation<ThreadMeta>[];
-		/** Map from threadId → messages, for expanded thread rendering */
-		threadMessages: Record<string, ThreadMessage[]>;
-		/** Map from threadId → CommentThread, for expanded thread rendering */
-		threadById: Record<string, CommentThread>;
-		onLineClick?: ((info: LineClickInfo) => void) | undefined;
-		onModeChange?: ((mode: 'unified' | 'split') => void) | undefined;
-		onAnnotationToggle?: ((threadId: string) => void) | undefined;
-		onReplyToggle?: ((threadId: string) => void) | undefined;
-		onReplySubmit?: ((threadId: string, body: string) => void) | undefined;
-		onCommentSubmit?: ((filePath: string, lineNo: number, side: 'deletions' | 'additions', body: string) => void) | undefined;
-		onCommentDismiss?: ((filePath: string, lineNo: number) => void) | undefined;
-		onCommentResolve?: ((threadId: string) => void) | undefined;
-		onCommentReopen?: ((threadId: string) => void) | undefined;
-		onCommentDiscard?: ((threadId: string) => void) | undefined;
-		onDiscardReply?: ((threadId: string, messageId: string) => void) | undefined;
-		onTokenHover?: ((info: TokenHoverInfo | null) => void) | undefined;
-		onApplySuggestion?: ((threadId: string, suggestion: string) => void) | undefined;
-		onEditMessage?: ((threadId: string, messageId: string, body: string) => void) | undefined;
-	}
-
-	let {
-		file,
-		mode,
-		annotations,
-		threadMessages,
-		threadById,
-		onLineClick,
-		onModeChange,
-		onAnnotationToggle,
-		onReplyToggle,
-		onReplySubmit,
-		onCommentSubmit,
-		onCommentDismiss,
-		onCommentResolve,
-		onCommentReopen,
-		onCommentDiscard,
-		onDiscardReply,
-		onTokenHover,
-		onApplySuggestion,
-		onEditMessage
-	}: Props = $props();
-
-	// ── Header DOM helpers ────────────────────────────────────────────────────
-	// The library's callbacks must return light-DOM Elements.  These helpers keep
-	// the option-object readable by separating construction from composition.
-
-	const SVG_UNIFIED = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="3.5" y1="4.5" x2="12.5" y2="4.5"/><line x1="3.5" y1="8" x2="12.5" y2="8"/><line x1="3.5" y1="11.5" x2="12.5" y2="11.5"/></svg>`;
-	const SVG_SPLIT = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><rect x="2" y="2.5" width="12" height="11" rx="1.5"/><line x1="8" y1="2.5" x2="8" y2="13.5"/></svg>`;
-
-	function buildViewModePill(
-		currentMode: 'unified' | 'split',
-		onChange: ((mode: 'unified' | 'split') => void) | undefined
-	): HTMLElement {
-		function makeBtn(svg: string, label: string, active: boolean): HTMLElement {
-			const btn = document.createElement('div');
-			btn.innerHTML = svg;
-			btn.title = label;
-			btn.setAttribute('role', 'button');
-			btn.setAttribute('aria-label', label);
-			btn.dataset.viewBtn = active ? 'active' : '';
-			return btn;
-		}
-
-		const pill = document.createElement('div');
-		pill.dataset.viewPill = '';
-
-		const unifiedBtn = makeBtn(SVG_UNIFIED, 'Unified view', currentMode === 'unified');
-		const splitBtn = makeBtn(SVG_SPLIT, 'Split view', currentMode === 'split');
-
-		unifiedBtn.addEventListener('click', (e) => { e.stopPropagation(); onChange?.('unified'); });
-		splitBtn.addEventListener('click', (e) => { e.stopPropagation(); onChange?.('split'); });
-
-		const sep = document.createElement('div');
-		sep.dataset.viewSep = '';
-
-		pill.appendChild(unifiedBtn);
-		pill.appendChild(sep);
-		pill.appendChild(splitBtn);
-		return pill;
-	}
-
-	// ── Base shadow-DOM CSS (always injected) ─────────────────────────────────
-	const BASE_CSS = `[data-diffs-header='default'] { position: static !important; }`;
-
-	// ── Header slot population (SSR-hydrate path) ─────────────────────────────
-	// Pierre's `hydrate` doesn't run renderHeaderPrefix / renderHeaderMetadata
-	// — only `render` does. After hydrate we recreate the slot DIVs the lib
-	// would have appended (FileDiff.js:622-655) so the file-status badge and
-	// the unified/split toggle pill appear inside the SSR'd header.
-	function populateHeaderSlots(
-		hostEl: HTMLElement,
-		fileDiff: FileDiffMetadata,
-		opts: FileDiffOptions<ThreadMeta>
-	): void {
-		function appendSlot(
-			slotName: string,
-			content: string | number | Element | null | undefined
-		): void {
-			if (content == null) return;
-			const slotEl = document.createElement('div');
-			slotEl.slot = slotName;
-			if (content instanceof Element) slotEl.appendChild(content);
-			else slotEl.innerText = String(content);
-			hostEl.appendChild(slotEl);
-		}
-		appendSlot(HEADER_PREFIX_SLOT_ID, opts.renderHeaderPrefix?.(fileDiff));
-		appendSlot(HEADER_METADATA_SLOT_ID, opts.renderHeaderMetadata?.(fileDiff));
-	}
-
-	// ── Local state ───────────────────────────────────────────────────────────
-
-	let wrapperEl: HTMLDivElement | null = null;
-	let instance = $state.raw<FileDiff<ThreadMeta> | null>(null);
-	let error = $state<string | null>(null);
-	/** Reference to the original options object for setOptions() merging. */
-	let initialOptions: FileDiffOptions<ThreadMeta> | null = null;
-	/**
-	 * Last annotations reference that has been applied to the FileDiff instance
-	 * — either by the initial render()/hydrate() in onMount, or by the
-	 * annotations $effect below. Used as a guard so the $effect skips its
-	 * eager initial run (which would re-render with forceRender:true and wipe
-	 * the SSR-hydrated tokens, forcing a cold worker tokenization).
-	 */
-	let appliedAnnotations: DiffLineAnnotation<ThreadMeta>[] | null = null;
-	let appliedThreadById: Record<string, CommentThread> | null = null;
-	let appliedThreadMessages: Record<string, ThreadMessage[]> | null = null;
-
-	/**
-	 * Mutable reference that renderAnnotation reads from. This avoids the
-	 * stale-closure problem: the callback is defined once in onMount but
-	 * needs to see the latest threadById / threadMessages when threads load
-	 * asynchronously after the initial render.
-	 */
-	const threadDataRef = {
-		threadById: {} as Record<string, CommentThread>,
-		threadMessages: {} as Record<string, ThreadMessage[]>,
-	};
-
-	// Note: $effect blocks that guard on `!instance` or `!initialOptions` rely on
-	// Svelte 5's ordering guarantee that onMount runs before $effects first execute.
-	// This is intentional — do not make instance $state (it would deep-proxy a large object).
-
-	function captureEl(el: HTMLDivElement) {
-		wrapperEl = el;
-		return {
-			destroy() {
-				wrapperEl = null;
-			}
-		};
-	}
-
-	// ── Shadow DOM helpers ────────────────────────────────────────────────────
-
-	/** Walk children looking for an element with a shadowRoot. */
-	function findShadowHost(container: HTMLElement): HTMLElement | null {
-		for (const child of container.children) {
-			if (child instanceof HTMLElement && child.shadowRoot) return child;
-		}
-		for (const child of container.children) {
-			if (child instanceof HTMLElement) {
-				for (const grandchild of child.children) {
-					if (grandchild instanceof HTMLElement && grandchild.shadowRoot) return grandchild;
-				}
-			}
-		}
-		return null;
-	}
-
-	function getShadowRoot(): ShadowRoot | null {
-		if (!wrapperEl) return null;
-		const host = findShadowHost(wrapperEl);
-		return host?.shadowRoot ?? null;
-	}
-
-	/**
-	 * Given a patch string and a target new-file line number, return the
-	 * 0-based `data-line-index` of the closest non-deletion line in the patch.
-	 */
-	function findPatchLineIndex(patch: string, targetLine: number): number | null {
-		const lines = patch.split('\n');
-		let patchLineIdx = 0;
-		let newLineNum = 0;
-		let bestIdx: number | null = null;
-
-		for (const raw of lines) {
-			if (raw.startsWith('@@')) {
-				// Parse hunk header: @@ -old,count +new,count @@
-				const m = /\+(\d+)/.exec(raw);
-				if (m?.[1]) {
-					newLineNum = parseInt(m[1], 10) - 1;
-				}
-				// hunk headers don't get a data-line-index slot
-				continue;
-			}
-			if (raw.startsWith('-')) {
-				// deletion — advances no new line number, but does occupy a patch line index
-				patchLineIdx++;
-				continue;
-			}
-			// context or addition
-			patchLineIdx++;
-			newLineNum++;
-			if (newLineNum >= targetLine) {
-				return patchLineIdx - 1;
-			}
-			bestIdx = patchLineIdx - 1;
-		}
-		return bestIdx;
-	}
-
-	// ─ Reactive updates ──────────────────────────────────────────────────────
-	// Re-render when thread data changes. The reference-equality guard skips
-	// the eager initial $effect run — at that point onMount has already rendered
-	// via render()/hydrate(). When threads load asynchronously, threadById,
-	// threadMessages, and annotations all get new references, triggering this
-	// effect. We update the mutable ref (so renderAnnotation sees fresh data),
-	// clear stale caches, and re-render with the new annotations.
-	$effect(() => {
-		if (!instance) return;
-		const currentAnnotations = annotations;
-		const currentThreadById = threadById;
-		const currentThreadMessages = threadMessages;
-		if (
-			currentAnnotations === appliedAnnotations &&
-			currentThreadById === appliedThreadById &&
-			currentThreadMessages === appliedThreadMessages
-		) return;
-		appliedAnnotations = currentAnnotations;
-		appliedThreadById = currentThreadById;
-		appliedThreadMessages = currentThreadMessages;
-
-		// Update mutable ref so renderAnnotation callback (defined once in
-		// onMount) reads fresh thread data.
-		threadDataRef.threadById = currentThreadById;
-		threadDataRef.threadMessages = currentThreadMessages;
-
-		// NOTE: do NOT clear `annotationCache` here. The library's
-		// renderAnnotations() is self-cleaning — it removes the previous wrapper
-		// before appending a new one whenever an annotation changed. Our store
-		// hands it a fresh `metadata` object every render and the library compares
-		// metadata by reference, so renderAnnotation always re-runs (picking up
-		// fresh thread data) AND the old row is removed. Calling `.clear()` empties
-		// the cache Map without removing the wrapper <div>s from the shadow DOM, so
-		// the next render appends fresh rows alongside the orphans → duplicate
-		// comments. That was the diff-tab comment-duplication bug.
-
-		// Clear header slots before re-render to prevent badge duplication.
-		// The library's applyHeaderToDOM reuses slot elements by reference; if
-		// the header HTML is regenerated (forceRender), old slot refs point to
-		// removed DOM nodes, causing new slots to be created alongside them.
-		// @ts-expect-error clearHeaderSlots is protected
-		instance.clearHeaderSlots?.();
-
-		// Re-render with new annotations. Must pass lineAnnotations so the
-		// library updates its internal state and creates annotation rows.
-		instance.render({ lineAnnotations: currentAnnotations, forceRender: true });
-
-		// The library removes the previous annotation wrappers via element.remove(),
-		// but the Svelte components we mounted inside them stay registered and live.
-		// Unmount the now-detached ones so their effects/listeners don't leak.
-		pruneDetachedMounts();
-	});
-
-	// ── Line cursor highlight (diff-line mode) ────────────────────────────────
-	$effect(() => {
-		if (!instance || !initialOptions) return;
-		const panel = getActivePanel();
-		const lineIdx = getCursorLineIndex();
-
-		if (panel === 'diff-line') {
-			const css = `${BASE_CSS} [data-line-index="${lineIdx}"] { background-color: var(--color-tree-active-bg) !important; outline: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent); outline-offset: -1px; }`;
-			instance.setOptions({ ...initialOptions, unsafeCSS: css });
-		} else if (panel !== 'diff-visual') {
-			// Clear highlight when not in line/visual mode
-			// (visual mode uses setSelectedLines instead)
-			instance.setOptions({ ...initialOptions, unsafeCSS: BASE_CSS });
-		}
-	});
-
-	// ── Scroll active line into view ──────────────────────────────────────────
-	$effect(() => {
-		if (!isInLineCursorMode()) return;
-		const lineIdx = getCursorLineIndex();
-
-		requestAnimationFrame(() => {
-			const shadowRoot = getShadowRoot();
-			if (!shadowRoot) return;
-			const lineEl = shadowRoot.querySelector<HTMLElement>(`[data-line-index="${lineIdx}"]`);
-			if (lineEl) {
-				lineEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-			}
-		});
-	});
-
-	// ── Walkthrough → diff jump ───────────────────────────────────────────────
-	$effect(() => {
-		const jump = getPendingDiffJump();
-		if (!jump || jump.filePath !== file.path || !file.patch) return;
-
-		// Clear first — instance is $state.raw so this effect won't re-run for it;
-		// clearing early prevents another instance from picking up the same jump
-		clearPendingDiffJump();
-
-		if (!instance) return;
-
-		const patchLineIdx = findPatchLineIndex(file.patch, jump.lineNumber);
-		if (patchLineIdx === null) return;
-
-		setTimeout(() => {
-			requestAnimationFrame(() => {
-				const shadowRoot = getShadowRoot();
-				if (!shadowRoot) return;
-				const lineEl = shadowRoot.querySelector<HTMLElement>(`[data-line-index="${patchLineIdx}"]`);
-				if (lineEl) {
-					lineEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-				}
-			});
-		}, 50);
-	});
-
-	// ── Visual line selection (diff-visual mode) ──────────────────────────────
-	$effect(() => {
-		if (!instance) return;
-		const panel = getActivePanel();
-
-		if (panel === 'diff-visual') {
-			const cursor = getCursorLineIndex();
-			const anchor = getAnchorLineIndex();
-			if (anchor === null) return;
-
-			const start = Math.min(anchor, cursor);
-			const end = Math.max(anchor, cursor);
-			const side = getCursorSide();
-
-			// With exactOptionalPropertyTypes, omit side entirely when null
-			const range = side !== null
-				? { start, end, side, endSide: side }
-				: { start, end };
-
-			instance.setSelectedLines(range);
-			// Clear unsafeCSS line highlight — selection replaces it
-			if (initialOptions) {
-				instance.setOptions({ ...initialOptions, unsafeCSS: BASE_CSS });
-			}
-		} else {
-			// Clear selection when leaving visual mode
-			instance.setSelectedLines(null);
-		}
-	});
-
-	// ── Instance lifecycle ────────────────────────────────────────────────────
-
-	onMount(() => {
-		if (!wrapperEl) return;
-
-		try {
-			const options: FileDiffOptions<ThreadMeta> = {
-				diffStyle: mode,
-				theme: { dark: 'pierre-dark', light: 'pierre-light' },
-				overflow: 'scroll',
-				expansionLineCount: 20,
-				collapsedContextThreshold: 3,
-				diffIndicators: 'bars',
-				expandUnchanged: true,
-				lineHoverHighlight: 'both',
-				enableGutterUtility: true,
-				enableLineSelection: true,
-				unsafeCSS: BASE_CSS,
-
-				// ── Hunk separators: Pierre's built-in line-info renders the
-				// "@@ -X,Y +A,B @@" range, an expand-up / expand-down button,
-				// and uses container queries (gated on this exact value) to size
-				// itself inside a constrained parent.
-				hunkSeparators: 'line-info',
-
-				// ── Header: file status badge ──────────────────────────────────
-				renderHeaderPrefix(fileDiff) {
-					const wrap = document.createElement('span');
-					wrap.style.cssText = 'display:flex;align-items:center;gap:6px;';
-
-					const type = fileDiff.type;
-					if (
-						type === 'new' ||
-						type === 'deleted' ||
-						type === 'rename-pure' ||
-						type === 'rename-changed'
-					) {
-						const badge = document.createElement('span');
-						const label =
-							type === 'new' ? 'new' : type === 'deleted' ? 'deleted' : 'renamed';
-					const color =
-						type === 'new'
-							? 'var(--color-success)'
-							: type === 'deleted'
-								? 'var(--color-danger)'
-								: 'var(--color-warning)';
-						badge.textContent = label;
-						badge.style.cssText = `font-size:9px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;background:color-mix(in srgb, ${color} 13%, transparent);color:${color};border-radius:3px;padding:1px 5px;`;
-						wrap.appendChild(badge);
-					}
-
-					return wrap;
-				},
-
-				// ── Header: unified/split icon pill toggle ──────────────────────
-				renderHeaderMetadata(_fileDiff) {
-					return buildViewModePill(mode, onModeChange);
-				},
-
-				// ── Token hover ────────────────────────────────────────────────
-				onTokenEnter(props: DiffTokenEventBaseProps) {
-					onTokenHover?.({
-						tokenText: props.tokenText,
-						lineNumber: props.lineNumber,
-						side: props.side,
-						element: props.tokenElement
-					});
-				},
-				onTokenLeave() {
-					onTokenHover?.(null);
-				},
-
-				// ── Line click → bubble up ─────────────────────────────────────
-				onLineClick(props) {
-					if (!onLineClick) return;
-					const code = props.lineElement?.textContent ?? '';
-					const rect = props.lineElement?.getBoundingClientRect() ?? new DOMRect();
-					onLineClick({
-						filePath: file.path,
-						lineNumber: props.lineNumber,
-						side: props.annotationSide,
-						lineType: props.lineType,
-						code,
-						rect
-					});
-				},
-
-				// ── Annotation rendering ───────────────────────────────────────
-				renderAnnotation(annotation) {
-					const meta = annotation.metadata;
-					if (!meta) return undefined;
-
-					const host = document.createElement('div');
-					host.style.cssText = ANNOTATION_HOST_STYLE;
-
-					if (meta.isInputActive) {
-						mountInto(host, AnnotationCommentInput, {
-							filePath: file.path,
-							lineNo: annotation.lineNumber,
-							onSubmit: (body: string) => {
-								onCommentSubmit?.(
-									file.path,
-									annotation.lineNumber,
-									annotation.side,
-									body
-								);
-							},
-							onDismiss: () => {
-								onCommentDismiss?.(file.path, annotation.lineNumber);
-							}
-						});
-					} else if (meta.isExpanded) {
-						// Read from mutable ref so we always see latest thread data
-						// even though this callback was defined once in onMount.
-						const thread = threadDataRef.threadById[meta.threadId];
-						const messages = threadDataRef.threadMessages[meta.threadId] ?? [];
-						if (!thread) return host;
-
-						mountAnnotationThread(host, {
-							thread,
-							messages,
-							threadId: meta.threadId,
-							isReplying: meta.isReplying,
-							isPending: meta.isPending,
-							onReplyToggle,
-							onCommentResolve,
-							onCommentReopen,
-							onCommentDiscard,
-							onDiscardReply,
-							onAnnotationToggle,
-							onApplySuggestion,
-							onReplySubmit,
-							onEditMessage
-						});
-					} else {
-						host.appendChild(
-							createMarkerDot(meta, () => onAnnotationToggle?.(meta.threadId))
-						);
-					}
-
-					return host;
-				},
-
-				onPostRender(node) {
-					// Pierre hardcodes `pre.tabIndex = 0` (see setWrapperNodeProps)
-					// with no opt-out. We use focus-mode for line-level keyboard
-					// navigation instead, so opt this pre out of the tab order.
-					const pre = node.shadowRoot?.querySelector('pre');
-					if (pre) pre.tabIndex = -1;
-				}
-			};
-
-			instance = new FileDiff<ThreadMeta>(options, workerManager);
-			// Store reference for setOptions() merging
-			initialOptions = options;
-
-			// Update threadDataRef BEFORE render/hydrate so renderAnnotation
-			// callback sees current thread data on the initial render.
-			threadDataRef.threadById = threadById;
-			threadDataRef.threadMessages = threadMessages;
-
-			// Parse the git patch string directly — this preserves the exact
-			// additions/deletions counts from GitHub's diff, so the library's
-			// header stats match the file tree without any overrides.
-			const patchHeader = [
-				`diff --git a/${file.oldPath ?? file.path} b/${file.path}`,
-				...(file.isNew ? ['new file mode 100644'] : []),
-				...(file.isDeleted ? ['deleted file mode 100644'] : []),
-				`--- ${file.isNew ? '/dev/null' : `a/${file.oldPath ?? file.path}`}`,
-				`+++ ${file.isDeleted ? '/dev/null' : `b/${file.path}`}`,
-			].join('\n');
-			const fullPatch = file.patch
-				? `${patchHeader}\n${file.patch}`
-				: patchHeader;
-			const patches = parsePatchFiles(fullPatch);
-			const parsed = patches[0]?.files[0];
-			if (!parsed) {
-				error = 'Failed to parse patch';
-				return;
-			}
-
-			// SSR-hydrate only when the server has prerendered HTML for unified
-			// mode (the server doesn't know the user's mode preference; split
-			// always falls through to render()). Hydrate skips the worker
-			// tokenize round-trip — the diff body paints synchronously and
-			// interaction managers attach to the existing DOM.
-			//
-			// Pierre's `hydrate` doesn't invoke `renderHeaderPrefix` /
-			// `renderHeaderMetadata` (only `render` does). So we manually
-			// populate the header slots after hydrate using the exported slot
-			// IDs — Pierre's shadow DOM has `<slot name="...">` placeholders
-			// that project these light-DOM children.
-			if (file.prerenderedHtml !== undefined && mode === 'unified') {
-				// Match the render() DOM structure: a <diffs-container> custom element
-				// as the shadow host inside wrapperEl. The tag name matters — app.css
-				// :900 overrides `diffs-container { color-scheme: inherit }` so Pierre's
-				// `light-dark()` token colors follow <html>'s theme instead of the OS.
-				// A plain <div> would skip that rule and produce mismatched colors
-				// (light tokens on a dark app background) for the entire SSR-visible
-				// window — until the worker re-render replaces them.
-				const hostEl = document.createElement(DIFFS_TAG_NAME);
-				wrapperEl.appendChild(hostEl);
-				instance.hydrate({
-					fileContainer: hostEl,
-					prerenderedHTML: file.prerenderedHtml,
-					fileDiff: parsed,
-					lineAnnotations: annotations,
-				});
-				populateHeaderSlots(hostEl, parsed, options);
-			} else {
-				instance.render({
-					containerWrapper: wrapperEl,
-					fileDiff: parsed,
-					lineAnnotations: annotations,
-					forceRender: true
-				});
-			}
-			// Mark initial state as applied so the post-mount $effect
-			// (which would otherwise re-render with forceRender:true) is a no-op.
-			appliedAnnotations = annotations;
-			appliedThreadById = threadById;
-			appliedThreadMessages = threadMessages;
-
-			// Set total line count for keyboard cursor navigation
-			if (file.patch) {
-				setTotalLineCount(countPatchLines(file.patch));
-			}
-
-		} catch (e) {
-			console.error('[DiffViewerInner] Render error:', e);
-			error = e instanceof Error ? e.message : String(e);
-		}
-	});
-
-	onDestroy(() => {
-		cleanupAllMounted();
-		try {
-			instance?.cleanUp();
-		} catch {
-			// ignore cleanup errors
-		}
-		instance = null;
-	});
+import {
+  DEFAULT_VIRTUAL_FILE_METRICS,
+  type DiffLineAnnotation,
+  type DiffTokenEventBaseProps,
+  FileDiff,
+  type FileDiffMetadata,
+  type FileDiffOptions,
+  parsePatchFiles,
+  VirtualizedFileDiff,
+} from "@pierre/diffs";
+import { buildGitPatchHeader, PIERRE_THEME, PR_DIFF_RENDER_OPTIONS } from "@revv/shared";
+import { onDestroy, onMount } from "svelte";
+import {
+  getActivePanel,
+  getAnchorLineIndex,
+  getCursorLineIndex,
+  getCursorSide,
+  isInLineCursorMode,
+  setTotalLineCount,
+} from "$lib/stores/focus-mode.svelte";
+import { clearPendingDiffJump, getPendingDiffJump } from "$lib/stores/review.svelte";
+import type { CommentThread, ReviewFile, ThreadMessage } from "$lib/types/review";
+import { cleanupAllMounted, mountInto, pruneDetachedMounts } from "$lib/utils/annotation-mount";
+import { countPatchLines } from "$lib/utils/count-patch-lines";
+import { workerManager } from "$lib/utils/worker-pool";
+import AnnotationCommentInput from "./AnnotationCommentInput.svelte";
+import {
+  ANNOTATION_HOST_STYLE,
+  createMarkerDot,
+  mountAnnotationThread,
+} from "./annotation-renderers";
+import type { LineClickInfo } from "./DiffViewer.svelte";
+import {
+  createDiffsHost,
+  createHeaderBadge,
+  createPierreVirtualizer,
+  getPierreShadowRoot,
+  PIERRE_BASE_CSS,
+  populateDiffHeaderSlots,
+  type ThreadMeta,
+} from "./pierre-diff-adapter";
+
+// ── Token hover info ──────────────────────────────────────────────────────
+
+export interface TokenHoverInfo {
+  tokenText: string;
+  lineNumber: number;
+  side: string;
+  element: HTMLElement;
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────
+
+interface Props {
+  file: ReviewFile;
+  mode: "unified" | "split";
+  annotations: DiffLineAnnotation<ThreadMeta>[];
+  /** Map from threadId → messages, for expanded thread rendering */
+  threadMessages: Record<string, ThreadMessage[]>;
+  /** Map from threadId → CommentThread, for expanded thread rendering */
+  threadById: Record<string, CommentThread>;
+  onLineClick?: ((info: LineClickInfo) => void) | undefined;
+  onModeChange?: ((mode: "unified" | "split") => void) | undefined;
+  onAnnotationToggle?: ((threadId: string) => void) | undefined;
+  onReplyToggle?: ((threadId: string) => void) | undefined;
+  onReplySubmit?: ((threadId: string, body: string) => void) | undefined;
+  onCommentSubmit?:
+    | ((filePath: string, lineNo: number, side: "deletions" | "additions", body: string) => void)
+    | undefined;
+  onCommentDismiss?: ((filePath: string, lineNo: number) => void) | undefined;
+  onCommentResolve?: ((threadId: string) => void) | undefined;
+  onCommentReopen?: ((threadId: string) => void) | undefined;
+  onCommentDiscard?: ((threadId: string) => void) | undefined;
+  onDiscardReply?: ((threadId: string, messageId: string) => void) | undefined;
+  onTokenHover?: ((info: TokenHoverInfo | null) => void) | undefined;
+  onApplySuggestion?: ((threadId: string, suggestion: string) => void) | undefined;
+  onEditMessage?: ((threadId: string, messageId: string, body: string) => void) | undefined;
+  scrollRoot?: HTMLElement | null;
+}
+
+let {
+  file,
+  mode,
+  annotations,
+  threadMessages,
+  threadById,
+  onLineClick,
+  onModeChange,
+  onAnnotationToggle,
+  onReplyToggle,
+  onReplySubmit,
+  onCommentSubmit,
+  onCommentDismiss,
+  onCommentResolve,
+  onCommentReopen,
+  onCommentDiscard,
+  onDiscardReply,
+  onTokenHover,
+  onApplySuggestion,
+  onEditMessage,
+  scrollRoot = null,
+}: Props = $props();
+
+// ── Header DOM helpers ────────────────────────────────────────────────────
+// The library's callbacks must return light-DOM Elements.  These helpers keep
+// the option-object readable by separating construction from composition.
+
+const SVG_UNIFIED = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><line x1="3.5" y1="4.5" x2="12.5" y2="4.5"/><line x1="3.5" y1="8" x2="12.5" y2="8"/><line x1="3.5" y1="11.5" x2="12.5" y2="11.5"/></svg>`;
+const SVG_SPLIT = `<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><rect x="2" y="2.5" width="12" height="11" rx="1.5"/><line x1="8" y1="2.5" x2="8" y2="13.5"/></svg>`;
+
+function buildViewModePill(
+  currentMode: "unified" | "split",
+  onChange: ((mode: "unified" | "split") => void) | undefined,
+): HTMLElement {
+  function makeBtn(svg: string, label: string, active: boolean): HTMLElement {
+    const btn = document.createElement("div");
+    btn.innerHTML = svg;
+    btn.title = label;
+    btn.setAttribute("role", "button");
+    btn.setAttribute("aria-label", label);
+    btn.dataset.viewBtn = active ? "active" : "";
+    return btn;
+  }
+
+  const pill = document.createElement("div");
+  pill.dataset.viewPill = "";
+
+  const unifiedBtn = makeBtn(SVG_UNIFIED, "Unified view", currentMode === "unified");
+  const splitBtn = makeBtn(SVG_SPLIT, "Split view", currentMode === "split");
+
+  unifiedBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    onChange?.("unified");
+  });
+  splitBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    onChange?.("split");
+  });
+
+  const sep = document.createElement("div");
+  sep.dataset.viewSep = "";
+
+  pill.appendChild(unifiedBtn);
+  pill.appendChild(sep);
+  pill.appendChild(splitBtn);
+  return pill;
+}
+
+// ── Local state ───────────────────────────────────────────────────────────
+
+let wrapperEl: HTMLDivElement | null = null;
+let instance = $state.raw<FileDiff<ThreadMeta> | VirtualizedFileDiff<ThreadMeta> | null>(null);
+let error = $state<string | null>(null);
+/** Reference to the original options object for setOptions() merging. */
+let initialOptions: FileDiffOptions<ThreadMeta> | null = null;
+let virtualizer = $state.raw<ReturnType<typeof createPierreVirtualizer> | null>(null);
+let parsedFileDiff: FileDiffMetadata | null = null;
+/**
+ * Last annotations reference that has been applied to the FileDiff instance
+ * — either by the initial render()/hydrate() in onMount, or by the
+ * annotations $effect below. Used as a guard so the $effect skips its
+ * eager initial run (which would re-render with forceRender:true and wipe
+ * the SSR-hydrated tokens, forcing a cold worker tokenization).
+ */
+let appliedAnnotations: DiffLineAnnotation<ThreadMeta>[] | null = null;
+let appliedThreadById: Record<string, CommentThread> | null = null;
+let appliedThreadMessages: Record<string, ThreadMessage[]> | null = null;
+
+/**
+ * Mutable reference that renderAnnotation reads from. This avoids the
+ * stale-closure problem: the callback is defined once in onMount but
+ * needs to see the latest threadById / threadMessages when threads load
+ * asynchronously after the initial render.
+ */
+const threadDataRef = {
+  threadById: {} as Record<string, CommentThread>,
+  threadMessages: {} as Record<string, ThreadMessage[]>,
+};
+
+// Note: $effect blocks that guard on `!instance` or `!initialOptions` rely on
+// Svelte 5's ordering guarantee that onMount runs before $effects first execute.
+// This is intentional — do not make instance $state (it would deep-proxy a large object).
+
+function captureEl(el: HTMLDivElement) {
+  wrapperEl = el;
+  return {
+    destroy() {
+      wrapperEl = null;
+    },
+  };
+}
+
+function getShadowRoot(): ShadowRoot | null {
+  return getPierreShadowRoot(wrapperEl);
+}
+
+function findRenderedLineElement(lineIndex: number): HTMLElement | null {
+  const shadowRoot = getShadowRoot();
+  if (!shadowRoot) return null;
+  return shadowRoot.querySelector<HTMLElement>(
+    `[data-line][data-line-index="${lineIndex}"], [data-line][data-line-index^="${lineIndex},"]`,
+  );
+}
+
+function getScrollTop(): number {
+  return scrollRoot?.scrollTop ?? window.scrollY;
+}
+
+function getScrollViewportHeight(): number {
+  return scrollRoot?.getBoundingClientRect().height ?? window.innerHeight;
+}
+
+function getElementTopInScrollRoot(element: HTMLElement): number {
+  const scrollContainerTop = scrollRoot?.getBoundingClientRect().top ?? 0;
+  return element.getBoundingClientRect().top - scrollContainerTop + getScrollTop();
+}
+
+function estimateDiffLineOffset(fileDiff: FileDiffMetadata, lineIndex: number): number {
+  const { diffHeaderHeight, fileGap, hunkSeparatorHeight, lineHeight } =
+    DEFAULT_VIRTUAL_FILE_METRICS;
+  const separatorGap = fileGap;
+  let separatorOffset = 0;
+
+  for (const [hunkIndex, hunk] of fileDiff.hunks.entries()) {
+    if (hunk.unifiedLineStart > lineIndex) break;
+    if (hunk.collapsedBefore > 0) {
+      separatorOffset += hunkSeparatorHeight + separatorGap + (hunkIndex > 0 ? separatorGap : 0);
+    }
+  }
+
+  return diffHeaderHeight + separatorOffset + lineIndex * lineHeight;
+}
+
+function scrollVirtualizedLineIntoView(lineIndex: number): boolean {
+  if (!virtualizer || !wrapperEl || !parsedFileDiff || !scrollRoot) return false;
+
+  const targetTop =
+    getElementTopInScrollRoot(wrapperEl) +
+    estimateDiffLineOffset(parsedFileDiff, lineIndex) -
+    getScrollViewportHeight() / 2;
+
+  scrollRoot.scrollTo({ top: Math.max(0, targetTop), behavior: "auto" });
+  return true;
+}
+
+function retryRenderedLineIntoView(
+  lineIndex: number,
+  onRendered: (() => void) | undefined,
+  attemptsLeft = 6,
+): void {
+  requestAnimationFrame(() => {
+    const lineEl = findRenderedLineElement(lineIndex);
+    if (lineEl) {
+      lineEl.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      onRendered?.();
+      return;
+    }
+    if (attemptsLeft > 0) retryRenderedLineIntoView(lineIndex, onRendered, attemptsLeft - 1);
+  });
+}
+
+function scrollLineIntoView(lineIndex: number, onRendered?: () => void): boolean {
+  const lineEl = findRenderedLineElement(lineIndex);
+  if (lineEl) {
+    lineEl.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    onRendered?.();
+    return true;
+  }
+
+  if (!scrollVirtualizedLineIntoView(lineIndex)) return false;
+
+  retryRenderedLineIntoView(lineIndex, onRendered);
+  return true;
+}
+
+/**
+ * Given a patch string and a target new-file line number, return the
+ * 0-based `data-line-index` of the closest non-deletion line in the patch.
+ */
+function findPatchLineIndex(patch: string, targetLine: number): number | null {
+  const lines = patch.split("\n");
+  let patchLineIdx = 0;
+  let newLineNum = 0;
+  let bestIdx: number | null = null;
+
+  for (const raw of lines) {
+    if (raw.startsWith("@@")) {
+      // Parse hunk header: @@ -old,count +new,count @@
+      const m = /\+(\d+)/.exec(raw);
+      if (m?.[1]) {
+        newLineNum = parseInt(m[1], 10) - 1;
+      }
+      // hunk headers don't get a data-line-index slot
+      continue;
+    }
+    if (raw.startsWith("-")) {
+      // deletion — advances no new line number, but does occupy a patch line index
+      patchLineIdx++;
+      continue;
+    }
+    // context or addition
+    patchLineIdx++;
+    newLineNum++;
+    if (newLineNum >= targetLine) {
+      return patchLineIdx - 1;
+    }
+    bestIdx = patchLineIdx - 1;
+  }
+  return bestIdx;
+}
+
+// ─ Reactive updates ──────────────────────────────────────────────────────
+// Re-render when thread data changes. The reference-equality guard skips
+// the eager initial $effect run — at that point onMount has already rendered
+// via render()/hydrate(). When threads load asynchronously, threadById,
+// threadMessages, and annotations all get new references, triggering this
+// effect. We update the mutable ref (so renderAnnotation sees fresh data),
+// clear stale caches, and re-render with the new annotations.
+$effect(() => {
+  if (!instance) return;
+  const currentAnnotations = annotations;
+  const currentThreadById = threadById;
+  const currentThreadMessages = threadMessages;
+  if (
+    currentAnnotations === appliedAnnotations &&
+    currentThreadById === appliedThreadById &&
+    currentThreadMessages === appliedThreadMessages
+  )
+    return;
+  appliedAnnotations = currentAnnotations;
+  appliedThreadById = currentThreadById;
+  appliedThreadMessages = currentThreadMessages;
+
+  // Update mutable ref so renderAnnotation callback (defined once in
+  // onMount) reads fresh thread data.
+  threadDataRef.threadById = currentThreadById;
+  threadDataRef.threadMessages = currentThreadMessages;
+
+  // NOTE: do NOT clear `annotationCache` here. The library's
+  // renderAnnotations() is self-cleaning — it removes the previous wrapper
+  // before appending a new one whenever an annotation changed. Our store
+  // hands it a fresh `metadata` object every render and the library compares
+  // metadata by reference, so renderAnnotation always re-runs (picking up
+  // fresh thread data) AND the old row is removed. Calling `.clear()` empties
+  // the cache Map without removing the wrapper <div>s from the shadow DOM, so
+  // the next render appends fresh rows alongside the orphans → duplicate
+  // comments. That was the diff-tab comment-duplication bug.
+
+  // Clear header slots before re-render to prevent badge duplication.
+  // The library's applyHeaderToDOM reuses slot elements by reference; if
+  // the header HTML is regenerated (forceRender), old slot refs point to
+  // removed DOM nodes, causing new slots to be created alongside them.
+  // @ts-expect-error clearHeaderSlots is protected
+  instance.clearHeaderSlots?.();
+
+  // Re-render with new annotations. Must pass lineAnnotations so the
+  // library updates its internal state and creates annotation rows.
+  instance.render({ lineAnnotations: currentAnnotations, forceRender: true });
+
+  // The library removes the previous annotation wrappers via element.remove(),
+  // but the Svelte components we mounted inside them stay registered and live.
+  // Unmount the now-detached ones so their effects/listeners don't leak.
+  pruneDetachedMounts();
+});
+
+// ── Line cursor highlight (diff-line mode) ────────────────────────────────
+$effect(() => {
+  if (!instance || !initialOptions) return;
+  const panel = getActivePanel();
+  const lineIdx = getCursorLineIndex();
+
+  if (panel === "diff-line") {
+    const css = `${PIERRE_BASE_CSS} [data-line-index="${lineIdx}"] { background-color: var(--color-tree-active-bg) !important; outline: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent); outline-offset: -1px; }`;
+    instance.setOptions({ ...initialOptions, unsafeCSS: css });
+  } else if (panel !== "diff-visual") {
+    // Clear highlight when not in line/visual mode
+    // (visual mode uses setSelectedLines instead)
+    instance.setOptions({ ...initialOptions, unsafeCSS: PIERRE_BASE_CSS });
+  }
+});
+
+// ── Scroll active line into view ──────────────────────────────────────────
+$effect(() => {
+  if (!isInLineCursorMode()) return;
+  const lineIdx = getCursorLineIndex();
+
+  requestAnimationFrame(() => {
+    scrollLineIntoView(lineIdx);
+  });
+});
+
+// ── Walkthrough → diff jump ───────────────────────────────────────────────
+$effect(() => {
+  const jump = getPendingDiffJump();
+  if (!jump || jump.filePath !== file.path || !file.patch) return;
+
+  if (!instance) return;
+
+  const patchLineIdx = findPatchLineIndex(file.patch, jump.lineNumber);
+  if (patchLineIdx === null) return;
+
+  setTimeout(() => {
+    requestAnimationFrame(() => {
+      scrollLineIntoView(patchLineIdx, clearPendingDiffJump);
+    });
+  }, 50);
+});
+
+// ── Visual line selection (diff-visual mode) ──────────────────────────────
+$effect(() => {
+  if (!instance) return;
+  const panel = getActivePanel();
+
+  if (panel === "diff-visual") {
+    const cursor = getCursorLineIndex();
+    const anchor = getAnchorLineIndex();
+    if (anchor === null) return;
+
+    const start = Math.min(anchor, cursor);
+    const end = Math.max(anchor, cursor);
+    const side = getCursorSide();
+
+    // With exactOptionalPropertyTypes, omit side entirely when null
+    const range = side !== null ? { start, end, side, endSide: side } : { start, end };
+
+    instance.setSelectedLines(range);
+    // Clear unsafeCSS line highlight — selection replaces it
+    if (initialOptions) {
+      instance.setOptions({ ...initialOptions, unsafeCSS: PIERRE_BASE_CSS });
+    }
+  } else {
+    // Clear selection when leaving visual mode
+    instance.setSelectedLines(null);
+  }
+});
+
+// ── Instance lifecycle ────────────────────────────────────────────────────
+
+onMount(() => {
+  if (!wrapperEl) return;
+
+  try {
+    const options: FileDiffOptions<ThreadMeta> = {
+      ...PR_DIFF_RENDER_OPTIONS,
+      diffStyle: mode,
+      theme: PIERRE_THEME,
+      enableGutterUtility: true,
+      enableLineSelection: true,
+      unsafeCSS: PIERRE_BASE_CSS,
+
+      // ── Header: file status badge ──────────────────────────────────
+      renderHeaderPrefix(fileDiff) {
+        const wrap = document.createElement("span");
+        wrap.style.cssText = "display:flex;align-items:center;gap:6px;";
+
+        const type = fileDiff.type;
+        if (
+          type === "new" ||
+          type === "deleted" ||
+          type === "rename-pure" ||
+          type === "rename-changed"
+        ) {
+          const label = type === "new" ? "new" : type === "deleted" ? "deleted" : "renamed";
+          const color =
+            type === "new"
+              ? "var(--color-success)"
+              : type === "deleted"
+                ? "var(--color-danger)"
+                : "var(--color-warning)";
+          wrap.appendChild(createHeaderBadge(label, color));
+        }
+
+        return wrap;
+      },
+
+      // ── Header: unified/split icon pill toggle ──────────────────────
+      renderHeaderMetadata(_fileDiff) {
+        return buildViewModePill(mode, onModeChange);
+      },
+
+      // ── Token hover ────────────────────────────────────────────────
+      onTokenEnter(props: DiffTokenEventBaseProps) {
+        onTokenHover?.({
+          tokenText: props.tokenText,
+          lineNumber: props.lineNumber,
+          side: props.side,
+          element: props.tokenElement,
+        });
+      },
+      onTokenLeave() {
+        onTokenHover?.(null);
+      },
+
+      // ── Line click → bubble up ─────────────────────────────────────
+      onLineClick(props) {
+        if (!onLineClick) return;
+        const code = props.lineElement?.textContent ?? "";
+        const rect = props.lineElement?.getBoundingClientRect() ?? new DOMRect();
+        onLineClick({
+          filePath: file.path,
+          lineNumber: props.lineNumber,
+          side: props.annotationSide,
+          lineType: props.lineType,
+          code,
+          rect,
+        });
+      },
+
+      // ── Annotation rendering ───────────────────────────────────────
+      renderAnnotation(annotation) {
+        const meta = annotation.metadata;
+        if (!meta) return undefined;
+
+        const host = document.createElement("div");
+        host.style.cssText = ANNOTATION_HOST_STYLE;
+
+        if (meta.isInputActive) {
+          mountInto(host, AnnotationCommentInput, {
+            filePath: file.path,
+            lineNo: annotation.lineNumber,
+            onSubmit: (body: string) => {
+              onCommentSubmit?.(file.path, annotation.lineNumber, annotation.side, body);
+            },
+            onDismiss: () => {
+              onCommentDismiss?.(file.path, annotation.lineNumber);
+            },
+          });
+        } else if (meta.isExpanded) {
+          // Read from mutable ref so we always see latest thread data
+          // even though this callback was defined once in onMount.
+          const thread = threadDataRef.threadById[meta.threadId];
+          const messages = threadDataRef.threadMessages[meta.threadId] ?? [];
+          if (!thread) return host;
+
+          mountAnnotationThread(host, {
+            thread,
+            messages,
+            threadId: meta.threadId,
+            isReplying: meta.isReplying,
+            isPending: meta.isPending,
+            onReplyToggle,
+            onCommentResolve,
+            onCommentReopen,
+            onCommentDiscard,
+            onDiscardReply,
+            onAnnotationToggle,
+            onApplySuggestion,
+            onReplySubmit,
+            onEditMessage,
+          });
+        } else {
+          host.appendChild(createMarkerDot(meta, () => onAnnotationToggle?.(meta.threadId)));
+        }
+
+        return host;
+      },
+
+      onPostRender(node) {
+        // Pierre hardcodes `pre.tabIndex = 0` (see setWrapperNodeProps)
+        // with no opt-out. We use focus-mode for line-level keyboard
+        // navigation instead, so opt this pre out of the tab order.
+        const pre = node.shadowRoot?.querySelector("pre");
+        if (pre) pre.tabIndex = -1;
+      },
+    };
+
+    // Store reference for setOptions() merging
+    initialOptions = options;
+
+    // Update threadDataRef BEFORE render/hydrate so renderAnnotation
+    // callback sees current thread data on the initial render.
+    threadDataRef.threadById = threadById;
+    threadDataRef.threadMessages = threadMessages;
+
+    // Parse the git patch string directly — this preserves the exact
+    // additions/deletions counts from GitHub's diff, so the library's
+    // header stats match the file tree without any overrides.
+    const patchHeader = buildGitPatchHeader(file);
+    const fullPatch = file.patch ? `${patchHeader}\n${file.patch}` : patchHeader;
+    const patches = parsePatchFiles(fullPatch);
+    const parsed = patches[0]?.files[0];
+    if (!parsed) {
+      error = "Failed to parse patch";
+      return;
+    }
+    parsedFileDiff = parsed;
+
+    // SSR-hydrate only when the server has prerendered HTML for unified
+    // mode (the server doesn't know the user's mode preference; split
+    // always falls through to render()). Hydrate skips the worker
+    // tokenize round-trip — the diff body paints synchronously and
+    // interaction managers attach to the existing DOM.
+    //
+    // Pierre's `hydrate` doesn't invoke `renderHeaderPrefix` /
+    // `renderHeaderMetadata` (only `render` does). So we manually
+    // populate the header slots after hydrate using the exported slot
+    // IDs — Pierre's shadow DOM has `<slot name="...">` placeholders
+    // that project these light-DOM children.
+    if (file.prerenderedHtml !== undefined && mode === "unified") {
+      instance = new FileDiff<ThreadMeta>(options, workerManager);
+      // Match the render() DOM structure: a <diffs-container> custom element
+      // as the shadow host inside wrapperEl. The tag name matters — app.css
+      // :900 overrides `diffs-container { color-scheme: inherit }` so Pierre's
+      // `light-dark()` token colors follow <html>'s theme instead of the OS.
+      // A plain <div> would skip that rule and produce mismatched colors
+      // (light tokens on a dark app background) for the entire SSR-visible
+      // window — until the worker re-render replaces them.
+      const hostEl = createDiffsHost();
+      wrapperEl.appendChild(hostEl);
+      instance.hydrate({
+        fileContainer: hostEl,
+        prerenderedHTML: file.prerenderedHtml,
+        fileDiff: parsed,
+        lineAnnotations: annotations,
+      });
+      populateDiffHeaderSlots(hostEl, parsed, options);
+    } else {
+      virtualizer = createPierreVirtualizer(scrollRoot, wrapperEl);
+      const hostEl = createDiffsHost();
+      wrapperEl.appendChild(hostEl);
+      instance = virtualizer
+        ? new VirtualizedFileDiff<ThreadMeta>(options, virtualizer, undefined, workerManager)
+        : new FileDiff<ThreadMeta>(options, workerManager);
+      instance.render({
+        fileContainer: hostEl,
+        fileDiff: parsed,
+        lineAnnotations: annotations,
+        forceRender: true,
+      });
+    }
+    // Mark initial state as applied so the post-mount $effect
+    // (which would otherwise re-render with forceRender:true) is a no-op.
+    appliedAnnotations = annotations;
+    appliedThreadById = threadById;
+    appliedThreadMessages = threadMessages;
+
+    // Set total line count for keyboard cursor navigation
+    if (file.patch) {
+      setTotalLineCount(countPatchLines(file.patch));
+    }
+  } catch (e) {
+    console.error("[DiffViewerInner] Render error:", e);
+    error = e instanceof Error ? e.message : String(e);
+  }
+});
+
+onDestroy(() => {
+  cleanupAllMounted();
+  try {
+    instance?.cleanUp();
+    virtualizer?.cleanUp();
+  } catch {
+    // ignore cleanup errors
+  }
+  instance = null;
+  virtualizer = null;
+});
 </script>
 
 {#if error}

--- a/apps/web/src/lib/components/review/FileViewer.svelte
+++ b/apps/web/src/lib/components/review/FileViewer.svelte
@@ -25,8 +25,9 @@ import {
   resolveThread,
 } from "$lib/stores/review.svelte";
 import type { CommentThread, ThreadMessage } from "$lib/types/review";
-import type { FileLineClickInfo, ThreadMeta, TokenHoverInfo } from "./FileViewerInner.svelte";
+import type { FileLineClickInfo, TokenHoverInfo } from "./FileViewerInner.svelte";
 import FileViewerInner from "./FileViewerInner.svelte";
+import type { ThreadMeta } from "./pierre-diff-adapter";
 
 // ── Props ─────────────────────────────────────────────────────────────────
 
@@ -38,9 +39,19 @@ interface Props {
   status: "idle" | "loading" | "ready" | "binary" | "too-large" | "not-found" | "error";
   errorMessage?: string | null;
   onTokenHover?: (info: TokenHoverInfo | null) => void;
+  scrollRoot?: HTMLElement | null;
 }
 
-let { path, content, isBinary, size, status, errorMessage = null, onTokenHover }: Props = $props();
+let {
+  path,
+  content,
+  isBinary,
+  size,
+  status,
+  errorMessage = null,
+  onTokenHover,
+  scrollRoot = null,
+}: Props = $props();
 
 function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -275,6 +286,7 @@ async function handleEditMessage(threadId: string, messageId: string, body: stri
 			{onTokenHover}
 			onApplySuggestion={handleApplySuggestion}
 			onEditMessage={handleEditMessage}
+			{scrollRoot}
 		/>
 	{/key}
 {/if}

--- a/apps/web/src/lib/components/review/FileViewerInner.svelte
+++ b/apps/web/src/lib/components/review/FileViewerInner.svelte
@@ -1,17 +1,4 @@
 <script lang="ts" module>
-// ── ThreadMeta ─────────────────────────────────────────────────────────────
-// Forked from DiffViewerInner. Same shape so AnnotationThread /
-// AnnotationCommentInput / mountInto can be shared verbatim.
-export interface ThreadMeta {
-  threadId: string;
-  status: string;
-  messageCount: number;
-  isExpanded: boolean;
-  isInputActive: boolean;
-  isReplying: boolean;
-  isPending: boolean;
-}
-
 // ── TokenHoverInfo ─────────────────────────────────────────────────────────
 export interface TokenHoverInfo {
   tokenText: string;
@@ -35,11 +22,13 @@ export interface TokenHoverInfo {
 	//     diff viewer's "new" / "deleted" / "renamed" badges.
 	import {
 		File as PierreFile,
+		VirtualizedFile,
 		type FileOptions,
 		type LineAnnotation,
 		type OnLineClickProps,
 		type TokenEventBase,
 	} from '@pierre/diffs';
+	import { PIERRE_THEME } from '@revv/shared';
 	import type { CommentThread, ThreadMessage } from '$lib/types/review';
 	import { workerManager } from '$lib/utils/worker-pool';
 	import { onMount, onDestroy } from 'svelte';
@@ -56,6 +45,14 @@ export interface TokenHoverInfo {
 		setTotalLineCount,
 		isInLineCursorMode,
 	} from '$lib/stores/focus-mode.svelte';
+	import {
+		createDiffsHost,
+		createHeaderBadge,
+		createPierreVirtualizer,
+		getPierreShadowRoot,
+		PIERRE_BASE_CSS,
+		type ThreadMeta
+	} from './pierre-diff-adapter';
 
 	// ── Line-click info bubbled to the wrapper ─────────────────────────────────
 	// Same shape as DiffViewer's `LineClickInfo`, minus the `side` field that
@@ -91,6 +88,7 @@ export interface TokenHoverInfo {
 		onTokenHover?: ((info: TokenHoverInfo | null) => void) | undefined;
 		onApplySuggestion?: ((threadId: string, suggestion: string) => void) | undefined;
 		onEditMessage?: ((threadId: string, messageId: string, body: string) => void) | undefined;
+		scrollRoot?: HTMLElement | null;
 	}
 
 	let {
@@ -113,6 +111,7 @@ export interface TokenHoverInfo {
 		onTokenHover,
 		onApplySuggestion,
 		onEditMessage,
+		scrollRoot = null,
 	}: Props = $props();
 
 	function formatSize(bytes: number): string {
@@ -121,15 +120,13 @@ export interface TokenHoverInfo {
 		return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 	}
 
-	// ── Base shadow-DOM CSS — same trick DiffViewerInner uses ────────────────
-	const BASE_CSS = `[data-diffs-header='default'] { position: static !important; }`;
-
 	// ── Local state ──────────────────────────────────────────────────────────
 
 	let wrapperEl: HTMLDivElement | null = null;
-	let instance = $state.raw<PierreFile<ThreadMeta> | null>(null);
+	let instance = $state.raw<PierreFile<ThreadMeta> | VirtualizedFile<ThreadMeta> | null>(null);
 	let error = $state<string | null>(null);
 	let initialOptions: FileOptions<ThreadMeta> | null = null;
+	let virtualizer = $state.raw<ReturnType<typeof createPierreVirtualizer> | null>(null);
 
 	function captureEl(el: HTMLDivElement) {
 		wrapperEl = el;
@@ -142,26 +139,8 @@ export interface TokenHoverInfo {
 
 	// ── Shadow DOM helpers (line-cursor scroll) ──────────────────────────────
 
-	function findShadowHost(container: HTMLElement): HTMLElement | null {
-		for (const child of container.children) {
-			if (child instanceof HTMLElement && child.shadowRoot) return child;
-		}
-		for (const child of container.children) {
-			if (child instanceof HTMLElement) {
-				for (const grandchild of child.children) {
-					if (grandchild instanceof HTMLElement && grandchild.shadowRoot) {
-						return grandchild;
-					}
-				}
-			}
-		}
-		return null;
-	}
-
 	function getShadowRoot(): ShadowRoot | null {
-		if (!wrapperEl) return null;
-		const host = findShadowHost(wrapperEl);
-		return host?.shadowRoot ?? null;
+		return getPierreShadowRoot(wrapperEl);
 	}
 
 	// ── Reactive updates ─────────────────────────────────────────────────────
@@ -190,14 +169,14 @@ export interface TokenHoverInfo {
 
 		if (panel === 'diff-line') {
 			const css =
-				`${BASE_CSS} [data-line-index="${lineIdx}"] { ` +
+				`${PIERRE_BASE_CSS} [data-line-index="${lineIdx}"] { ` +
 				`background-color: var(--color-tree-active-bg) !important; ` +
 				`outline: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent); ` +
 				`outline-offset: -1px; ` +
 				`}`;
 			instance.setOptions({ ...initialOptions, unsafeCSS: css });
 		} else if (panel !== 'diff-visual') {
-			instance.setOptions({ ...initialOptions, unsafeCSS: BASE_CSS });
+			instance.setOptions({ ...initialOptions, unsafeCSS: PIERRE_BASE_CSS });
 		}
 	});
 
@@ -233,12 +212,12 @@ export interface TokenHoverInfo {
 
 		try {
 			const options: FileOptions<ThreadMeta> = {
-				theme: { dark: 'pierre-dark', light: 'pierre-light' },
+				theme: PIERRE_THEME,
 				overflow: 'scroll',
 				lineHoverHighlight: 'both',
 				enableGutterUtility: true,
 				enableLineSelection: true,
-				unsafeCSS: BASE_CSS,
+				unsafeCSS: PIERRE_BASE_CSS,
 
 				// ── Header: "unchanged" badge ─────────────────────────────────
 				// Mirrors DiffViewerInner's renderHeaderPrefix shape so the
@@ -248,15 +227,8 @@ export interface TokenHoverInfo {
 					const wrap = document.createElement('span');
 					wrap.style.cssText = 'display:flex;align-items:center;gap:6px;';
 
-					const badge = document.createElement('span');
-					badge.textContent = 'unchanged';
 					const color = 'var(--color-text-muted)';
-					badge.style.cssText =
-						`font-size:9px;font-weight:600;letter-spacing:0.06em;` +
-						`text-transform:uppercase;` +
-						`background:color-mix(in srgb, ${color} 13%, transparent);` +
-						`color:${color};border-radius:3px;padding:1px 5px;`;
-					wrap.appendChild(badge);
+					wrap.appendChild(createHeaderBadge('unchanged', color));
 
 					return wrap;
 				},
@@ -356,11 +328,16 @@ export interface TokenHoverInfo {
 				},
 			};
 
-			instance = new PierreFile<ThreadMeta>(options, workerManager);
+			virtualizer = createPierreVirtualizer(scrollRoot, wrapperEl);
+			const hostEl = createDiffsHost();
+			wrapperEl.appendChild(hostEl);
+			instance = virtualizer
+				? new VirtualizedFile<ThreadMeta>(options, virtualizer, undefined, workerManager)
+				: new PierreFile<ThreadMeta>(options, workerManager);
 			initialOptions = options;
 
 			instance.render({
-				containerWrapper: wrapperEl,
+				fileContainer: hostEl,
 				file: { name: path, contents: content },
 				lineAnnotations: annotations,
 			});
@@ -379,10 +356,12 @@ export interface TokenHoverInfo {
 		cleanupAllMounted();
 		try {
 			instance?.cleanUp();
+			virtualizer?.cleanUp();
 		} catch {
 			// ignore cleanup errors
 		}
 		instance = null;
+		virtualizer = null;
 	});
 </script>
 

--- a/apps/web/src/lib/components/review/ProposedDiffModal.svelte
+++ b/apps/web/src/lib/components/review/ProposedDiffModal.svelte
@@ -7,6 +7,7 @@ import {
   parseDiffFromFile,
 } from "@pierre/diffs";
 import { FileTree, type GitStatusEntry } from "@pierre/trees";
+import { PIERRE_THEME } from "@revv/shared";
 import MessageSquare from "phosphor-svelte/lib/Chat";
 import GitMerge from "phosphor-svelte/lib/GitMerge";
 import Send from "phosphor-svelte/lib/PaperPlaneRight";
@@ -242,7 +243,7 @@ function buildOptions(
 ): FileDiffOptions<CommentMeta> {
   return {
     diffStyle,
-    theme: { dark: "pierre-dark", light: "pierre-light" },
+    theme: PIERRE_THEME,
     // Collapse unchanged regions by default so line-info separators have
     // something to expand. With `true`, Pierre flattens the whole file
     // inline and no separator clicks would be meaningful.

--- a/apps/web/src/lib/components/review/ReviewLayout.svelte
+++ b/apps/web/src/lib/components/review/ReviewLayout.svelte
@@ -480,41 +480,46 @@ const panel = $derived(getActivePanel());
 		bind:this={diffScrollEl}
 		onscroll={handleDiffScroll}
 	>
-		{#if activeFile}
-			<div class="file-title-section" bind:this={fileTitleSectionEl}>
-				<h1 class="file-title">{activeFileName}</h1>
-			</div>
-			<FileIssues filePath={activeFile.path} />
-			{#if activeFileIsImage}
-				<ImageDiffViewer {prId} file={activeFile} />
+		{#if diffScrollEl}
+			{#if activeFile}
+				<div class="file-title-section" bind:this={fileTitleSectionEl}>
+					<h1 class="file-title">{activeFileName}</h1>
+				</div>
+				<FileIssues filePath={activeFile.path} />
+				{#if activeFileIsImage}
+					<ImageDiffViewer {prId} file={activeFile} />
+				{:else}
+					<DiffViewer
+						file={activeFile}
+						onModeChange={(m) => setDiffMode(m)}
+						commentTrigger={pendingCommentTrigger}
+						scrollRoot={diffScrollEl}
+					/>
+				{/if}
+			{:else if showFileViewer && activeFilePath}
+				<!-- Title rendered by the layout (same as the diff path) so the
+				     file viewer fills the pane edge-to-edge — no inner padding,
+				     full-width gutter, identical font / sizing to the diff. -->
+				<div class="file-title-section" bind:this={fileTitleSectionEl}>
+					<h1 class="file-title">{activeFileName}</h1>
+				</div>
+				<FileViewer
+					path={activeFilePath}
+					content={repoFile.status === "ok" && repoFile.data.status === "ready" ? repoFile.data.content : ""}
+					isBinary={repoFile.status === "ok" && repoFile.data.status === "binary"}
+					size={repoFile.status === "ok" ? ("size" in repoFile.data ? repoFile.data.size : 0) : 0}
+					status={repoFile.status === "ok" ? repoFile.data.status : repoFile.status}
+					errorMessage={repoFile.status === "error" ? repoFile.error : null}
+					scrollRoot={diffScrollEl}
+				/>
 			{:else}
 				<DiffViewer
-					file={activeFile}
+					file={null}
 					onModeChange={(m) => setDiffMode(m)}
 					commentTrigger={pendingCommentTrigger}
+					scrollRoot={diffScrollEl}
 				/>
 			{/if}
-		{:else if showFileViewer && activeFilePath}
-			<!-- Title rendered by the layout (same as the diff path) so the
-			     file viewer fills the pane edge-to-edge — no inner padding,
-			     full-width gutter, identical font / sizing to the diff. -->
-			<div class="file-title-section" bind:this={fileTitleSectionEl}>
-				<h1 class="file-title">{activeFileName}</h1>
-			</div>
-			<FileViewer
-				path={activeFilePath}
-				content={repoFile.status === "ok" && repoFile.data.status === "ready" ? repoFile.data.content : ""}
-				isBinary={repoFile.status === "ok" && repoFile.data.status === "binary"}
-				size={repoFile.status === "ok" ? ("size" in repoFile.data ? repoFile.data.size : 0) : 0}
-				status={repoFile.status === "ok" ? repoFile.data.status : repoFile.status}
-				errorMessage={repoFile.status === "error" ? repoFile.error : null}
-			/>
-		{:else}
-			<DiffViewer
-				file={null}
-				onModeChange={(m) => setDiffMode(m)}
-				commentTrigger={pendingCommentTrigger}
-			/>
 		{/if}
 	</div>
 
@@ -540,4 +545,3 @@ const panel = $derived(getActivePanel());
 		word-break: break-all;
 	}
 </style>
-

--- a/apps/web/src/lib/components/review/pierre-diff-adapter.ts
+++ b/apps/web/src/lib/components/review/pierre-diff-adapter.ts
@@ -1,0 +1,79 @@
+import {
+  DIFFS_TAG_NAME,
+  type FileDiffMetadata,
+  type FileDiffOptions,
+  HEADER_METADATA_SLOT_ID,
+  HEADER_PREFIX_SLOT_ID,
+  Virtualizer,
+} from "@pierre/diffs";
+
+export interface ThreadMeta {
+  threadId: string;
+  status: string;
+  messageCount: number;
+  isExpanded: boolean;
+  isInputActive: boolean;
+  isReplying: boolean;
+  isPending: boolean;
+}
+
+export const PIERRE_BASE_CSS = `[data-diffs-header='default'] { position: static !important; }`;
+
+export function createDiffsHost(): HTMLElement {
+  return document.createElement(DIFFS_TAG_NAME);
+}
+
+export function findShadowHost(container: HTMLElement): HTMLElement | null {
+  for (const child of container.children) {
+    if (child instanceof HTMLElement && child.shadowRoot) return child;
+  }
+  for (const child of container.children) {
+    if (child instanceof HTMLElement) {
+      for (const grandchild of child.children) {
+        if (grandchild instanceof HTMLElement && grandchild.shadowRoot) {
+          return grandchild;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+export function getPierreShadowRoot(container: HTMLElement | null): ShadowRoot | null {
+  if (!container) return null;
+  return findShadowHost(container)?.shadowRoot ?? null;
+}
+
+export function populateDiffHeaderSlots(
+  hostEl: HTMLElement,
+  fileDiff: FileDiffMetadata,
+  opts: FileDiffOptions<ThreadMeta>,
+): void {
+  function appendSlot(slotName: string, content: string | number | Element | null | undefined) {
+    if (content == null) return;
+    const slotEl = document.createElement("div");
+    slotEl.slot = slotName;
+    if (content instanceof Element) slotEl.appendChild(content);
+    else slotEl.innerText = String(content);
+    hostEl.appendChild(slotEl);
+  }
+  appendSlot(HEADER_PREFIX_SLOT_ID, opts.renderHeaderPrefix?.(fileDiff));
+  appendSlot(HEADER_METADATA_SLOT_ID, opts.renderHeaderMetadata?.(fileDiff));
+}
+
+export function createHeaderBadge(label: string, color: string): HTMLElement {
+  const badge = document.createElement("span");
+  badge.textContent = label;
+  badge.style.cssText = `font-size:9px;font-weight:600;letter-spacing:0.06em;text-transform:uppercase;background:color-mix(in srgb, ${color} 13%, transparent);color:${color};border-radius:3px;padding:1px 5px;`;
+  return badge;
+}
+
+export function createPierreVirtualizer(
+  scrollRoot: HTMLElement | null,
+  contentContainer: HTMLElement,
+): Virtualizer | null {
+  if (scrollRoot === null) return null;
+  const virtualizer = new Virtualizer();
+  virtualizer.setup(scrollRoot, contentContainer);
+  return virtualizer;
+}

--- a/apps/web/src/lib/components/walkthrough/WalkthroughCodeBlock.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughCodeBlock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { DIFFS_TAG_NAME, type FileOptions, File as PierreFile } from "@pierre/diffs";
-import type { CodeBlock } from "@revv/shared";
+import { type CodeBlock, PIERRE_THEME } from "@revv/shared";
 import ArrowUpRight from "phosphor-svelte/lib/ArrowUpRight";
 import { jumpToDiffLine } from "$lib/stores/review.svelte";
 import { renderMarkdown } from "$lib/utils/markdown";
@@ -19,7 +19,7 @@ let instance: PierreFile<never> | null = null;
 
 function mountCodeBlock(el: HTMLDivElement) {
   const options: FileOptions<never> = {
-    theme: { dark: "pierre-dark", light: "pierre-light" },
+    theme: PIERRE_THEME,
     overflow: "scroll",
     // Suppress Pierre's built-in file header — we render our own clickable
     // header above so the user can jump to this file in the Diff tab.

--- a/apps/web/src/lib/components/walkthrough/WalkthroughDiffBlock.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughDiffBlock.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { DIFFS_TAG_NAME, FileDiff, type FileDiffOptions, parsePatchFiles } from "@pierre/diffs";
-import type { DiffBlock } from "@revv/shared";
+import { buildGitPatchHeader, type DiffBlock, PIERRE_THEME } from "@revv/shared";
 import ArrowUpRight from "phosphor-svelte/lib/ArrowUpRight";
 import FileBadge from "$lib/components/ui/FileBadge.svelte";
 import { jumpToDiffLine } from "$lib/stores/review.svelte";
@@ -31,7 +31,7 @@ let instance: FileDiff<never> | null = null;
 function mountDiffBlock(el: HTMLDivElement) {
   const options: FileDiffOptions<never> = {
     diffStyle: "unified",
-    theme: { dark: "pierre-dark", light: "pierre-light" },
+    theme: PIERRE_THEME,
     overflow: "scroll",
     // Suppress Pierre's built-in file header — we render our own clickable
     // header above so the user can jump to this file in the Diff tab.
@@ -40,11 +40,7 @@ function mountDiffBlock(el: HTMLDivElement) {
 
   instance = new FileDiff<never>(options, workerManager);
 
-  const patchHeader = [
-    `diff --git a/${block.filePath} b/${block.filePath}`,
-    `--- a/${block.filePath}`,
-    `+++ b/${block.filePath}`,
-  ].join("\n");
+  const patchHeader = buildGitPatchHeader({ path: block.filePath });
   const fullPatch = `${patchHeader}\n${block.patch}`;
   const parsed = parsePatchFiles(fullPatch)[0]?.files[0];
 

--- a/apps/web/src/lib/stores/review.svelte.ts
+++ b/apps/web/src/lib/stores/review.svelte.ts
@@ -129,7 +129,10 @@ export async function pullLatestCommit(prId: string): Promise<void> {
     setIsLoadingFiles(true);
     setFilesError(null);
 
-    const { data, error } = await api.api.prs({ id: prId }).files.get();
+    const activePath = getActiveFilePath();
+    const { data, error } = await api.api.prs({ id: prId }).files.get({
+      query: activePath === null ? {} : { active: activePath },
+    });
     if (error || !Array.isArray(data)) {
       throw new Error("Failed to refetch files");
     }
@@ -149,7 +152,6 @@ export async function pullLatestCommit(prId: string): Promise<void> {
     // If the user has an active file that's gone in the new diff, fall back
     // to the first file. If the active file still exists, leave it alone so
     // the user's scroll position in the diff tab isn't reset.
-    const activePath = getActiveFilePath();
     const stillExists = activePath !== null && mapped.some((f) => f.path === activePath);
     if (!stillExists && mapped.length > 0) {
       // biome-ignore lint/style/noNonNullAssertion: length > 0 guarantees [0] exists

--- a/apps/web/src/lib/utils/code-highlight.svelte.ts
+++ b/apps/web/src/lib/utils/code-highlight.svelte.ts
@@ -1,5 +1,6 @@
 import pierreDark from "@pierre/theme/pierre-dark";
 import pierreLight from "@pierre/theme/pierre-light";
+import { PIERRE_THEME } from "@revv/shared";
 import { createHighlighter, type Highlighter } from "shiki";
 
 let highlighter: Highlighter | null = null;
@@ -73,10 +74,7 @@ export function highlightCode(code: string, lang: string): string | null {
 
     return highlighter.codeToHtml(code, {
       lang: normalized,
-      themes: {
-        light: "pierre-light",
-        dark: "pierre-dark",
-      },
+      themes: PIERRE_THEME,
     });
   } catch {
     return null;

--- a/apps/web/src/lib/utils/worker-pool.ts
+++ b/apps/web/src/lib/utils/worker-pool.ts
@@ -1,4 +1,11 @@
 import { getOrCreateWorkerPoolSingleton } from "@pierre/diffs/worker";
+import { PIERRE_DIFF_PRELOAD_LANGS, PIERRE_THEME } from "@revv/shared";
+
+function getWorkerPoolSize(): number {
+  const cores = navigator.hardwareConcurrency;
+  if (!Number.isFinite(cores)) return 2;
+  return Math.max(1, Math.min(4, Math.floor(cores) - 1));
+}
 
 export const workerManager =
   typeof window !== "undefined"
@@ -8,24 +15,11 @@ export const workerManager =
             new Worker(new URL("@pierre/diffs/worker/worker-portable.js", import.meta.url), {
               type: "module",
             }),
-          poolSize: 2,
+          poolSize: getWorkerPoolSize(),
         },
         highlighterOptions: {
-          langs: [
-            "typescript",
-            "javascript",
-            "svelte",
-            "css",
-            "json",
-            "python",
-            "go",
-            "rust",
-            "html",
-            "shellscript",
-            "yaml",
-            "sql",
-          ],
-          theme: { dark: "pierre-dark", light: "pierre-light" },
+          langs: [...PIERRE_DIFF_PRELOAD_LANGS],
+          theme: PIERRE_THEME,
         },
       })
     : undefined;

--- a/apps/web/src/routes/review/[prId]/+page.svelte
+++ b/apps/web/src/routes/review/[prId]/+page.svelte
@@ -167,6 +167,7 @@ $effect(() => {
 
     clearReviewFiles();
     setIsLoadingFiles(true);
+    const activeFileHint = getActiveFilePath();
 
     (async () => {
       try {
@@ -175,7 +176,9 @@ $effect(() => {
         // matching GitHub's "Files changed" tab. There is no per-commit
         // selection — the dropdown is read-only.
         const [filesResult] = await Promise.all([
-          api.api.prs({ id: prId }).files.get(),
+          api.api.prs({ id: prId }).files.get({
+            query: activeFileHint === null ? {} : { active: activeFileHint },
+          }),
           loadSession(prId).catch((e) =>
             console.error("[review] Session load failed (non-blocking):", e),
           ),

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -22,16 +22,16 @@
 
 ```
 apps/web        SvelteKit frontend (Tauri webview + localhost:5173 in dev)
-apps/server     Bun/Elysia HTTP + WebSocket server (port 45678)
+apps/server     Bun/Elysia HTTP + SSE server (port 45678)
 apps/desktop    Tauri v2 shell (minimal Rust: window, tray, deep-link, updater)
-packages/shared Cross-app types, WS schemas, constants
+packages/shared Cross-app types, SSE event schemas, constants
 ```
 
 ### Server Layer
 
 The server uses the [Effect](https://effect.website/) library pervasively. Every service is a `Context.Tag` + `Layer`, composed through `Layer.provide` / `Layer.mergeAll`. Dependency injection is compile-time typed via the `Effect<A, E, R>` `R` parameter; errors are typed via the `E` channel.
 
-**Key services:** `WalkthroughJobs`, `PollScheduler`, `WebSocketHub`, `SettingsService`, `OpencodeSupervisor`, `ChatSessionService`, `RepoCloneService`, `SyncService`, `AiService`.
+**Key services:** `WalkthroughJobs`, `PollScheduler`, `Broadcaster`, `SettingsService`, `OpencodeSupervisor`, `ChatSessionService`, `RepoCloneService`, `SyncService`, `AiService`.
 
 **Database:** Drizzle ORM on SQLite. 25 tables. All timestamps stored as ISO 8601 text. JSON arrays/objects stored as text columns. No migration runner — schema applied directly on boot.
 
@@ -72,8 +72,8 @@ Both paths share the same MCP tool handler implementations, satisfying the agent
 
 **Stores (Svelte 5 runes):** `$state` / `$derived` / `$effect` in `.svelte.ts` files. Named getter/setter functions, not subscribables.
 
-- `walkthrough.svelte.ts` — SSE streaming, hydration from REST, WS mutation application, all walkthrough display state (~1545 lines)
-- `ws.svelte.ts` — WebSocket connection with exponential backoff reconnect; exhaustive switch on `WsServerMessage.type`
+- `walkthrough.svelte.ts` — applies `walkthrough:event` envelopes from the global SSE bus, hydration from REST, all walkthrough display state (~1545 lines)
+- `events.svelte.ts` — global SSE (`EventSource`) connection to `GET /api/events` with exponential backoff reconnect; exhaustive switch on `ServerEventMessage.type`
 - `prs.svelte.ts` — PR list with fuzzy search, grouping, and derived views
 - `review.svelte.ts` — diff files, comment threads, per-PR scroll positions
 
@@ -93,7 +93,7 @@ Applying schema directly with `createTableIfNotExists` works during development 
 
 ### 2. `walkthrough.svelte.ts` is a Maintenance Liability
 
-At ~1545 lines, this file conflates transport concerns (SSE streaming, WS mutation application) with domain state (phases, blocks, issues, ratings) and hydration logic. As the chat-edit path and generation path diverge in their invalidation needs, this file will become increasingly difficult to reason about. It should be split — at minimum, separating streaming/transport from display state.
+At ~1545 lines, this file conflates transport concerns (SSE event dispatch and mutation application) with domain state (phases, blocks, issues, ratings) and hydration logic. As the chat-edit path and generation path diverge in their invalidation needs, this file will become increasingly difficult to reason about. It should be split — at minimum, separating streaming/transport from display state.
 
 ### 3. Single-User Assumption Baked In
 
@@ -103,9 +103,9 @@ The `settings.json` singleton, `id: "default"` user, and the lack of user scopin
 
 The 60-second rolling crash-loop window is tracked in memory. A server restart resets the counter, so a persistently broken opencode daemon gets 3 free retry attempts on every server restart rather than hitting a terminal error state. This can cause repeated startup noise without a clean failure mode.
 
-### 5. WebSocket Hub Has No Message Queue
+### 5. SSE Broadcaster Has No Message Queue
 
-The design correctly requires clients to reconcile from the DB on reconnect, and the WS store does this. But it's an implicit contract that every future WS consumer must also uphold. A missed `walkthrough:complete` during a brief disconnect requires a round-trip re-fetch to recover. This adds cognitive load on every new feature that introduces WS events.
+The design correctly requires clients to reconcile from the DB on reconnect, and the SSE store (`events.svelte.ts`) does this — the server does not replay missed events. But it's an implicit contract that every future SSE consumer must also uphold. A missed `lifecycle:complete` during a brief disconnect requires a round-trip re-fetch to recover. This adds cognitive load on every new feature that introduces SSE events.
 
 ---
 

--- a/docs/audits/prd-frontend-reliability.md
+++ b/docs/audits/prd-frontend-reliability.md
@@ -16,7 +16,7 @@ The frontend audit uncovered 6 critical bugs and 8 high-severity reliability iss
 
 ### US-001: Fix `mergePullRequests` duplicate PR bug
 
-**Description:** As a user, I want the PR list to remain deduplicated after WebSocket updates, so that I don't see the same PR multiple times.
+**Description:** As a user, I want the PR list to remain deduplicated after SSE `prs:updated` pushes, so that I don't see the same PR multiple times.
 
 **Acceptance Criteria:**
 
@@ -25,16 +25,17 @@ The frontend audit uncovered 6 critical bugs and 8 high-severity reliability iss
 - [ ] After receiving `prs:updated` multiple times, `pullRequests` array length is stable.
 - [ ] `make typecheck` passes.
 
-### US-002: Fix `disconnect()` → reconnect loop
+### US-002: Ensure sign-out fully stops the SSE connection
 
-**Description:** As a user, I want signing out to stop all WebSocket activity, so that the app does not spam reconnection attempts with a cleared token.
+**Description:** As a user, I want signing out to stop all SSE activity, so that the app does not keep reconnecting with a cleared token.
+
+**Context:** The realtime channel is `EventSource`, which auto-reconnects on transient errors. Sign-out calls `disconnect()`, which must `close()` the source (stopping native reconnection) and clear the liveness watchdog — otherwise the browser keeps retrying `GET /api/events` with a stale token.
 
 **Acceptance Criteria:**
 
-- [ ] `apps/web/src/lib/stores/ws.svelte.ts` declares `let intentionalDisconnect = false`.
-- [ ] `disconnect()` sets `intentionalDisconnect = true` before closing the socket.
-- [ ] `onClose` handler checks `if (intentionalDisconnect)` and skips `scheduleReconnect()`.
-- [ ] After `signOut()`, no WebSocket connection attempts occur for ≥5 seconds.
+- [ ] `apps/web/src/lib/stores/events.svelte.ts` `disconnect()` clears the watchdog timer, calls `source.close()`, and nulls `source`.
+- [ ] The `error` handler does not schedule a manual reconnect that could race the native retry after an intentional close.
+- [ ] After `signOut()`, no `GET /api/events` connection attempts occur for ≥5 seconds.
 - [ ] `make typecheck` passes.
 
 ### US-003: Fix `applyUserUpdate` avatar loss
@@ -126,7 +127,7 @@ The frontend audit uncovered 6 critical bugs and 8 high-severity reliability iss
 ## Functional Requirements
 
 - FR-1: PR deduplication must use a `Set<string>` of IDs, not arrays.
-- FR-2: WebSocket disconnect must be intentional-disconnect-aware.
+- FR-2: SSE sign-out must fully `close()` the `EventSource` so native auto-reconnect stops.
 - FR-3: User state updates must preserve existing fields via spread.
 - FR-4: Destructive operations (removeAccount) must complete locally regardless of network.
 - FR-5: 401 responses from identity must trigger sign-out.
@@ -150,9 +151,9 @@ The frontend audit uncovered 6 critical bugs and 8 high-severity reliability iss
 
 ## Success Metrics
 
-- PR list length is stable after repeated WS updates.
+- PR list length is stable after repeated SSE `prs:updated` pushes.
 - Sign-out stops all network activity (verified in Network tab).
-- Avatar persists after partial `user:updated` WS messages.
+- Avatar persists after partial `user:updated` SSE messages.
 - Double-clicking "Pin" sends exactly one request.
 - HMR remount does not duplicate `setInterval` timers.
 - `make typecheck && make lint` passes.

--- a/docs/audits/prd-security-hardening.md
+++ b/docs/audits/prd-security-hardening.md
@@ -26,16 +26,17 @@ The 2026-05-20 security audit uncovered 2 critical vulnerabilities, 7 high-sever
 - [ ] `make typecheck` passes.
 - [ ] Manual test: `curl -H "Origin: https://evil.localhost.attacker.com" -I http://localhost:45678/api/prs` returns **no** `Access-Control-Allow-Origin` header.
 
-### US-002: Move WebSocket token out of query string
+### US-002: Keep the session bearer token out of the SSE URL
 
 **Description:** As a user, I want my bearer token to stay out of server access logs and browser history, so that a log breach does not compromise my session.
 
-**Acceptance Criteria:**
+**Context:** The global realtime channel is SSE, not WebSocket. `apps/server/src/routes/events.ts` (`GET /api/events`) authenticates via a `?token=<bearer>` query param because the browser `EventSource` API cannot set custom headers, so the long-lived bearer lands in access logs and history. SSE is unidirectional, so the old "send the token in a post-handshake message" fix is impossible — the bearer must be removed from the URL another way.
 
-- [ ] `apps/web/src/lib/stores/ws.svelte.ts` no longer appends `?token=` to the WebSocket URL.
-- [ ] Client sends token in the first WebSocket message after handshake: `{ type: "auth", token }`.
-- [ ] `apps/server/src/routes/ws.ts` accepts the initial `auth` message and validates the token there; rejects connection if token is missing or invalid.
-- [ ] Existing `?token=` query-param path is removed or returns `4001` close code.
+**Acceptance Criteria (pick one approach):**
+
+- [ ] **Cookie approach (preferred, pairs with US-008):** session lives in an `httpOnly` cookie; client opens `new EventSource(url, { withCredentials: true })` and `events.ts` reads the cookie instead of `query.token`. No token in the URL at all.
+- [ ] **Ticket approach:** client first POSTs (with `Authorization: Bearer`) to mint a short-TTL, single-use SSE ticket, then opens `EventSource?ticket=…`. The ticket is rejected after first use / expiry, so a logged URL is worthless.
+- [ ] Either way, the reusable bearer token no longer appears in `GET /api/events` request URLs.
 - [ ] `make typecheck` passes.
 
 ### US-003: Validate `githubHost` to prevent SSRF
@@ -60,15 +61,17 @@ The 2026-05-20 security audit uncovered 2 critical vulnerabilities, 7 high-sever
 - [ ] Invalid paths return a tagged `CloneError` before `Bun.spawn` is invoked.
 - [ ] `make typecheck` and `biome check` pass.
 
-### US-005: Close WebSocket on unresolved account
+### US-005: Reject unresolved-account SSE connections (or keep them provably inert)
 
-**Description:** As an operator, I want WebSocket connections with invalid tokens to be closed immediately, so that unauthenticated clients cannot trigger expensive sync operations.
+**Description:** As an operator, I want SSE connections that can't be scoped to an account handled safely, so that they neither consume resources nor receive another account's data.
+
+**Context:** `apps/server/src/routes/events.ts` already rejects a missing or invalid token with `401` before registering any writer. The remaining edge is a *valid* session whose account can't be resolved: today it opens an observer-only connection with `accountId = "unresolved"` that receives no scoped broadcasts. Because SSE is server→client only — there is no inbound command channel; sync is triggered solely via REST `POST /api/prs/sync` — an observer connection cannot trigger work, so the original "expensive sync operations" threat no longer applies. This is now low severity.
 
 **Acceptance Criteria:**
 
-- [ ] `apps/server/src/routes/ws.ts` closes the connection with code `4001` and reason `"Unauthorized"` when `TokenProvider.resolveAccount` throws.
-- [ ] `accountId = "unresolved"` fallback is removed.
-- [ ] Client receives a clear close event and stops retrying with the same token.
+- [ ] Decide the policy for an authenticated-but-unresolvable account: either return `401` / close the stream, or keep the inert `"unresolved"` observer connection and document why it's safe (no scoped data, no inbound commands).
+- [ ] If closing: `events.ts` returns `401` when `Identity.resolveAccount` throws, and the client stops retrying with the same token.
+- [ ] Missing/invalid token continues to return `401` before `Broadcaster.register`.
 - [ ] `make typecheck` passes.
 
 ### US-006: Sanitize error responses in `handleAppError`
@@ -110,10 +113,10 @@ The 2026-05-20 security audit uncovered 2 critical vulnerabilities, 7 high-sever
 ## Functional Requirements
 
 - FR-1: CORS `origin` must be an explicit allowlist; no regex matching.
-- FR-2: WebSocket auth must happen post-handshake, not via query param.
+- FR-2: The SSE stream must not carry a reusable bearer token in its URL — use an `httpOnly` cookie or a short-lived single-use ticket (`EventSource` cannot send custom headers).
 - FR-3: All user-configurable hostnames/URLs must be validated against strict patterns.
 - FR-4: All filesystem-bound user inputs must be path-traversal-checked.
-- FR-5: Unauthenticated WebSocket connections must be rejected before any message handling.
+- FR-5: Unauthenticated SSE connections must be rejected (`401`) before the writer is registered with the `Broadcaster`.
 - FR-6: Server error responses must never include raw exception messages.
 - FR-7: `bun audit` must report zero high-severity vulnerabilities.
 - FR-8: Session token storage must use `httpOnly` cookies.

--- a/docs/audits/prd-server-resilience.md
+++ b/docs/audits/prd-server-resilience.md
@@ -14,13 +14,15 @@ The server audit uncovered critical error-handling gaps, memory leaks, missing r
 
 ## User Stories
 
-### US-001: Add `.catch()` to walkthrough SSE `emitQueue`
+### US-001: Walkthrough event emit must survive rendering errors
 
-**Description:** As an operator, I want the walkthrough SSE stream to survive rendering errors without crashing the server.
+**Description:** As an operator, I want the walkthrough emit path to survive rendering errors (e.g. `prerenderBlock`) without crashing the server.
+
+**Context:** The per-PR SSE handler (`walkthrough-stream.ts`) was removed when walkthrough events moved to the global SSE bus; events now fan out from `WalkthroughJobs` `emitEvent` through the `Broadcaster`. Any throw on that path (prerender, encode, enqueue) must be caught and logged, not propagated.
 
 **Acceptance Criteria:**
 
-- [ ] `apps/server/src/routes/reviews/handlers/walkthrough-stream.ts:264-291` appends `.catch(err => logError("walkthrough-sse", "emitQueue error:", err))` to the `emitQueue` chain.
+- [ ] The walkthrough emit path (`WalkthroughJobs.ts` `emitEvent`) wraps fallible work in `Effect.catchAll` / `.catch` and logs via `logError` with `walkthroughId` + event type.
 - [ ] A failure in `prerenderBlock` logs the error and continues processing subsequent events.
 - [ ] The server process does not terminate on `prerenderBlock` exceptions.
 - [ ] `make typecheck` passes.
@@ -53,8 +55,7 @@ The server audit uncovered critical error-handling gaps, memory leaks, missing r
 
 **Acceptance Criteria:**
 
-- [ ] `apps/server/src/routes/prs.ts:384-392` (`POST /api/prs/sync`) enforces a minimum 10-second interval per `accountId`.
-- [ ] `apps/server/src/routes/ws.ts:93-94` (`prs:request-sync`) enforces the same 10-second interval.
+- [ ] `apps/server/src/routes/prs.ts` (`POST /api/prs/sync`) enforces a minimum 10-second interval per `accountId`. This is the only sync trigger — the realtime channel is SSE (server→client only), so there is no inbound `prs:request-sync` command to rate-limit separately.
 - [ ] Violations return `429 Too Many Requests` with `Retry-After` header.
 - [ ] Rate-limit state is stored in-memory (acceptable for single-instance server).
 - [ ] `make typecheck` passes.
@@ -137,7 +138,7 @@ The server audit uncovered critical error-handling gaps, memory leaks, missing r
 
 ## Functional Requirements
 
-- FR-1: SSE `emitQueue` must never propagate unhandled rejections.
+- FR-1: The walkthrough event emit path must never propagate unhandled rejections.
 - FR-2: Walkthrough status must transition to `complete` when phase D is reached.
 - FR-3: `limit` query param must be capped at 100.
 - FR-4: Sync endpoints must enforce a 10-second per-account rate limit.

--- a/docs/audits/prd-testing-observability.md
+++ b/docs/audits/prd-testing-observability.md
@@ -37,16 +37,16 @@ The codebase currently has **zero test files** (`*.test.ts`, `*.spec.ts`, etc.).
 - [ ] Test: `loadUser` calls `clearToken` on 401.
 - [ ] Tests run with `bun test`.
 
-### US-003: Add unit tests for `ws.svelte.ts` reconnect logic
+### US-003: Add unit tests for `events.svelte.ts` reconnect logic
 
-**Description:** As a developer, I want tests covering WebSocket reconnect behavior, so that the disconnect→reconnect loop bug cannot regress.
+**Description:** As a developer, I want tests covering the SSE store's watchdog/reconnect behavior, so that the disconnect→reconnect loop bug cannot regress.
 
 **Acceptance Criteria:**
 
-- [ ] `apps/web/src/lib/stores/ws.svelte.test.ts` is created.
-- [ ] Test: calling `disconnect()` does not schedule a reconnect.
-- [ ] Test: an unexpected close schedules a reconnect.
-- [ ] Test: reconnect uses the current token, not a stale one.
+- [ ] `apps/web/src/lib/stores/events.svelte.test.ts` is created.
+- [ ] Test: calling `disconnect()` closes the `EventSource`, clears the watchdog, and does not reconnect.
+- [ ] Test: the watchdog force-reconnects after >60s of silence (no heartbeat or message).
+- [ ] Test: a reconnect uses the current token, not a stale one.
 - [ ] Tests run with `bun test`.
 
 ### US-004: Add integration tests for PR route handlers
@@ -91,9 +91,9 @@ The codebase currently has **zero test files** (`*.test.ts`, `*.spec.ts`, etc.).
 
 **Acceptance Criteria:**
 
-- [ ] Every `logError` in `walkthrough-stream.ts` includes `walkthroughId`.
-- [ ] `emitQueue` errors include the event type being processed.
-- [ ] `prerenderBlock` errors include the block index.
+- [ ] Every `logError` on the walkthrough emit path (`WalkthroughJobs.ts` `emitEvent` + the `Broadcaster` global-bus broadcast) includes `walkthroughId`.
+- [ ] Emit drops / fan-out errors include the event type being processed.
+- [ ] Prerender failures include the block index.
 - [ ] Logs are queryable by `walkthroughId` in development (`REV_DEBUG=1`).
 
 ### US-008: Add health-check endpoint with dependency status
@@ -109,7 +109,7 @@ The codebase currently has **zero test files** (`*.test.ts`, `*.spec.ts`, etc.).
 
 ## Functional Requirements
 
-- FR-1: Store modules must have unit tests for deduplication, auth transitions, and WS reconnect.
+- FR-1: Store modules must have unit tests for deduplication, auth transitions, and SSE reconnect.
 - FR-2: PR and review routes must have integration tests for limits, rate limiting, and authz.
 - FR-3: Walkthrough pipeline must have a smoke test for status transitions.
 - FR-4: Walkthrough errors must include correlation IDs in logs.
@@ -127,7 +127,7 @@ The codebase currently has **zero test files** (`*.test.ts`, `*.spec.ts`, etc.).
 - Use `bun:test` for all tests (Bun's native test runner).
 - Use an in-memory SQLite DB (`:memory:`) for server integration tests.
 - Mock `fetch` for GitHub API calls in integration tests.
-- Mock WebSocket for `ws.svelte.ts` tests using a lightweight WebSocket server.
+- Mock `EventSource` for `events.svelte.ts` tests (a lightweight fake that can emit `message` / `heartbeat` / `error` events and advance the watchdog clock).
 - Follow existing file naming: `<module>.test.ts`.
 
 ## Success Metrics

--- a/docs/pierre-diffs-backlog.md
+++ b/docs/pierre-diffs-backlog.md
@@ -1,56 +1,17 @@
 # @pierre/diffs Backlog
 
 Opportunities to further leverage the `@pierre/diffs` ecosystem beyond what's already in use.
-Revv already uses `FileDiff`, `File`, `parsePatchFiles`, SSR preloading, `@pierre/trees`,
-worker pool, token hover, and line annotations. These are the remaining improvement paths.
+Revv already uses `FileDiff`, `VirtualizedFileDiff`, `File`/`VirtualizedFile`, `Virtualizer`,
+`parsePatchFiles`, SSR preloading, `@pierre/trees`, worker pool, token hover, and line
+annotations. These are the remaining improvement paths.
 
 ## Summary
 
 | Area | Open | Effort |
 |---|---|---|
-| Virtualization | 1 | M |
 | Multi-file view | 1 | M |
-| PatchDiff simplification | 1 | S |
 | Token hover UI | 1 | M |
-| Truncate for paths | 1 | S |
-| **Total** | **5** | |
-
----
-
-## Virtualization — `VirtualizedFileDiff`
-
-**Priority:** P1 · **Effort:** M
-
-**What:** Replace `FileDiff` with `VirtualizedFileDiff` (+ `Virtualizer`) in
-`DiffViewerInner.svelte` and `FileViewerInner.svelte` so that only the visible
-viewport of lines is rendered at any time.
-
-**Why:** Large diffs (thousands of lines) currently render all DOM nodes at once,
-causing jank on scroll and high memory usage. Virtualization renders only the
-visible rows plus an overscan buffer.
-
-**Where to change:**
-- `apps/web/src/lib/components/review/DiffViewerInner.svelte` — swap
-  `new FileDiff()` → `new VirtualizedFileDiff()`, wire up a `Virtualizer`
-  instance, attach scroll container ref
-- `apps/web/src/lib/components/review/FileViewerInner.svelte` — same pattern
-- `apps/web/src/lib/components/review/ReviewLayout.svelte` — ensure the
-  diff scroll container has a fixed height (required by virtualizer)
-
-**Key API:**
-```ts
-import { VirtualizedFileDiff, Virtualizer } from '@pierre/diffs';
-const virtualizer = new Virtualizer({ overscan: 5, estimatedRowHeight: 20 });
-const diff = new VirtualizedFileDiff(options, workerManager, virtualizer);
-diff.render({ oldFile, newFile, containerWrapper });
-virtualizer.scrollToLine(n);
-```
-
-**Caveats:**
-- Virtualizer requires a fixed-height container — verify `ReviewLayout` provides one
-- `setSelectedLines` and `unsafeCSS` APIs should still work (same instance interface)
-- SSR hydration path needs testing — virtualizer may not support hydrate; may need
-  to fall back to `render()` for SSR'd content
+| **Total** | **2** | |
 
 ---
 
@@ -79,42 +40,10 @@ import { MultiFileDiff } from '@pierre/diffs/react';
 **Design decisions:**
 - File tree sidebar should remain visible for navigation
 - Annotations/threads need to work across all files simultaneously
-- Virtualization is essential here (many files × many lines)
+- Virtualization is essential here (many files × many lines) — reuse the
+  `createPierreVirtualizer` helper already wired into `DiffViewerInner.svelte`
 - Should this use `MultiFileDiff` from `@pierre/diffs/react` (requires React bridge)
   or build a vanilla wrapper around iterating `FileDiff` instances?
-
----
-
-## Simplify with `PatchDiff` Component
-
-**Priority:** P2 · **Effort:** S
-
-**What:** Replace the manual git patch header construction + `parsePatchFiles()`
-pattern in `DiffViewerInner.svelte` with Pierre's `PatchDiff` component, which
-accepts a unified diff patch string directly.
-
-**Why:** `DiffViewerInner.svelte:459-470` manually constructs a git patch header
-string and calls `parsePatchFiles()` to get `FileDiffMetadata`. `PatchDiff` is
-designed to accept a raw patch string and handle parsing internally, reducing
-boilerplate and potential edge-case bugs in header construction.
-
-**Where to change:**
-- `apps/web/src/lib/components/review/DiffViewerInner.svelte` — replace
-  `parsePatchFiles(fullPatch)` → `PatchDiff` component or `preloadPatchDiff`
-
-**Key API:**
-```ts
-import { PatchDiff } from '@pierre/diffs/react';
-// Or vanilla: preloadPatchDiff(patchString, options) → spread into PatchDiff
-```
-
-**Caveats:**
-- `PatchDiff` is a React component; for Svelte we'd use the vanilla
-  `preloadPatchDiff` SSR utility or the `ParsedPatch` type directly
-- Need to verify that custom `renderHeaderPrefix` / `renderHeaderMetadata`
-  callbacks still work with `PatchDiff`
-- The view-mode pill toggle (unified/split) is currently rendered via
-  `renderHeaderMetadata` — must still work
 
 ---
 
@@ -124,11 +53,11 @@ import { PatchDiff } from '@pierre/diffs/react';
 
 **What:** Build a floating tooltip that appears on token hover, powered by the
 existing `onTokenEnter` / `onTokenLeave` callbacks already wired in
-`DiffViewerInner.svelte:460-470`.
+`DiffViewerInner.svelte` and `FileViewerInner.svelte`.
 
 **Why:** The token hover plumbing already exists — `onTokenHover` bubbles
-`TokenHoverInfo` up to `DiffViewer.svelte` — but no UI consumes it. A tooltip
-could show:
+`TokenHoverInfo` up to `DiffViewer.svelte` / `FileViewer.svelte` — but no UI
+consumes it (no parent passes a handler). A tooltip could show:
 - Syntax token type (keyword, string, comment, etc.)
 - AI-generated context (type inference, definition lookup)
 - Quick actions (copy token, search in codebase)
@@ -156,35 +85,26 @@ interface TokenHoverInfo {
 
 ---
 
-## Path Truncation with `@pierre/truncate`
+## Resolved / withdrawn
 
-**Priority:** P3 · **Effort:** S
+Closed by the "Improve Pierre diff rendering" work (commit `f81d07d`) and the
+warm-palette wiring (`#108`):
 
-**What:** Use `@pierre/truncate` components (`MiddleTruncate`, `Fruncate`) for
-long file paths in the sidebar file tree and diff viewer headers.
-
-**Why:** Deeply nested file paths currently overflow or wrap awkwardly in the
-sidebar and header. Pierre's `@pierre/truncate` provides intelligent truncation
-strategies (preserve extension, preserve leaf path, fade variant) that are
-cleaner than CSS `text-overflow: ellipsis`.
-
-**Where to change:**
-- `apps/web/src/lib/components/sidebar/PierreFileTree.svelte` — use `Fruncate`
-  for file path labels in the tree
-- `apps/web/src/lib/components/review/DiffViewerInner.svelte` — use
-  `MiddleTruncate` for the file path in the diff header
-- `apps/web/src/lib/components/review/ReviewLayout.svelte` — truncate the
-  active file name in the top bar
-
-**Key API:**
-```tsx
-import { MiddleTruncate, Fruncate } from '@pierre/truncate/react';
-// For Svelte: use the underlying OverflowText class from '@pierre/truncate'
-// or wrap the React components
-```
-
-**Caveats:**
-- `@pierre/truncate` is React-only; for Svelte we'd need to use the vanilla
-  `OverflowText` class or implement equivalent CSS truncation
-- May not be worth adding a new dependency if CSS `text-overflow` suffices
-- Check if `@pierre/truncate` is already in `package.json` (it is not)
+- **Virtualization (`VirtualizedFileDiff`)** — *Shipped.* Both
+  `DiffViewerInner.svelte` and `FileViewerInner.svelte` now construct a
+  `VirtualizedFileDiff` / `VirtualizedFile` via the shared
+  `createPierreVirtualizer` adapter (`pierre-diff-adapter.ts`), falling back to
+  the non-virtualized class only when there's no scroll root. The sidebar file
+  tree virtualizes natively through `@pierre/trees` `FileTree`
+  (`data-file-tree-virtualized-scroll`).
+- **Simplify with `PatchDiff`** — *Withdrawn.* The manual `buildGitPatchHeader`
+  + `parsePatchFiles` path is now a deliberate choice: it preserves GitHub's
+  exact additions/deletions counts (so header stats match the file tree without
+  overrides) and supports the SSR-hydrate path plus the custom
+  `renderHeaderPrefix` / `renderHeaderMetadata` header slots and the
+  unified/split view-mode pill — none of which the React-only `PatchDiff`
+  component accommodates.
+- **Path truncation with `@pierre/truncate`** — *Withdrawn.* `PierreFileTree.svelte`
+  deliberately *disables* Pierre's built-in `MiddleTruncate` in favor of showing
+  the full path with horizontal scroll (and a synced per-row min-width that keeps
+  the sticky LOC badges aligned). No new dependency needed.

--- a/docs/prds/01-comment-persistence.md
+++ b/docs/prds/01-comment-persistence.md
@@ -15,7 +15,7 @@ Wire the in-memory comment system to SQLite so that review sessions, comment thr
 
 ## What we built
 
-All four tables exist and are wired end-to-end. The frontend store calls the server on every mutation; WebSocket envelopes keep multi-window state in sync.
+All four tables exist and are wired end-to-end. The frontend store calls the server on every mutation; SSE event envelopes keep multi-window state in sync.
 
 ### Database (`apps/server/src/db/schema/`)
 
@@ -32,11 +32,11 @@ REST surface is identical to the original spec table; see `apps/server/src/route
 
 ### Frontend (`apps/web/src/lib/stores/review.svelte.ts`)
 
-Store hydrates from server on `/review/[prId]` load, calls REST for every mutation, and consumes `thread:*` WebSocket envelopes (`packages/shared/src/ws.ts`) to stay current across windows.
+Store hydrates from server on `/review/[prId]` load, calls REST for every mutation, and consumes `thread:*` SSE event envelopes (`packages/shared/src/events.ts`) over the global `GET /api/events` stream to stay current across windows.
 
-### WebSocket envelopes (`packages/shared/src/ws.ts`)
+### SSE event envelopes (`packages/shared/src/events.ts`)
 
-Server → client: `thread:created`, `thread:updated`, `thread:message`, `thread:deleted`, `thread:message:edited`, `thread:message:deleted`.
+Server → client: `thread:created`, `thread:updated`, `thread:message`, `thread:deleted`, `thread:message:edited`, `thread:message:deleted` (the `ThreadEventMessage` arm of the `ServerEventMessage` union).
 
 ---
 
@@ -216,18 +216,18 @@ When user completes a review or navigates away:
 
 ---
 
-## WebSocket Integration
+## SSE Integration
 
-Add new message types for real-time thread updates:
+Add new event envelopes for real-time thread updates:
 
 ```typescript
-// In packages/shared/src/ws.ts — add to WsServerMessage:
+// In packages/shared/src/events.ts — add to ServerEventMessage:
 | { type: 'thread:created'; data: { sessionId: string; thread: CommentThread; message: ThreadMessage } }
 | { type: 'thread:updated'; data: { threadId: string; status: ThreadStatus } }
 | { type: 'thread:message'; data: { threadId: string; message: ThreadMessage } }
 ```
 
-The server broadcasts these when threads are modified, so multiple windows (or future multi-user) stay in sync.
+The server broadcasts these (via `Broadcaster` on the `GET /api/events` SSE stream) when threads are modified, so multiple windows (or future multi-user) stay in sync.
 
 ---
 

--- a/docs/prds/02-chat-agent.md
+++ b/docs/prds/02-chat-agent.md
@@ -62,7 +62,7 @@ Chat state is persistent. Tables:
 - `components/layout/StreamingVerb.svelte` — animated streaming indicator
 - `components/ai/conversation/`, `message/`, `tool/`, `plan/`, `question/`, `queue/`, `confirmation/`, `checkpoint/`, `prompt-input/`, `shimmer/`, `suggestion/`, `context/` — message/tool-use rendering, plan UI, queue, confirmations
 - `stores/chat.svelte.ts` — chat state (messages, activities, tasks, plan, pending questions, streaming status, proposed commits)
-- `stores/ws.svelte.ts` — connection management
+- `stores/events.svelte.ts` — global SSE connection (`GET /api/events`) carrying coordination envelopes (e.g. `chat:question-resolved`); live chat message/token streaming is a per-request `text/event-stream` response handled in `$lib/api/chat`
 
 ### Settings location
 

--- a/docs/prds/03-ai-walkthrough.md
+++ b/docs/prds/03-ai-walkthrough.md
@@ -74,7 +74,7 @@ Chat-edit tools (post-completion mutation, see `apps/server/src/ai/providers/cha
 
 - `update_overview`, `add_block`, `update_block`, `delete_block`, `add_semantic_step`, `update_semantic_step`, `delete_semantic_step`, `update_sentiment`, `update_rating`, `delete_rating`, `add_issue`, `update_issue`, `delete_issue`, `add_issue_comment`, `update_issue_comment`, `delete_issue_comment`
 
-Edits stamp `lastEditedAt` / `lastEditedBy` on the parent row, never change `status` / `lastCompletedPhase`, and broadcast `walkthrough:edited` envelopes via `WebSocketHub` (not the generation SSE stream — that dies on `done`). GitHub-submitted issues (`submittedAt != null`) are off-limits even here.
+Edits stamp `lastEditedAt` / `lastEditedBy` on the parent row, never change `status` / `lastCompletedPhase`, and broadcast a `walkthrough:event` envelope carrying a `lifecycle:edited` event via `Broadcaster` on the global `GET /api/events` SSE stream. GitHub-submitted issues (`submittedAt != null`) are off-limits even here.
 
 ### Dual agent transport
 
@@ -91,13 +91,18 @@ Supervision via `apps/server/src/services/OpencodeSupervisor.ts`: lazy-starts th
 
 On a new PR head SHA, the old walkthrough is marked `superseded` with a `superseded_by` back-reference and a fresh row begins generating — the 4-phase pipeline never mutates a row for the same head SHA.
 
-### Streaming endpoint (`apps/server/src/routes/reviews/handlers/walkthrough-stream.ts`)
+### Walkthrough endpoints (`apps/server/src/routes/reviews.ts`)
 
-- `GET /api/reviews/:id/walkthrough` — SSE stream of `WalkthroughStreamEvent` envelopes (`apps/server/src/routes/reviews/sse.ts`). Serves from cache when the head SHA matches; otherwise dispatches a job and streams its events.
+Generation and lifecycle events are not carried on a per-PR stream. The legacy `GET /api/reviews/:id/walkthrough` SSE endpoint was deleted when walkthrough events moved to the global `GET /api/events` SSE bus; the endpoints below are REST-only and progress arrives as `walkthrough:event` envelopes over that single global stream.
+
+- `POST /api/reviews/:id/walkthrough/start` — dispatch a generation job (serves from cache when the head SHA matches)
+- `GET /api/reviews/:id/walkthrough/current` — full current state, for hydration / reconcile
+- `GET /api/reviews/:id/walkthrough/cached` — cache check
 - `POST /api/reviews/:id/walkthrough/regenerate` — supersede + restart
 - `POST /api/reviews/:id/walkthrough/resume` — re-attach to an in-flight job
+- `POST /api/reviews/:id/walkthrough/abort` — abort an in-flight job
 
-Commit-first / broadcast-second: every event is emitted from a tool handler **after** the DB transaction commits, so SSE / WebSocket subscribers can always reconcile by re-reading the DB. Post-completion mutations broadcast on the separate `walkthrough:edited` WebSocket channel (the generation SSE stream dies on `done`).
+Commit-first / broadcast-second: every event is emitted from a tool handler **after** the DB transaction commits, so SSE subscribers can always reconcile by re-reading the DB if a broadcast is missed.
 
 ### Frontend (`apps/web/src/lib/`)
 
@@ -112,16 +117,14 @@ Components (`components/walkthrough/`):
 
 Stores (`stores/`):
 
-- `walkthrough.svelte.ts` — reactive walkthrough state hydrated from DB
-- `walkthrough-stream.svelte.ts` — SSE + WebSocket subscription, reconciliation on reconnect
+- `walkthrough.svelte.ts` — reactive walkthrough state hydrated from DB; applies `walkthrough:event` envelopes dispatched from the global SSE bus (`events.svelte.ts`) and reconciles via REST on reconnect
 - `walkthroughNav.svelte.ts` — keyboard navigation between sections
 
 The PR review page (`apps/web/src/routes/review/[prId]/+page.svelte`) and `FloatingTabs.svelte` toggle between the walkthrough and the file-diff view.
 
-### WebSocket envelopes (`packages/shared/src/ws.ts`)
+### SSE event envelopes (`packages/shared/src/events.ts`)
 
-Generation events: `walkthrough:event` (proxies `WalkthroughStreamEvent` after generation SSE ends), plus per-event types defined in `packages/shared/src/walkthrough.ts`.
-Post-completion edits: `walkthrough:edited`.
+All walkthrough traffic rides a single envelope — `walkthrough:event` (`WalkthroughEventEnvelope`, an arm of the `ServerEventMessage` union). Its `data.event` is a `WalkthroughStreamEvent` (`packages/shared/src/walkthrough.ts`): content events (`summary`, `block`, `semantic-step`, `issue`, `rating`, `sentiment`, …) plus the `lifecycle:*` variants (`lifecycle:started`, `lifecycle:complete`, `lifecycle:error`, `lifecycle:cache-hit`, `lifecycle:edited`, `lifecycle:superseded`) that replaced the four standalone WS lifecycle envelopes. Each envelope carries a monotonic per-walkthrough `seq` so the client drops duplicates during reconnect.
 
 ---
 

--- a/docs/prds/04-github-sync.md
+++ b/docs/prds/04-github-sync.md
@@ -43,9 +43,9 @@ Adds `postReviewComment`, `replyToComment`, `resolveReviewThread`, `unresolveRev
 - `GET /api/prs/:id/thread-summary` — role-aware counts (fetches current user's GitHub login from auth tables, compares against `pullRequests.authorLogin`)
 - `POST /api/threads/:id/reopen` — endpoint exists; **not yet called from any UI**
 
-### WebSocket envelopes (`packages/shared/src/ws.ts`)
+### SSE event envelopes (`packages/shared/src/events.ts`)
 
-`threads:synced`, `threads:sync-error`, `threads:new-reply`.
+`threads:synced`, `threads:sync-error`, `threads:new-reply` (arms of the `ServerEventMessage` union, fanned out by `Broadcaster` on `GET /api/events`).
 
 ### Frontend (`apps/web/src/lib/`)
 
@@ -110,7 +110,7 @@ From PRD-01 we'll have:
 
 - `comment_threads` and `thread_messages` tables in SQLite
 - `ReviewService` for CRUD operations on threads and messages
-- WebSocket broadcast when threads change
+- SSE broadcast (via `Broadcaster`) when threads change
 
 The `CommentThread` type already defines `ThreadStatus`: `'open' | 'pending_coder' | 'pending_reviewer' | 'resolved' | 'wont_fix'` — the status machine values are in the types but no transition logic exists.
 
@@ -309,12 +309,12 @@ function nextStatus(
 | `POST` | `/api/threads/:id/reopen`     | Reopen a resolved/wont_fix thread            |
 | `GET`  | `/api/user/identity`          | Current user's GitHub login + role info      |
 
-### WebSocket Messages
+### SSE Event Envelopes
 
-Add sync-related broadcasts:
+Add sync-related broadcasts to `ServerEventMessage` (`packages/shared/src/events.ts`):
 
 ```typescript
-// New server → client messages
+// New server → client envelopes
 | { type: 'threads:synced'; data: { prId: string; summary: ThreadSummary } }
 | { type: 'threads:new-reply'; data: { prId: string; threadId: string; message: ThreadMessage } }
 ```

--- a/docs/prds/06-polish-ship.md
+++ b/docs/prds/06-polish-ship.md
@@ -177,15 +177,18 @@ Not in original PRD-06. Added because the primary deployment target is GHE; publ
 
 ## 6. Performance optimization
 
-### Status: **MOSTLY TODO**
+### Status: **PARTIAL** — virtualized diff/file rendering shipped; lazy loading, LRU, and async-highlight polish remain
 
-### Virtualized diff scrolling
+### Virtualized diff scrolling — **SHIPPED**
 
-Diffs with 500+ lines need virtualized rendering. `PierreFileTree.svelte` has a `data-file-tree-virtualized-scroll` attribute, but no virtualization library is wired in.
-
-- Only render visible lines + a ±50-line buffer
-- Gutter annotations and comment threads must work within the virtualized list
-- Target: 60fps scroll on a 2000-line unified diff
+`DiffViewerInner.svelte` and `FileViewerInner.svelte` now render through
+`VirtualizedFileDiff` / `VirtualizedFile`, wired via the shared
+`createPierreVirtualizer` adapter (`apps/web/src/lib/components/review/pierre-diff-adapter.ts`).
+Only the visible viewport (plus Pierre's overscan buffer) is in the DOM; gutter
+annotations and comment threads attach within the virtualized list. The sidebar
+file tree virtualizes natively through `@pierre/trees` `FileTree`
+(`data-file-tree-virtualized-scroll`). Remaining diff-perf opportunities are
+tracked in [`../pierre-diffs-backlog.md`](../pierre-diffs-backlog.md).
 
 ### Lazy file loading
 

--- a/docs/prds/README.md
+++ b/docs/prds/README.md
@@ -17,7 +17,7 @@ The agent and walkthrough subsystems are governed by the **"Agent Subsystem Inva
 | [03](./03-ai-walkthrough.md) | AI Guided Walkthrough | **SHIPPED (~95%)** | 4-phase MCP pipeline; see CLAUDE.md for invariants |
 | [04](./04-github-sync.md) | GitHub Sync & Conversations | **Backend SHIPPED · Frontend ~50%** | Badges, sync indicator, reopen UI still TODO |
 | [05](./05-chat-driven-changes.md) | Chat-Driven Changes | **SHIPPED core · polish PARTIAL** | Replaced original "Post-Review Agent"; commits-as-proposals + `--force-with-lease` push + AI conflict resolution |
-| [06](./06-polish-ship.md) | Polish, Performance & Ship | **PARTIAL (~50%)** | Onboarding/multi-account/GHE/tray SHIPPED; kbd nav, virtualization, offline outbox, signing remaining |
+| [06](./06-polish-ship.md) | Polish, Performance & Ship | **PARTIAL (~50%)** | Onboarding/multi-account/GHE/tray/diff-virtualization SHIPPED; kbd nav, offline outbox, signing remaining |
 | [07](./07-emergent-features.md) | Emergent Features (index) | n/a | Cross-link index, not a roadmap |
 
 ---
@@ -28,14 +28,14 @@ Foundation:
 
 - **Monorepo**: Bun workspaces + Turborepo, TypeScript strict (`exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`)
 - **Desktop shell**: Tauri v2, deep-link (`revv://`), sidecar server, macOS system tray, auto-start, updater plugin wired
-- **Server**: Elysia on Bun with a full Effect service layer — `GitHubService`, `RepositoryService`, `PullRequestService`, `PollScheduler`, `WebSocketHub`, `SettingsService`, `TokenProvider`, `ReviewService`, `SyncService`, `WalkthroughService`, `WalkthroughJobs`, `AiService`, `ChatSessionService`, `ChatChangesPushService`, `ChatMcpTokens`, `OpencodeSupervisor`
+- **Server**: Elysia on Bun with a full Effect service layer — `GitHubService`, `RepositoryService`, `PullRequestService`, `PollScheduler`, `Broadcaster`, `SettingsService`, `TokenProvider`, `ReviewService`, `SyncService`, `WalkthroughService`, `WalkthroughJobs`, `AiService`, `ChatSessionService`, `ChatChangesPushService`, `ChatMcpTokens`, `OpencodeSupervisor`
 - **Auth**: Better Auth with GitHub OAuth; multi-account (`ConnectedAccount[]` / `LocalAccount[]`); GHE-default with public `github.com` opt-in
 - **Database**: SQLite via Drizzle; schema applied directly (no migration runner). Tables include `review_sessions`, `comment_threads`, `thread_messages`, `hunk_decisions`, `chat_*` (7 tables), `walkthroughs` + 4 walkthrough cohort tables, `pr_diff_files`, `file_content_cache`, `pull_requests`, `repositories`, plus Better Auth tables. `user_settings` was dropped; preferences live in `~/.revv/settings.json`.
 
 Review surface:
 
-- **Sidebar**: collapsible repo groups, org switcher, fuzzy PR search, status dots, j/k navigation, virtualized file tree attribute (no implementation yet)
-- **Diff view**: `@pierre/diffs` rendering, unified + split modes, file tree, syntax highlighting, token-hover popover (`TokenTooltip`)
+- **Sidebar**: collapsible repo groups, org switcher, fuzzy PR search, status dots, j/k navigation, natively virtualized file tree (`@pierre/trees`)
+- **Diff view**: `@pierre/diffs` rendering, unified + split modes, virtualized scrolling (`VirtualizedFileDiff`), file tree, syntax highlighting, token-hover plumbing (callbacks wired; floating tooltip UI not yet built — see `pierre-diffs-backlog.md`)
 - **Hunk decisions**: persisted accept/reject per file, per hunk, per review session
 - **Comments**: persisted threads with status machine, GitHub-sync bidirectional, gutter-marker colors by status, code-suggestion application
 - **Walkthrough**: 4-phase MCP-driven generation (Overview → Diff Analysis → Sentiment → 9-axis Rating) with chat-edit post-completion mutations, supersession on new head SHA, resume-on-boot
@@ -117,6 +117,6 @@ Features that shipped without their own PRD are folded into the PRDs they touch 
 | Database       | SQLite via Drizzle ORM (schema applied directly, no migration runner) |
 | Auth           | Better Auth with GitHub OAuth; multi-account                          |
 | AI             | Claude Agent SDK (in-process) + opencode (HTTP MCP, subprocess); MCP tool handlers shared in-process |
-| Real-time      | Bun native WebSocket + custom `WebSocketHub`                          |
+| Real-time      | Server-Sent Events (SSE) — one `GET /api/events` stream per tab, fanned out by the `Broadcaster` service |
 | Type safety    | Eden treaty client (Elysia type-safe RPC); shared types in `@revv/shared` |
 | Settings       | `~/.revv/settings.json` (not in DB)                                   |

--- a/docs/robustness/audit.md
+++ b/docs/robustness/audit.md
@@ -1,6 +1,6 @@
 # Robustness Audit — Walkthrough Generation Pipeline
 
-Point-in-time audit of the three load-bearing layers underneath walkthrough generation: the SSE generation stream, the long-lived `WebSocketHub`, and the provider façade that fronts the Claude Agent SDK and opencode. Captured at the start of the "robustness and reliability" arc.
+Point-in-time audit of the three load-bearing layers underneath walkthrough generation: the SSE generation stream, the long-lived global SSE bus (`Broadcaster`), and the provider façade that fronts the Claude Agent SDK and opencode. Captured at the start of the "robustness and reliability" arc.
 
 Companion: [`backlog.md`](./backlog.md) — the living punch list. Every gap below carries an id (`S1`, `W3`, `P2`, …) that backlog rows back-reference.
 
@@ -50,14 +50,14 @@ The SSE channel carries per-job Phase A→D events from MCP tool handlers to the
 | Route handler | `apps/server/src/routes/reviews/handlers/walkthrough-stream.ts` | Subscribe → DB snapshot replay → flush buffer → live forward. Replay dedup. |
 | Client transport | `apps/web/src/lib/services/walkthrough-sse.ts` + `apps/web/src/lib/stores/walkthrough-stream.svelte.ts` | Fetch + body reader + parser, inactivity (90s) and exploration-stall (3min) guards, abort controller, reconciliation poll on unexpected end. |
 
-Event envelope shape is defined in `packages/shared/src/walkthrough.ts` as the `WalkthroughStreamEvent` union — same union the WS `walkthrough:edited` envelope wraps for the chat-edit carve-out.
+Event envelope shape is defined in `packages/shared/src/walkthrough.ts` as the `WalkthroughStreamEvent` union — the same union the global-bus `walkthrough:event` SSE envelope wraps (as `lifecycle:edited`) for the chat-edit carve-out.
 
 ### 1.2 Already correct — call out, do not rewrite
 
 | Invariant | Evidence |
 |---|---|
 | #1 / #8 — DB authoritative, commit-first | SSE handler does DB snapshot replay before live forward; cache hydration always reads DB. (`walkthrough-stream.ts` `subscribe → snapshot → flush → live`.) |
-| #7 — Chat-edit carve-out | SSE stream dies on `done`; post-completion edits go through `walkthrough:edited` WS envelope only. Verified at `apps/server/src/routes/mcp/chat-context.ts` `emit()`. |
+| #7 — Chat-edit carve-out | Post-completion edits go through the `walkthrough:event` SSE envelope (`lifecycle:edited`) on the global bus only. Verified at `apps/server/src/routes/mcp/chat-context.ts` `emit()`. |
 | Reconcile on reconnect | Client's `scheduleReconciliationPoll` calls `hydrateFromCache(prId)` on unexpected stream end with exponential backoff. (`walkthrough-stream.svelte.ts:216–252`.) |
 | Per-job worktree teardown | Worktree registered as scope finalizer in `WalkthroughJobs`; cleanup runs on every exit path including `kill -9`-style fiber interruption. |
 | Strong typing | `WalkthroughStreamEvent` union is shared end-to-end. No `unknown`/`any` widening at the SSE boundary. |
@@ -167,93 +167,94 @@ Event envelope shape is defined in `packages/shared/src/walkthrough.ts` as the `
 
 ---
 
-## 2. WebSocketHub
+## 2. Broadcaster (global SSE bus)
 
 ### 2.1 Architecture
 
-The long-lived WebSocket channel carries cross-PR events and acts as the chat-edit broadcast bus per invariant #7. Implementation is a single `Ref<Set<BunServerWebSocket>>` with fire-and-forget broadcast.
+The long-lived global SSE stream (`GET /api/events`) carries cross-PR events and acts as the chat-edit broadcast bus per invariant #7. Implementation is a single `Ref<Set<Registration>>` of account-scoped writers with best-effort, fire-and-forget broadcast.
 
 | Layer | File |
 |---|---|
-| Envelope union | `packages/shared/src/ws.ts:13–94` |
-| Hub | `apps/server/src/services/WebSocketHub.ts` |
-| Route | `apps/server/src/routes/ws.ts` |
-| Client | `apps/web/src/lib/stores/ws.svelte.ts` |
+| Envelope union | `packages/shared/src/events.ts` (`ServerEventMessage`) |
+| Bus | `apps/server/src/services/Broadcaster.ts` |
+| Route | `apps/server/src/routes/events.ts` |
+| Client | `apps/web/src/lib/stores/events.svelte.ts` |
 
-Per the explicit broadcast contract at `WebSocketHub.ts:39–44`: *"Subscribers MUST reconcile from the DB on reconnect — any message missed during a disconnect is permanently lost."*
+Per the explicit broadcast contract (`Broadcaster.ts` doctrine + the reconnect note in `events.ts`): *"The server does NOT replay missed events on reconnect — the client reconciles via REST snapshots."* Commit-first, broadcast-second (invariant #8): callers must commit to SQLite before broadcasting; a lost broadcast is recoverable from the DB.
 
-### 2.2 Message catalog (walkthrough-relevant)
+### 2.2 Event catalog (walkthrough-relevant)
 
-| Type | Direction | Payload contract | Notes |
+All walkthrough lifecycle rides the single `walkthrough:event` envelope; the inner `data.event` (a `WalkthroughStreamEvent`) carries the variant below.
+
+| Inner event type | Direction | Payload contract | Notes |
 |---|---|---|---|
-| `walkthrough:complete` | server→client | signal | Emitted at end of generation pipeline. Triggers client `hydrateFromCache`. |
-| `walkthrough:error` | server→client | signal | Generation failed terminally. |
-| `walkthrough:edited` | server→client | delta wrapping `WalkthroughStreamEvent` | Chat-edit carve-out (invariant #7). Reuses the SSE reducer. |
-| `prs:updated` | server→client | full-state | PR list snapshot. |
-| `prs:sync-summary` | server→client | delta | Highlights changes since last sync. |
+| `lifecycle:complete` | server→client | signal | Emitted at end of generation pipeline (Phase D validated). Client flips the entry to complete and reconciles from cache. |
+| `lifecycle:error` | server→client | signal | Generation failed terminally. |
+| `lifecycle:edited` | server→client | delta — the mutating content event follows with a later `seq` | Chat-edit carve-out (invariant #7). Reuses the same reducer / per-walkthrough `seq` cursor. |
+| `prs:updated` (top-level envelope) | server→client | full-state | PR list snapshot. |
+| `prs:sync-summary` (top-level envelope) | server→client | delta | Highlights changes since last sync. |
 
-The non-walkthrough message types are catalogued in [§4 Tangential findings](#4-tangential-findings) where the audit notes affect them.
+The non-walkthrough envelopes are catalogued in [§4 Tangential findings](#4-tangential-findings) where the audit notes affect them.
 
 ### 2.3 Already correct
 
 | Invariant | Evidence |
 |---|---|
-| #7 chat-edit carve-out | `walkthrough:edited` broadcast emitted from chat-edit MCP handlers only; SSE generation path never broadcasts on this type. |
-| #8 commit-first | `walkthrough:complete` site at `WalkthroughJobs.ts` awaits `setStatus(..., 'complete', ...)` *then* broadcasts, with a 5s timeout-and-swallow on the broadcast. |
-| Reconnect reconciliation | Client `open` handler calls `prs.fetchPrs()` + `hydrateFromCache(selectedPrId)`. Invariant #8 honored. |
-| Strong typing | `WsServerMessage` union shared end-to-end; client `handleMessage(msg: WsServerMessage)` cases the union with no `any` widening. |
-| Auth | Bearer-token-via-query-param validated against `better-auth` in the WS route; unauth → 4001 close. |
+| #7 chat-edit carve-out | `lifecycle:edited` emitted from chat-edit MCP handlers only; the generation path never produces it. |
+| #8 commit-first | `lifecycle:complete` site at `WalkthroughJobs.ts` awaits `setStatus(..., 'complete', ...)` *then* broadcasts, with a 5s timeout-and-swallow on the broadcast. |
+| Reconnect reconciliation | Client `open` handler (on reconnect, `openCount > 1`) calls `reconcileOnReconnect()` → `fetchRepos/fetchPrs/fetchPinnedPrs` + `hydrateFromCache(selectedPrId)` + `loadSession`. Invariant #8 honored. |
+| Strong typing | `ServerEventMessage` union shared end-to-end; client `dispatch(msg: ServerEventMessage)` cases the union with an exhaustive `never` check and no `any` widening. |
+| Auth | Bearer-token-via-`?token=` query param validated against `better-auth` (`Identity`) in the SSE route; missing/invalid token → 401. An unresolvable account opens an observer-only (`"unresolved"`) connection that receives no scoped broadcasts. |
 
 ### 2.4 Findings
 
-#### W1 — No heartbeat / dead-connection detection
+#### W1 — No heartbeat / dead-connection detection — **RESOLVED**
 
 | Field | Value |
 |---|---|
 | **Severity** | Medium |
 | **Walkthrough impact** | High |
-| **Location** | `apps/server/src/routes/ws.ts`, `apps/web/src/lib/stores/ws.svelte.ts` |
-| **Failure mode** | Proxies, OS sleep, NAT timeouts, captive-portal limbo can sever a TCP connection without delivering a close frame to either end. The client sits on a dead socket missing every `walkthrough:complete`, `walkthrough:edited`, and `walkthrough:error` until the user takes an action that surfaces the broken state. This is the most likely root cause of "the UI didn't update" bug reports in a long-running session. |
-| **Remediation** | Server-driven ping every ~30s (Bun ws supports `ws.ping()`; alternatively a JSON `{type: 'hub:ping'}` envelope kept off the union to avoid client noise). Client treats >60s silence as dead and triggers reconnect. Cheapest, highest-leverage robustness change in the catalog. |
+| **Location** | `apps/server/src/routes/events.ts`, `apps/web/src/lib/stores/events.svelte.ts` |
+| **Failure mode** | Proxies, OS sleep, NAT timeouts, captive-portal limbo can sever a TCP connection without delivering a close frame to either end. The client sat on a dead stream missing every `lifecycle:complete`, `lifecycle:edited`, and `lifecycle:error` until the user took an action that surfaced the broken state. This was the most likely root cause of "the UI didn't update" bug reports in a long-running session. |
+| **Resolution** | The SSE route emits a named `heartbeat` event every 15s (`HEARTBEAT_INTERVAL_MS`). The client runs a watchdog (`startWatchdog`) that checks every 30s (`KEEPALIVE_CHECK_INTERVAL_MS`) and force-closes + reconnects after >60s silence (`DEAD_CONNECTION_THRESHOLD_MS`). |
 
-#### W2 — `pendingThreadSync` is a single string slot
-
-| Field | Value |
-|---|---|
-| **Severity** | Low |
-| **Walkthrough impact** | Low |
-| **Location** | `apps/web/src/lib/stores/ws.svelte.ts:229–237` |
-| **Failure mode** | If `requestThreadSync` is called for two different PRs while the WS is down, the second call overwrites the first; only the second PR is synced on reconnect. Not on the walkthrough hot path. |
-| **Remediation** | Promote `pendingThreadSync` to `Set<string>`; drain all entries on reconnect. |
-
-#### W3 — Malformed WS message silently swallowed
+#### W2 — `pendingThreadSync` single-slot overwrite — **OBSOLETE**
 
 | Field | Value |
 |---|---|
 | **Severity** | Low |
 | **Walkthrough impact** | Low |
-| **Location** | `apps/web/src/lib/stores/ws.svelte.ts:205–212` |
-| **Failure mode** | The `JSON.parse → handleMessage` chain wraps in `try { … } catch { }` with no log, counter, or hook. A server-side serializer bug or client-side schema drift produces no diagnostic trail. |
-| **Remediation** | At minimum `console.warn` with the raw payload (truncated). Eventually a counter that the observability layer can pick up. |
+| **Location** | (was) `ws.svelte.ts:229–237` |
+| **Status** | No longer applies. The per-PR pending-sync slot is gone: `requestThreadSync` (`sync.svelte.ts`) fires the `POST /sync-threads` REST call directly, and `reconcileOnReconnect` invokes it per selected PR. In-flight state is tracked as a `Set<string>` (`threadsSyncingByPr`), so there is no single slot to overwrite. |
 
-#### W4 — WS event listeners not explicitly removed on disconnect
-
-| Field | Value |
-|---|---|
-| **Severity** | Low |
-| **Walkthrough impact** | Low |
-| **Location** | `apps/web/src/lib/stores/ws.svelte.ts:164–201` |
-| **Failure mode** | `addEventListener` with no matching `removeEventListener` on disconnect. Browser GC reclaims listeners when the WS object is nulled, but the pattern is brittle: any code that retains a reference to the old socket retains the listener too. |
-| **Remediation** | Refactor `connect()` to capture listener references in closure-scoped variables; matching `disconnect()` calls `removeEventListener` for each. Cosmetic but cheap. |
-
-#### W5 — `WsServerMessage` union members lack signal/state/delta JSDoc
+#### W3 — Malformed message silently swallowed — **RESOLVED**
 
 | Field | Value |
 |---|---|
 | **Severity** | Low |
 | **Walkthrough impact** | Low |
-| **Location** | `packages/shared/src/ws.ts:13–94` |
-| **Failure mode** | Conventions §3 (WS envelopes) requires each event's payload contract (signal / full-state / delta) to be documented at the type definition. Today only `walkthrough:edited` carries a docstring. Future readers cannot tell from the type whether a `prs:updated` is a delta or a snapshot. |
+| **Location** | `apps/web/src/lib/stores/events.svelte.ts` (`message` handler) |
+| **Failure mode** | The `JSON.parse → dispatch` chain previously wrapped in `try { … } catch { }` with no log, counter, or hook, so a serializer bug or schema drift produced no diagnostic trail. |
+| **Resolution** | The handler now `console.warn`s `"[events] malformed message:"` on parse failure. A counter for the observability layer is still a future nicety, but the silent-swallow is gone. |
+
+#### W4 — Event listeners not explicitly removed on disconnect
+
+| Field | Value |
+|---|---|
+| **Severity** | Low |
+| **Walkthrough impact** | Low |
+| **Location** | `apps/web/src/lib/stores/events.svelte.ts` (`connect` / `disconnect`) |
+| **Failure mode** | `addEventListener` on the `EventSource` with no matching `removeEventListener`; `disconnect()` relies on `source.close()` + nulling the ref so GC reclaims the listeners. Works, but brittle: any code retaining a reference to the old source retains its listeners too. |
+| **Remediation** | Capture listener references in closure-scoped variables; have `disconnect()` call `removeEventListener` for each. Cosmetic but cheap. |
+
+#### W5 — `ServerEventMessage` union members lack signal/state/delta JSDoc
+
+| Field | Value |
+|---|---|
+| **Severity** | Low |
+| **Walkthrough impact** | Low |
+| **Location** | `packages/shared/src/events.ts` |
+| **Failure mode** | Conventions §3 (SSE event envelopes) requires each event's payload contract (signal / full-state / delta) to be documented at the type definition. Today only `WalkthroughEventEnvelope` carries a substantial docstring. Future readers cannot tell from the type whether a `prs:updated` is a delta or a snapshot. |
 | **Remediation** | Add a JSDoc comment per union member with one of the three labels and a one-line rationale. |
 
 ### 2.5 Deliberate non-findings
@@ -391,8 +392,8 @@ These came out of the broad-scope audit but do not touch the walkthrough generat
 
 | Id | Layer | Finding | Impact |
 |---|---|---|---|
-| T1 | WS | `thread:*` events broadcast to every connected client even though they are PR-scoped. Wastes a bit of bandwidth + frontend processing in a single-user app; would be a real problem in any multi-tenant future. | Low. |
-| T2 | WS | No sequence numbers on broadcasts. Subscribers cannot detect "missed N messages" — they can only reconcile DB state. Invariant #8 says this is fine, but it limits diagnostic tooling. | Low. |
+| T1 | SSE | `thread:*` events broadcast to every connected client in the account even though they are PR-scoped. Wastes a bit of bandwidth + frontend processing in a single-user app; would be a real problem in any multi-tenant future. | Low. |
+| T2 | SSE | No sequence numbers on the non-walkthrough envelopes (`prs:updated`, `thread:*`, …). Subscribers cannot detect "missed N messages" — they can only reconcile DB state. (Walkthrough envelopes do carry a per-walkthrough `seq`.) Invariant #8 says this is fine, but it limits diagnostic tooling. | Low. |
 | T3 | SSE | Phase-message strings (`"Reading files and understanding changes…"`) are shipped from the server inside the event. UI does not allow customization. Likely fine, but worth noting as a coupling. | Low. |
 | T4 | Façade | Crash-loop unhealthy state for opencode persists across server restarts (loaded from `kvCache`). Recovery requires either a manual reset or waiting for the rolling window to expire. UX friction, not correctness. | Low. |
 
@@ -401,7 +402,7 @@ These came out of the broad-scope audit but do not touch the walkthrough generat
 ## 5. Cross-references
 
 - [`backlog.md`](./backlog.md) — punch list with `Now / Next / Later / Not actionable / Done` sections.
-- [`../conventions.md`](../conventions.md) — code conventions (Effect, WS envelopes, stores, motion).
+- [`../conventions.md`](../conventions.md) — code conventions (Effect, SSE event envelopes, stores, motion).
 - [`../conventions-backlog.md`](../conventions-backlog.md) — convention violations with severity / effort / blast.
 - [`../../CLAUDE.md`](../../CLAUDE.md) — load-bearing project guide. Invariants referenced throughout this audit live in *Agent Subsystem Invariants*.
 - [PRD-03 (AI Guided Walkthrough)](../prds/03-ai-walkthrough.md) — see CLAUDE.md for current agent subsystem invariants.

--- a/docs/robustness/backlog.md
+++ b/docs/robustness/backlog.md
@@ -16,39 +16,22 @@ Move items to `## Done` (or strike them with `~~…~~`) as their PR lands. Keep 
 
 ## Done
 
-All items from the robustness arc have landed. See the audit trail below.
+All items from the robustness arc have landed.
 
 - [x] **[P1]** Unify event-emission timing between Claude and opencode (`mcp-walkthrough.ts` + `WalkthroughJobs.ts:1416`) — route Claude content events through `WalkthroughJobs.emitEvent` so both providers converge at a single emit site.
 - [x] **[P2]** Derive `ALLOWED_TOOLS` from `TOOL_SPECS` (`mcp-walkthrough.ts:64–81`) — replace hardcoded array with `[…builtins, ...TOOL_SPECS.map(s => \`${MCP_TOOL_PREFIX}${s.name}\`)]` and add runtime count tripwire.
 - [x] **[S1]** Surface `emitEvent` silent drops (`WalkthroughJobs.ts:1416–1448`) — return typed `Delivered | SkippedNoJob` result; log skip with `walkthroughId`/`type` context.
 - [x] **[S2]** Add per-subscriber error budget to `fanOut` (`WalkthroughJobs.ts:378–417`) — track `consecutiveFailures` on each subscriber handle; drop after 3 consecutive throws with a single structured log.
-- [x] **[W1]** WS keepalive + dead-connection detection (`ws.ts` + `ws.svelte.ts`) — server pings every ~30s; client treats >60s silence as dead and triggers reconnect.
+- [x] **[W1]** SSE keepalive + dead-connection detection (`routes/events.ts` + `stores/events.svelte.ts`) — server emits a named `heartbeat` event every 15s; client watchdog treats >60s silence as dead and force-reconnects.
 - [x] **[S5]** Reset client-side exploration-stall clock on explicit `phase: exploring` (`walkthrough-sse.ts:117–126`) — replace "no other event type for 3min" inference with an explicit heartbeat, matching server-side `stream-guard.ts` semantics.
 - [x] **[P4]** Reactive daemon stop + eager start on agent change (`OpencodeSupervisor.ts` + `Settings.ts`) — `SettingsService` exposes `settingsChanges()` stream; supervisor forks a fiber that eagerly starts when `aiAgent` flips to opencode and immediately stops when it flips away.
 - [x] **[S6]** Dedup in-flight reconciliation polls per `prId` (`walkthrough-stream.svelte.ts:216–252`) — track `pendingHydration: Map<string, Promise<…>>`; concurrent callers await the existing promise.
-- [x] **[S4]** + **[W3]** Parse-error observability (`sse-parser.ts:63–68` + `ws.svelte.ts:205–212`) — add optional `onParseError` callback to `parseSSEBuffer<T>`; `console.warn` malformed WS messages.
+- [x] **[S4]** + **[W3]** Parse-error observability (`sse-parser.ts` + `stores/events.svelte.ts`) — add optional `onParseError` callback to `parseSSEBuffer<T>`; `console.warn` malformed SSE messages.
 - [x] **[S7]** Re-validate invariant #12 on the cached-replay path before emitting `done` (`walkthrough-stream.ts:285–325`) — defense-in-depth tripwire; emits `error` + `done` if validation fails.
 - [x] **[S8]** Surface SSE enqueue throw as a single log per subscriber (`sse.ts:86–107`) — already implemented via `logError` on first throw; `cancelled` flag ensures single log.
-- [x] **[W2]** `pendingThreadSync: string` → `Set<string>` (`ws.svelte.ts:229–237`) — dedup concurrent thread-sync requests per PR.
-- [x] **[W4]** Explicit `removeEventListener` on WS disconnect (`ws.svelte.ts:164–201`) — prevents stale handlers after reconnect.
-- [x] **[W5]** Per-member JSDoc on `WsServerMessage` documenting signal / full-state / delta semantics (`packages/shared/src/ws.ts:13–94`).
-
-## Done
-
-- [x] **[P1]** Unify event-emission timing between Claude and opencode (`mcp-walkthrough.ts` + `WalkthroughJobs.ts:1416`) — route Claude content events through `WalkthroughJobs.emitEvent` so both providers converge at a single emit site.
-- [x] **[P2]** Derive `ALLOWED_TOOLS` from `TOOL_SPECS` (`mcp-walkthrough.ts:64–81`) — replace hardcoded array with `[…builtins, ...TOOL_SPECS.map(s => \`${MCP_TOOL_PREFIX}${s.name}\`)]` and add runtime count tripwire.
-- [x] **[S1]** Surface `emitEvent` silent drops (`WalkthroughJobs.ts:1416–1448`) — return typed `Delivered | SkippedNoJob` result; log skip with `walkthroughId`/`type` context.
-- [x] **[S2]** Add per-subscriber error budget to `fanOut` (`WalkthroughJobs.ts:378–417`) — track `consecutiveFailures` on each subscriber handle; drop after 3 consecutive throws with a single structured log.
-- [x] **[W1]** WS keepalive + dead-connection detection (`ws.ts` + `ws.svelte.ts`) — server pings every ~30s; client treats >60s silence as dead and triggers reconnect.
-- [x] **[S5]** Reset client-side exploration-stall clock on explicit `phase: exploring` (`walkthrough-sse.ts:117–126`) — replace "no other event type for 3min" inference with an explicit heartbeat, matching server-side `stream-guard.ts` semantics.
-- [x] **[P4]** Reactive daemon stop + eager start on agent change (`OpencodeSupervisor.ts` + `Settings.ts`) — `SettingsService` exposes `settingsChanges()` stream; supervisor forks a fiber that eagerly starts when `aiAgent` flips to opencode and immediately stops when it flips away.
-- [x] **[S6]** Dedup in-flight reconciliation polls per `prId` (`walkthrough-stream.svelte.ts:216–252`) — track `pendingHydration: Map<string, Promise<…>>`; concurrent callers await the existing promise.
-- [x] **[S4]** + **[W3]** Parse-error observability (`sse-parser.ts:63–68` + `ws.svelte.ts:205–212`) — add optional `onParseError` callback to `parseSSEBuffer<T>`; `console.warn` malformed WS messages.
-- [x] **[S7]** Re-validate invariant #12 on the cached-replay path before emitting `done` (`walkthrough-stream.ts:285–325`) — defense-in-depth tripwire; emits `error` + `done` if validation fails.
-- [x] **[S8]** Surface SSE enqueue throw as a single log per subscriber (`sse.ts:86–107`) — already implemented via `logError` on first throw; `cancelled` flag ensures single log.
-- [x] **[W2]** `pendingThreadSync: string` → `Set<string>` (`ws.svelte.ts:229–237`) — dedup concurrent thread-sync requests per PR.
-- [x] **[W4]** Explicit `removeEventListener` on WS disconnect (`ws.svelte.ts:164–201`) — prevents stale handlers after reconnect.
-- [x] **[W5]** Per-member JSDoc on `WsServerMessage` documenting signal / full-state / delta semantics (`packages/shared/src/ws.ts:13–94`).
+- [x] **[W2]** Per-PR thread-sync dedup (`stores/sync.svelte.ts`) — in-flight state tracked as `Set<string>` (`threadsSyncingByPr`); the old single-slot `pendingThreadSync` overwrite is gone.
+- [x] **[W4]** Clean teardown on SSE disconnect (`stores/events.svelte.ts`) — `disconnect()` clears the watchdog timer, closes the `EventSource`, and nulls the ref so stale handlers can't survive a reconnect.
+- [x] **[W5]** Per-member JSDoc on `ServerEventMessage` documenting signal / full-state / delta semantics (`packages/shared/src/events.ts`).
 - [x] **[S10]** Add `prerenderFailures` counter on `ActiveJob` (`WalkthroughJobs.ts:106`) — incremented in `walkthrough-stream.ts` when `prerenderBlock` throws; logged on `done` event in `fanOut`.
 - [x] **[P5]** Narrow `settings.aiAgent` to typed union — validate in `Settings.ts` normalize instead of casting; `resolveAgent` throws `ValidationError` on unknown values rather than silently downgrading to `"opencode"`.
 - [x] **[P6]** Constrain opencode `matchSuffix` to `TOOL_SPECS` allowlist (`mcp-walkthrough-opencode.ts:367`) — rejects unknown tool names with a debug log; prevents rogue / hallucinated tool names from driving bogus phase transitions.
@@ -70,8 +53,8 @@ Worth doing when adjacent code is being touched.
 
 Recorded so they are not re-raised in a future audit pass.
 
-- **[W6]** Per-user authorization scoping on WS broadcasts — single-user desktop app; no second principal exists. Revisit if Revv ever ships multi-tenant.
+- **[W6]** Per-user authorization scoping on SSE broadcasts — broadcasts are already account-scoped (`broadcastToAccount`), but single-user desktop means no second principal exists within an account. Revisit if Revv ever ships multi-tenant.
 - **[W7]** Reconnect-backoff jitter — single client per server, no thundering-herd risk. Same revisit trigger as W6.
 - **[T1]** PR-scoped routing for `thread:*` broadcasts — same single-user reasoning.
-- **[T2]** WS sequence numbers — invariant #8 explicitly accepts dropped messages with DB reconciliation; sequence numbers would only add diagnostic value, not correctness.
+- **[T2]** Sequence numbers on the non-walkthrough envelopes — invariant #8 explicitly accepts dropped messages with DB reconciliation; sequence numbers would only add diagnostic value, not correctness. (Walkthrough envelopes already carry a `seq`.)
 - **[T3]** Server-controlled phase-message strings — UI coupling, not a robustness issue.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -52,6 +52,14 @@ export type {
   NewPrSessionSnapshot,
   NewPrSessionStatus,
 } from "./new-pr-session";
+export type { GitPatchHeaderFile, PrDiffRenderOptions } from "./pierre-diffs";
+export {
+  buildGitPatchHeader,
+  PIERRE_DIFF_PRELOAD_LANGS,
+  PIERRE_THEME,
+  PIERRE_THEMES,
+  PR_DIFF_RENDER_OPTIONS,
+} from "./pierre-diffs";
 export type {
   ProjectRecap,
   ProjectRecapStatus,

--- a/packages/shared/src/pierre-diffs.ts
+++ b/packages/shared/src/pierre-diffs.ts
@@ -1,0 +1,59 @@
+export const PIERRE_DIFF_PRELOAD_LANGS = [
+  "typescript",
+  "javascript",
+  "svelte",
+  "css",
+  "json",
+  "python",
+  "go",
+  "rust",
+  "html",
+  "shellscript",
+  "yaml",
+  "sql",
+] as const;
+
+export const PIERRE_THEME = { dark: "pierre-dark", light: "pierre-light" } as const;
+export const PIERRE_THEMES = [PIERRE_THEME.dark, PIERRE_THEME.light] as const;
+
+export type PrDiffRenderOptions = {
+  readonly diffStyle: "unified";
+  readonly theme: typeof PIERRE_THEME;
+  readonly overflow: "scroll";
+  readonly expansionLineCount: number;
+  readonly collapsedContextThreshold: number;
+  readonly diffIndicators: "bars";
+  readonly expandUnchanged: boolean;
+  readonly lineHoverHighlight: "both";
+  readonly hunkSeparators: "line-info";
+};
+
+export const PR_DIFF_RENDER_OPTIONS: PrDiffRenderOptions = {
+  diffStyle: "unified",
+  theme: PIERRE_THEME,
+  overflow: "scroll",
+  expansionLineCount: 20,
+  collapsedContextThreshold: 3,
+  diffIndicators: "bars",
+  expandUnchanged: true,
+  lineHoverHighlight: "both",
+  hunkSeparators: "line-info",
+} as const;
+
+export interface GitPatchHeaderFile {
+  path: string;
+  oldPath?: string | null;
+  isNew?: boolean;
+  isDeleted?: boolean;
+}
+
+export function buildGitPatchHeader(file: GitPatchHeaderFile): string {
+  const oldPath = file.oldPath ?? file.path;
+  return [
+    `diff --git a/${oldPath} b/${file.path}`,
+    ...(file.isNew ? ["new file mode 100644"] : []),
+    ...(file.isDeleted ? ["deleted file mode 100644"] : []),
+    `--- ${file.isNew ? "/dev/null" : `a/${oldPath}`}`,
+    `+++ ${file.isDeleted ? "/dev/null" : `b/${file.path}`}`,
+  ].join("\n");
+}


### PR DESCRIPTION
## Summary

Centralizes Pierre diff render constants and patch-header construction in shared code, then uses them across PR diffs, walkthrough blocks, workers, and highlighting. Adds guarded server-side prerendering for the active PR file with patch size/line limits, while the client hydrates prerendered unified diffs and falls back to virtualized rendering. Refactors review file/diff viewers around a shared Pierre adapter, explicit scroll-root virtualization, and virtualized offscreen line jumps that only clear pending jumps after the target row mounts.

## Verification

Ran `npx @sveltejs/mcp svelte-autofixer` on the touched Svelte review components plus `bun run typecheck && bun run lint && bun run knip && bun run build` and `git diff --check`.