### PR TITLE
fix(web): instant pane toggles + repair Cmd+Option+B shortcut

### DIFF
--- a/apps/web/src/lib/components/layout/AppShell.svelte
+++ b/apps/web/src/lib/components/layout/AppShell.svelte
@@ -116,6 +116,11 @@ $effect(() => {
   const open = rightPanelOpen;
   const width = rightPanelWidth;
   if (!panelEl || !mainEl) return;
+  // gsap.set (not panelEl.style.transform): it writes the same
+  // `transform: translate3d(...)` format as the CSS fallback on
+  // `.rightpanel-area`, so the inline write and the static rule agree on
+  // units and there's no first-paint flash. Don't "simplify" to a plain
+  // style write — that risks format drift against the CSS fallback.
   gsap.set(panelEl, { x: open ? 0 : width });
   mainEl.style.setProperty("--vignette-opacity", open ? "0.65" : "0");
 });
@@ -315,7 +320,7 @@ function onRightHandleDblClick(): void {
 		   the resize-observing @pierre diff in the main pane on every frame,
 		   tanking the toggle to single-digit fps. Both panes toggle instantly —
 		   the sidebar via the grid track, the right panel via the snapped
-		   translateX in the panel-choreography $effect above. */
+		   translateX in the right-panel $effect above. */
 	}
 
 	/* ── Rail (always-visible project switcher) ── */
@@ -407,10 +412,10 @@ function onRightHandleDblClick(): void {
 			0 8px 24px -12px color-mix(in srgb, black 10%, transparent);
 	}
 
-	/* Right-edge vignette that fades in when the panel opens, softening the
-	   hard clip as the main area loses width to the panel. Opacity is driven
-	   by GSAP through `--vignette-opacity` (see panel-choreography.ts) so
-	   the slide + fade share a single tween and stay in sync. */
+	/* Right-edge vignette that appears when the panel opens, softening the
+	   hard clip as the main area loses width to the panel. Opacity is set
+	   directly (`--vignette-opacity`) by the right-panel $effect above —
+	   instant, no tween, in lockstep with the panel's snapped translateX. */
 	.main-area::after {
 		content: '';
 		position: absolute;
@@ -473,12 +478,12 @@ function onRightHandleDblClick(): void {
 	}
 
 	/* ── Right pane (chat) ──
-	   `.rightpanel-slot` is the grid cell whose width animates 0 ↔
+	   `.rightpanel-slot` is the grid cell whose width snaps 0 ↔
 	   rightPanelWidth; that drives the main column's shrink/grow.
 	   `.rightpanel-area` is absolutely-positioned inside it at a stable
-	   width so its contents never reflow during the track animation. The
-	   visible slide is a GSAP translateX tween on the panel, synchronized
-	   with the CSS grid transition (same duration + easing). */
+	   width so its contents never reflow when the track changes. The panel's
+	   translateX (off-screen ↔ 0) is snapped via `gsap.set` in the
+	   right-panel $effect above — instant, matching the grid track. */
 	.rightpanel-slot {
 		grid-area: rightpanel;
 		position: relative;
@@ -500,12 +505,11 @@ function onRightHandleDblClick(): void {
 			inset 0 1px 0 0 color-mix(in srgb, white 60%, transparent),
 			0 1px 2px -1px color-mix(in srgb, black 6%, transparent),
 			0 8px 24px -12px color-mix(in srgb, black 10%, transparent);
-		/* First-paint transform for the closed state. The GSAP choreography
-		   (panel-choreography $effect above) takes over once the first
-		   effect runs, writing the transform inline (which beats this rule
-		   on specificity). Keeping the static CSS means an open-on-reload
-		   panel renders at its correct resting position without a one-frame
-		   flash before JS attaches. */
+		/* First-paint transform for the closed state. The right-panel $effect
+		   above takes over once it first runs, writing the transform inline
+		   (which beats this rule on specificity). Keeping the static CSS means
+		   an open-on-reload panel renders at its correct resting position
+		   without a one-frame flash before JS attaches. */
 		transform: translateX(var(--right-panel-width));
 	}
 

--- a/apps/web/src/lib/components/layout/AppShell.svelte
+++ b/apps/web/src/lib/components/layout/AppShell.svelte
@@ -3,13 +3,12 @@ import { page } from "$app/state";
 import SettingsModal from "$lib/components/settings/SettingsModal.svelte";
 import UserMenu from "$lib/components/sidebar/UserMenu.svelte";
 import { RAIL_WIDTH } from "$lib/constants";
-import { gsap, gsapFade, prefersReducedMotion, tokens } from "$lib/motion";
+import { gsap, gsapFade, tokens } from "$lib/motion";
 import { getSelectedPr } from "$lib/stores/prs.svelte";
 import {
   getActiveTab,
   getIsPullingCommit,
   getLoadedHeadSha,
-  getReviewFiles,
   pullLatestCommit,
   setActiveTab,
 } from "$lib/stores/review.svelte";
@@ -20,7 +19,6 @@ import {
   getRightPanelWidth,
   getSidebarCollapsed,
   getSidebarPeekHovering,
-  getSidebarView,
   getSidebarWidth,
   RIGHT_PANEL_WIDTH_MAX,
   RIGHT_PANEL_WIDTH_MIN,
@@ -47,8 +45,6 @@ import WalkthroughActionBar from "./WalkthroughActionBar.svelte";
 
 let { children } = $props();
 
-const LARGE_FILE_TREE_ANIMATION_THRESHOLD = 120;
-
 const sidebarCollapsed = $derived(getSidebarCollapsed());
 // Effective collapsed state: false when the user is hovering a project
 // avatar (or the sidebar itself) so the column expands as a peek without
@@ -63,16 +59,11 @@ const paletteOpen = $derived(getPaletteOpen());
 const paletteMode = $derived(getPaletteMode());
 const sidebarWidth = $derived(getSidebarWidth());
 const rightPanelWidth = $derived(getRightPanelWidth());
-const sidebarView = $derived(getSidebarView());
-const reviewFiles = $derived(getReviewFiles());
 const pr = $derived(getSelectedPr());
 const walkthroughStatus = $derived(pr ? getPrWalkthroughStatus(pr.id) : "idle");
 const activeTab = $derived(getActiveTab());
 const isSettingsRoute = $derived(page.url.pathname.startsWith("/settings"));
 const isReviewRoute = $derived(page.url.pathname.startsWith("/review/"));
-const shouldSnapSidebarLayout = $derived(
-  sidebarView === "files" && reviewFiles.length >= LARGE_FILE_TREE_ANIMATION_THRESHOLD,
-);
 const showFloatingActions = $derived(
   !!pr && isReviewRoute && !isSettingsRoute && activeTab === "walkthrough",
 );
@@ -112,58 +103,21 @@ $effect(() => {
   }
 });
 
-// Right-panel slide + main-area vignette. Grid-track interpolation stays
-// on a CSS transition; JS-driving it forces a Svelte reactivity flush per
-// frame (de65e4c9). Snap on first paint and during a live drag.
-//
-// The grid-track animation is cheap because both flanking panes render
-// at a stable width (sidebar via `width: var(--sidebar-width)`, right
-// panel via absolute positioning inside `.rightpanel-slot`), so neither
-// pane's contents reflow as the track changes. Only the main area
-// actually resizes, and its diff viewer / file tree are virtualized
-// externally (@pierre/diffs, @pierre/trees).
+// Right panel appears/disappears instantly, same as the sidebar — snap the
+// panel's translateX (off-screen ↔ 0) and the main-area vignette on every
+// toggle, no tween. The vignette softens the main pane's clipped right edge
+// while the chat panel covers it. The closed-state transform also lives in
+// CSS (`.rightpanel-area`) so an open-on-reload panel paints correctly before
+// this effect attaches.
 let panelEl = $state<HTMLElement | null>(null);
 let mainEl = $state<HTMLElement | null>(null);
-let panelSlide: gsap.QuickToFunc | null = null;
-let vignetteSetter: gsap.QuickToFunc | null = null;
-const vignetteProxy = { v: 0 };
-let firstChoreography = true;
 
 $effect(() => {
   const open = rightPanelOpen;
   const width = rightPanelWidth;
-  const resizing = isResizingRight;
   if (!panelEl || !mainEl) return;
-
-  const targetX = open ? 0 : width;
-  const targetV = open ? 0.65 : 0;
-
-  if (firstChoreography || resizing || prefersReducedMotion()) {
-    gsap.set(panelEl, { x: targetX });
-    mainEl.style.setProperty("--vignette-opacity", String(targetV));
-    firstChoreography = false;
-    return;
-  }
-
-  // CustomEase parses bare cubic-bezier control points (tokens.ts:4–8).
-  // Wrapping them in `cubic-bezier(...)` silently falls back to power1.out,
-  // which desyncs against the CSS grid transition's real expo curve.
-  if (!panelSlide) {
-    panelSlide = gsap.quickTo(panelEl, "x", {
-      duration: tokens.smooth,
-      ease: tokens.easeOutExpo,
-    });
-  }
-  if (!vignetteSetter) {
-    const el = mainEl;
-    vignetteSetter = gsap.quickTo(vignetteProxy, "v", {
-      duration: tokens.smooth,
-      ease: tokens.easeOutExpo,
-      onUpdate: () => el.style.setProperty("--vignette-opacity", String(vignetteProxy.v)),
-    });
-  }
-  panelSlide(targetX);
-  vignetteSetter(targetV);
+  gsap.set(panelEl, { x: open ? 0 : width });
+  mainEl.style.setProperty("--vignette-opacity", open ? "0.65" : "0");
 });
 
 const gridStyle = $derived(
@@ -230,8 +184,6 @@ function onRightHandleDblClick(): void {
 <div
 	class="app-shell"
 	class:sidebar-collapsed={sidebarEffectiveCollapsed}
-	class:is-resizing={isDragging || isResizingRight}
-	class:snap-sidebar-layout={shouldSnapSidebarLayout}
 	class:rightpanel-open={rightPanelOpen}
 	style={gridStyle}
 >
@@ -359,18 +311,11 @@ function onRightHandleDblClick(): void {
 		/* Positioning context for the absolutely-positioned right pane. */
 		position: relative;
 		background-color: var(--color-bg-secondary);
-		/* Animates the main column when either flanking pane toggles. The
-		   per-frame cost is bounded by the stable-width pattern documented
-		   on the panel-choreography $effect above. */
-		transition: grid-template-columns var(--duration-smooth) var(--ease-out-expo);
-	}
-
-	/* Snap (no tween) during a live drag, and when the sidebar is showing a
-	   large virtualized tree where animating the column would relayout it
-	   on every frame. */
-	.app-shell.is-resizing,
-	.app-shell.snap-sidebar-layout {
-		transition: none;
+		/* No transition on grid-template-columns: tweening the track relayouts
+		   the resize-observing @pierre diff in the main pane on every frame,
+		   tanking the toggle to single-digit fps. Both panes toggle instantly —
+		   the sidebar via the grid track, the right panel via the snapped
+		   translateX in the panel-choreography $effect above. */
 	}
 
 	/* ── Rail (always-visible project switcher) ── */

--- a/apps/web/src/lib/stores/shortcuts.svelte.ts
+++ b/apps/web/src/lib/stores/shortcuts.svelte.ts
@@ -94,8 +94,11 @@ function handleKeydown(e: KeyboardEvent): void {
     return;
   }
 
-  // Cmd+Option+B → toggle right panel (chat) — only when actively reviewing a PR
-  if (!e.shiftKey && e.altKey && e.key.toLowerCase() === "b") {
+  // Cmd+Option+B → toggle right panel (chat) — only when actively reviewing a PR.
+  // Match on `e.code` (physical key), not `e.key`: on macOS, holding Option
+  // rewrites `e.key` to the composed glyph (Option+B → "∫"), so `e.key` never
+  // equals "b" for this combo and the shortcut would silently never fire.
+  if (!e.shiftKey && e.altKey && e.code === "KeyB") {
     const onPrPage = window.location.pathname.startsWith("/review/");
     if (!onPrPage) return;
     e.preventDefault();


### PR DESCRIPTION
Toggling the sidebar or chat panel ran at single-digit fps: the `.app-shell` `grid-template-columns` transition resized the main pane every frame, and the @pierre diff renderer's ResizeObservers relayout every visible line on each intermediate width. This removes the grid transition (and its now-dead snap machinery) so the sidebar snaps instantly, and replaces the right panel's GSAP slide choreography with a snap so it appears instantly too. It also fixes the Cmd+Option+B right-panel shortcut, which matched `e.key === "b"` but never fired because macOS rewrites `e.key` to "∫" when Option is held — now it matches `e.code === "KeyB"` (the physical key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)