### PR TITLE
fix(diff): show all comments in unified view after SSR hydrate (#114)

### DIFF
--- a/apps/web/src/lib/components/review/DiffViewerInner.svelte
+++ b/apps/web/src/lib/components/review/DiffViewerInner.svelte
@@ -211,7 +211,7 @@ function getShadowRoot(): ShadowRoot | null {
 function hasUnhydratedAnnotation(annos: DiffLineAnnotation<ThreadMeta>[]): boolean {
   if (annos.length === 0) return false;
   const shadowRoot = getShadowRoot();
-  if (!shadowRoot) return annos.length > 0;
+  if (!shadowRoot) return true;
   const slotNames = new Set<string>();
   for (const slot of shadowRoot.querySelectorAll("slot[name^='annotation-']")) {
     const name = slot.getAttribute("name");

--- a/apps/web/src/lib/components/review/DiffViewerInner.svelte
+++ b/apps/web/src/lib/components/review/DiffViewerInner.svelte
@@ -198,15 +198,9 @@ function getShadowRoot(): ShadowRoot | null {
 
 /**
  * True when a live annotation has no matching `<slot>` in the just-hydrated
- * shadow DOM. The server prerenders the unified diff's annotation slots from a
- * point-in-time thread snapshot (`/api/prs/:id/files`); the client's live
- * thread set (loaded via `/reviews/active`, and reloaded on SSE without
- * refetching files) can diverge — e.g. AI comments that land after the
- * snapshot. Pierre's `hydrate` adopts the prerendered slots as-is and never
- * rebuilds the body, so those extra comments project into a non-existent slot
- * and silently vanish in unified view (they show in split, which always uses
- * the full `render()` path). Detecting the gap lets us force a single
- * corrective render only when needed, keeping the SSR no-tokenize happy path.
+ * shadow DOM — i.e. Pierre's `hydrate` adopted prerendered slots that don't
+ * cover the current annotation set. See the hydrate call site in onMount for
+ * why the prerendered and live sets diverge and what the corrective render does.
  */
 function hasUnhydratedAnnotation(annos: DiffLineAnnotation<ThreadMeta>[]): boolean {
   if (annos.length === 0) return false;
@@ -342,6 +336,13 @@ function findPatchLineIndex(patch: string, targetLine: number): number | null {
 // threadMessages, and annotations all get new references, triggering this
 // effect. We update the mutable ref (so renderAnnotation sees fresh data),
 // clear stale caches, and re-render with the new annotations.
+//
+// LOAD-BEARING: the hydrate path in onMount may deliberately leave
+// `appliedAnnotations` null (when prerendered slots don't cover every live
+// annotation) precisely so this guard sees a mismatch and fires one corrective
+// render on first run. Don't "simplify" the guard to assume appliedAnnotations
+// is always set after mount — that silently reintroduces the vanished-comment
+// bug fixed in #114.
 $effect(() => {
   if (!instance) return;
   const currentAnnotations = annotations;
@@ -622,12 +623,6 @@ onMount(() => {
     // populate the header slots after hydrate using the exported slot
     // IDs — Pierre's shadow DOM has `<slot name="...">` placeholders
     // that project these light-DOM children.
-    //
-    // Set true when hydration adopted prerendered slots that don't cover every
-    // live annotation — the post-mount $effect must then run one corrective
-    // render() to rebuild the missing ones.
-    let needsAnnotationReconcile = false;
-
     if (file.prerenderedHtml !== undefined && mode === "unified") {
       instance = new FileDiff<ThreadMeta>(options, workerManager);
       // Match the render() DOM structure: a <diffs-container> custom element
@@ -646,7 +641,20 @@ onMount(() => {
         lineAnnotations: annotations,
       });
       populateDiffHeaderSlots(hostEl, parsed, options);
-      needsAnnotationReconcile = hasUnhydratedAnnotation(annotations);
+
+      // The server prerenders the unified diff's annotation slots from a
+      // point-in-time thread snapshot (`/api/prs/:id/files`); the client's
+      // live thread set (loaded via `/reviews/active`, and reloaded on SSE
+      // without refetching files) can diverge — e.g. AI comments that land
+      // after the snapshot. `hydrate` adopts the prerendered slots as-is and
+      // never rebuilds the body, so those extra comments project into a
+      // non-existent slot and silently vanish in unified view (split is fine —
+      // it always uses the full `render()` path). When that gap exists, leave
+      // appliedAnnotations null so the reconcile $effect fires exactly once and
+      // rebuilds the missing slots via one corrective render(); otherwise mark
+      // them applied so the $effect is a no-op and the SSR no-tokenize fast
+      // paint is preserved.
+      appliedAnnotations = hasUnhydratedAnnotation(annotations) ? null : annotations;
     } else {
       virtualizer = createPierreVirtualizer(scrollRoot, wrapperEl);
       const hostEl = createDiffsHost();
@@ -660,15 +668,14 @@ onMount(() => {
         lineAnnotations: annotations,
         forceRender: true,
       });
-    }
-    // Mark initial state as applied so the post-mount $effect
-    // (which would otherwise re-render with forceRender:true) is a no-op.
-    // Exception: when hydration left some live annotations without a slot,
-    // leave appliedAnnotations null so the $effect fires exactly once and
-    // rebuilds the missing slots via a corrective render().
-    if (!needsAnnotationReconcile) {
+      // render() projected every annotation, so mark them applied to keep the
+      // post-mount $effect a no-op.
       appliedAnnotations = annotations;
     }
+    // Mark thread data as applied so the post-mount $effect (which would
+    // otherwise re-render with forceRender:true) is a no-op. appliedAnnotations
+    // is set per-branch above — the hydrate branch may leave it null on purpose
+    // to trigger one corrective render.
     appliedThreadById = threadById;
     appliedThreadMessages = threadMessages;
 

--- a/apps/web/src/lib/components/review/DiffViewerInner.svelte
+++ b/apps/web/src/lib/components/review/DiffViewerInner.svelte
@@ -6,6 +6,7 @@ import {
   FileDiff,
   type FileDiffMetadata,
   type FileDiffOptions,
+  getLineAnnotationName,
   parsePatchFiles,
   VirtualizedFileDiff,
 } from "@pierre/diffs";
@@ -193,6 +194,30 @@ function captureEl(el: HTMLDivElement) {
 
 function getShadowRoot(): ShadowRoot | null {
   return getPierreShadowRoot(wrapperEl);
+}
+
+/**
+ * True when a live annotation has no matching `<slot>` in the just-hydrated
+ * shadow DOM. The server prerenders the unified diff's annotation slots from a
+ * point-in-time thread snapshot (`/api/prs/:id/files`); the client's live
+ * thread set (loaded via `/reviews/active`, and reloaded on SSE without
+ * refetching files) can diverge — e.g. AI comments that land after the
+ * snapshot. Pierre's `hydrate` adopts the prerendered slots as-is and never
+ * rebuilds the body, so those extra comments project into a non-existent slot
+ * and silently vanish in unified view (they show in split, which always uses
+ * the full `render()` path). Detecting the gap lets us force a single
+ * corrective render only when needed, keeping the SSR no-tokenize happy path.
+ */
+function hasUnhydratedAnnotation(annos: DiffLineAnnotation<ThreadMeta>[]): boolean {
+  if (annos.length === 0) return false;
+  const shadowRoot = getShadowRoot();
+  if (!shadowRoot) return annos.length > 0;
+  const slotNames = new Set<string>();
+  for (const slot of shadowRoot.querySelectorAll("slot[name^='annotation-']")) {
+    const name = slot.getAttribute("name");
+    if (name) slotNames.add(name);
+  }
+  return annos.some((anno) => !slotNames.has(getLineAnnotationName(anno)));
 }
 
 function findRenderedLineElement(lineIndex: number): HTMLElement | null {
@@ -597,6 +622,12 @@ onMount(() => {
     // populate the header slots after hydrate using the exported slot
     // IDs — Pierre's shadow DOM has `<slot name="...">` placeholders
     // that project these light-DOM children.
+    //
+    // Set true when hydration adopted prerendered slots that don't cover every
+    // live annotation — the post-mount $effect must then run one corrective
+    // render() to rebuild the missing ones.
+    let needsAnnotationReconcile = false;
+
     if (file.prerenderedHtml !== undefined && mode === "unified") {
       instance = new FileDiff<ThreadMeta>(options, workerManager);
       // Match the render() DOM structure: a <diffs-container> custom element
@@ -615,6 +646,7 @@ onMount(() => {
         lineAnnotations: annotations,
       });
       populateDiffHeaderSlots(hostEl, parsed, options);
+      needsAnnotationReconcile = hasUnhydratedAnnotation(annotations);
     } else {
       virtualizer = createPierreVirtualizer(scrollRoot, wrapperEl);
       const hostEl = createDiffsHost();
@@ -631,7 +663,12 @@ onMount(() => {
     }
     // Mark initial state as applied so the post-mount $effect
     // (which would otherwise re-render with forceRender:true) is a no-op.
-    appliedAnnotations = annotations;
+    // Exception: when hydration left some live annotations without a slot,
+    // leave appliedAnnotations null so the $effect fires exactly once and
+    // rebuilds the missing slots via a corrective render().
+    if (!needsAnnotationReconcile) {
+      appliedAnnotations = annotations;
+    }
     appliedThreadById = threadById;
     appliedThreadMessages = threadMessages;
 


### PR DESCRIPTION
Fixes #114. Review comments (notably AI-generated "Revv AI" comments) showed in split view but silently vanished in unified view. The unified view's SSR-hydrate path adopts the server-prerendered shadow DOM as-is and never rebuilds the diff body, so its annotation `<slot>` placeholders come only from the server's point-in-time thread snapshot — when the client's live thread set diverges (AI comments landing after the snapshot, or an SSE session reload that refetches threads but not files), those extra comments project into a non-existent slot and disappear. After hydrate, the client now compares the live annotations against the slot names actually present in the prerendered shadow DOM (via Pierre's exported `getLineAnnotationName`) and, on a mismatch, leaves `appliedAnnotations` null so the existing post-mount `$effect` fires exactly once to rebuild the missing slots. The matching happy path is unchanged, preserving the SSR no-tokenize fast paint. typecheck, lint, knip, and build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)