### PR TITLE
feat(walkthrough): render Mermaid diagrams in walkthroughs

### DIFF
--- a/apps/desktop/src/lib.rs
+++ b/apps/desktop/src/lib.rs
@@ -1,8 +1,34 @@
 use tauri::{
+	http::{header, Response, StatusCode},
 	menu::{Menu, MenuItem, PredefinedMenuItem},
 	tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
 	AppHandle, Manager, WindowEvent,
 };
+
+const ARTIFACT_HOST_HTML: &str = include_str!("../../web/static/artifact-host.html");
+
+/// Single source of truth for the artifact-host CSP is the
+/// `<meta http-equiv="Content-Security-Policy" content="…">` tag inside
+/// artifact-host.html. We extract it from the compiled-in HTML and serve it as
+/// an HTTP header too — the header (unlike the meta tag) survives the host's
+/// `document.write`, so it is the durable enforcement. Deriving it here instead
+/// of duplicating the literal keeps the header and the meta from drifting.
+fn artifact_host_csp() -> &'static str {
+	const FALLBACK: &str = "default-src 'none'";
+	let html = ARTIFACT_HOST_HTML;
+	let Some(marker) = html.find("Content-Security-Policy") else {
+		return FALLBACK;
+	};
+	let tail = &html[marker..];
+	let Some(rel_start) = tail.find("content=\"") else {
+		return FALLBACK;
+	};
+	let start = marker + rel_start + "content=\"".len();
+	match html[start..].find('"') {
+		Some(len) => &html[start..start + len],
+		None => FALLBACK,
+	}
+}
 
 /// Show, unminimize, and focus the main window. Called from tray menu
 /// interactions, tray left-clicks, and the single-instance handler (when
@@ -18,6 +44,22 @@ fn show_main_window(app: &AppHandle) {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
 	let builder = tauri::Builder::default()
+		.register_uri_scheme_protocol("artifact", |_ctx, request| {
+			let path = request.uri().path();
+			if path == "/" || path == "/artifact-host.html" {
+				Response::builder()
+					.header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+					.header(header::CONTENT_SECURITY_POLICY, artifact_host_csp())
+					.body(ARTIFACT_HOST_HTML.as_bytes().to_vec())
+					.expect("artifact host response should be valid")
+			} else {
+				Response::builder()
+					.status(StatusCode::NOT_FOUND)
+					.header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+					.body(b"not found".to_vec())
+					.expect("artifact not-found response should be valid")
+			}
+		})
 		// Single-instance must be the first plugin registered. If a second
 		// copy of Revv is launched (e.g. the user clicks the app icon while
 		// it's already running in the tray), this fires in the existing

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -81,7 +81,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' http://localhost:45678 http://localhost:45679 ws://localhost:45678 ws://localhost:45679 ws://localhost:9223; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:"
+      "csp": "default-src 'self'; connect-src 'self' http://localhost:45678 http://localhost:45679 ws://localhost:45678 ws://localhost:45679 ws://localhost:9223; frame-src artifact: http://artifact.localhost; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:"
     }
   },
   "plugins": {

--- a/apps/server/src/ai/agent-stream/normalized-events.ts
+++ b/apps/server/src/ai/agent-stream/normalized-events.ts
@@ -210,13 +210,17 @@ export interface BuiltActivity {
  * Used by every provider that surfaces tool calls in the UI. Centralising
  * this means a future change to how we describe Bash commands or MCP tools
  * only needs to land in one place.
+ *
+ * `cwd` (the agent's working directory — the per-job git worktree) is optional:
+ * when supplied, absolute path arguments are rendered relative to it so the
+ * feed shows `apps/server/…` instead of the full `/Users/…/worktree/…` path.
  */
-export function buildActivity(rawToolName: string, input: unknown): BuiltActivity {
+export function buildActivity(rawToolName: string, input: unknown, cwd?: string): BuiltActivity {
   const toolName = normalizeToolName(rawToolName);
   return {
     activityKind: classifyTool(toolName),
     toolName,
-    summary: buildExplorationDescription(toolName, input),
+    summary: buildExplorationDescription(toolName, input, cwd),
     ...(input !== undefined ? { payload: input } : {}),
   };
 }

--- a/apps/server/src/ai/prompts/walkthrough-system.md
+++ b/apps/server/src/ai/prompts/walkthrough-system.md
@@ -159,6 +159,28 @@ When a diff introduces or modifies non-trivial logic — a new code path, a cond
 
 This is distinct from an annotation (which is a short descriptor alongside a code block). A flow explanation is a standalone markdown step that stands on its own, before or after the relevant code/diff steps, giving the reviewer the full mental model of "what happens when this runs."
 
+#### Diagrams (Mermaid)
+
+A fenced `mermaid` block inside any markdown step or annotation renders as a diagram. Use diagrams only when they beat prose for understanding the change; prose remains the narrative spine, and the diagram supplements it.
+
+- Control flow or branching → `flowchart`
+- Async or request/response sequences → `sequenceDiagram`
+- State machines or lifecycle transitions → `stateDiagram-v2`
+- Schema or entity relationships → `erDiagram`
+- "How we got here" journey chapters → `gitGraph` or `timeline` when it adds clarity
+
+Rules: keep diagrams small, use valid Mermaid syntax, show one concept per diagram, and name real functions/types/states from the diff. Do not add a diagram just to decorate an explanation.
+
+````markdown
+```mermaid
+flowchart TD
+  Start[handleRequest] --> HasToken{token present?}
+  HasToken -- no --> Reject[return 401]
+  HasToken -- yes --> LoadUser[loadUser(token)]
+  LoadUser --> Respond[return review context]
+```
+````
+
 ### Worked examples (REQUIRED for bugs and complex concepts)
 
 Whenever you explain a bug or a non-trivial concept, illustrate it with a concrete worked example — not an abstract description of what _could_ go wrong, but a specific scenario that shows it happening.

--- a/apps/server/src/ai/prompts/walkthrough-system.md
+++ b/apps/server/src/ai/prompts/walkthrough-system.md
@@ -32,8 +32,8 @@ Phase B is composed of **semantic steps** ("chapters"). Each chapter is a meanin
 
 **For each chapter you write:**
 
-1. Open the chapter AND write its first block in a single call: `add_semantic_step({ semantic_step_index, title, summary?, initial_block: { markdown | code | diff } })`. `semantic_step_index` is monotonic zero-based (0, 1, 2, …). `title` is short (~≤60 chars), names the _concept_ not a file ("Token validation changes", "Race condition in refresh flow", "Test coverage gaps"). `summary` is optional 1–2 sentences of preface. `initial_block` is REQUIRED — it lands at `step_index=0` of the chapter and has the same shape as an `add_diff_step` block (exactly one of `markdown`, `code`, `diff`). The first `add_semantic_step` call advances the pipeline from Phase A to Phase B.
-2. Continue walking through the chapter with `add_diff_step({ semantic_step_index, step_index, markdown | code | diff })` — one call per atomic block. `semantic_step_index` is the index of the chapter you just opened; `step_index` starts at **1** (because `add_semantic_step`'s `initial_block` already wrote `step_index=0`), and increments per call. Typically 1–4 additional `add_diff_step` calls per chapter, so each chapter holds 2–5 atomic blocks total.
+1. Open the chapter AND write its first block in a single call: `add_semantic_step({ semantic_step_index, title, summary?, initial_block: { markdown | code | diff | artifact } })`. `semantic_step_index` is monotonic zero-based (0, 1, 2, …). `title` is short (~≤60 chars), names the _concept_ not a file ("Token validation changes", "Race condition in refresh flow", "Test coverage gaps"). `summary` is optional 1–2 sentences of preface. `initial_block` is REQUIRED — it lands at `step_index=0` of the chapter and has the same shape as an `add_diff_step` block (exactly one of `markdown`, `code`, `diff`, `artifact`). The first `add_semantic_step` call advances the pipeline from Phase A to Phase B.
+2. Continue walking through the chapter with `add_diff_step({ semantic_step_index, step_index, markdown | code | diff | artifact })` — one call per atomic block. `semantic_step_index` is the index of the chapter you just opened; `step_index` starts at **1** (because `add_semantic_step`'s `initial_block` already wrote `step_index=0`), and increments per call. Typically 1–4 additional `add_diff_step` calls per chapter, so each chapter holds 2–5 atomic blocks total.
 
 Each `add_diff_step` persists exactly one unit:
 
@@ -41,6 +41,21 @@ Each `add_diff_step` persists exactly one unit:
   - `markdown.content` — prose narrative (headings / bullets / inline code — see formatting below).
   - `code` — source-code excerpt (`file_path`, line range, language, content, annotation, annotation_position).
   - `diff` — unified-diff hunk (`file_path`, `patch`, annotation, annotation_position).
+  - `artifact` — an interactive HTML/CSS/JS island (`html`, annotation, annotation_position) for a steppable state machine, toggleable before/after, tiny chart, or other interaction that prose/code/diff cannot express clearly.
+
+Artifacts are for the interactive piece only; keep the surrounding explanation in `markdown` blocks. Artifact `html` MUST be a single complete self-contained HTML document with inline `<style>` and `<script>`, vanilla JS only, no external network/CDN imports, and no `localStorage` or `sessionStorage` access. The document runs in a sandboxed iframe with an opaque origin, so storage APIs throw and parent DOM/cookies are inaccessible.
+
+**Styling artifacts (theme-aware by construction).** The host injects Revv's theme-aware CSS variables and a base stylesheet onto the artifact's root, and **re-applies them when the user toggles light/dark**. So **style exclusively with the injected variables — never hardcode hex colors, `rgb()`/`hsl()` literals, or font families.** A hardcoded color is the one thing that breaks: it won't flip in dark mode (the most common artifact defect). Available variables:
+
+- **Surfaces:** `--color-bg-primary`, `--color-bg-secondary`, `--color-bg-tertiary`, `--color-bg-elevated`
+- **Lines:** `--color-border`, `--color-border-subtle`
+- **Text:** `--color-text-primary`, `--color-text-secondary`, `--color-text-muted`
+- **Accent (the one accent):** `--color-accent`, `--color-accent-hover`, `--color-accent-muted`
+- **Status:** `--color-success`, `--color-warning`, `--color-danger`
+- **Type:** `--font-sans`, `--font-mono`
+- **Geometry:** `--radius-card`, `--radius-island`, `--spacing-island-half`, `--spacing-island`, `--spacing-inset`, `--spacing-island-2x`
+
+**Design language:** calm and restrained. The artifact sits inline in the walkthrough — keep its background **transparent / flush** (no outer card or border of its own). Use the accent sparingly, for the one active/primary element. Match the app's geometry via `--radius-card`/`--radius-island`. **No** gradients, glassmorphism, neon, purple "AI" styling, decorative drop shadows, or emoji. The baseline already neutralizes motion under `prefers-reduced-motion` — don't fight it. `data-theme` (`"light"`/`"dark"`) is set on `<html>` if you genuinely need a theme-conditional branch, but prefer variables that already flip.
 
 Both tools are atomic idempotent upserts: a retry of the same `add_semantic_step` (same `semantic_step_index`) or `add_diff_step` (same `(semantic_step_index, step_index)`) replays as a no-op. `add_semantic_step` atomically writes BOTH the chapter row and its `step_index=0` block in one transaction — on retry, both are upserted. Do NOT batch multiple steps into one call; the schemas reject arrays.
 

--- a/apps/server/src/ai/prompts/walkthrough.ts
+++ b/apps/server/src/ai/prompts/walkthrough.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { isAbsolute, relative } from "node:path";
 import type { RatingAxis, WalkthroughBlock } from "@revv/shared";
 import type { PrFileMeta } from "../../services/GitHub";
 import { loadSkills } from "../skills/registry";
@@ -24,22 +25,44 @@ export const WALKTHROUGH_MCP_SYSTEM_PROMPT: string =
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-export function buildExplorationDescription(toolName: string, input: unknown): string {
+/**
+ * Render a tool's path argument relative to the agent's working directory
+ * (the per-job git worktree). Agents are handed absolute worktree paths, so
+ * the raw `file_path` is a long `/Users/…/worktree/apps/server/…` string that
+ * clips in the narrow exploration feed. Relativizing against `cwd` yields the
+ * familiar repo-relative form (`apps/server/…`). Falls back to the original
+ * path when no `cwd` is supplied, the path isn't absolute (already relative,
+ * e.g. Grep's `.`), or it resolves outside the worktree (so we never surface a
+ * confusing `../../` escape).
+ */
+function toRepoRelative(p: string, cwd?: string): string {
+  if (!p || !cwd || !isAbsolute(p)) return p;
+  const rel = relative(cwd, p);
+  if (!rel || rel.startsWith("..")) return p;
+  return rel;
+}
+
+export function buildExplorationDescription(
+  toolName: string,
+  input: unknown,
+  cwd?: string,
+): string {
   const inp = input as Record<string, unknown> | null | undefined;
   const str = (k: string): string => (typeof inp?.[k] === "string" ? (inp[k] as string) : "");
+  const path = (k: string): string => toRepoRelative(str(k), cwd);
   switch (toolName) {
     case "Read":
-      return `Reading ${str("file_path") || "file"}`;
+      return `Reading ${path("file_path") || "file"}`;
     case "Grep":
-      return `Searching for '${str("pattern")}' in ${str("path") || "codebase"}`;
+      return `Searching for '${str("pattern")}' in ${path("path") || "codebase"}`;
     case "Glob":
       return `Finding files matching ${str("pattern") || "*"}`;
     case "LS":
-      return `Listing ${str("path") || "."}`;
+      return `Listing ${path("path") || "."}`;
     case "Write":
-      return `Wrote ${str("file_path") || "file"}`;
+      return `Wrote ${path("file_path") || "file"}`;
     case "Edit":
-      return `Edited ${str("file_path") || "file"}`;
+      return `Edited ${path("file_path") || "file"}`;
     case "Bash": {
       // Single-line, truncated. The first line of the command is enough
       // signal for the chat panel; full command is in the agent transcript.

--- a/apps/server/src/ai/providers/chat-edit-tools/content-handlers.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/content-handlers.ts
@@ -8,13 +8,11 @@ import { walkthroughBlocks } from "../../../db/schema/walkthrough-blocks";
 import { walkthroughIssues } from "../../../db/schema/walkthrough-issues";
 import { walkthroughSemanticSteps } from "../../../db/schema/walkthrough-semantic-steps";
 import { walkthroughs } from "../../../db/schema/walkthroughs";
+import { blockVariantCount, buildBlock, emptyBlockError } from "../walkthrough-blocks";
 import { blockIdFor, unwrapJsonWrappedString } from "../walkthrough-tools";
 import {
   assertStillComplete,
-  blockContentVariantCount,
-  buildBlock,
   decodeIssue,
-  emptyBlockContentError,
   fail,
   findIssuesReferencingBlocks,
   ok,
@@ -90,12 +88,12 @@ export const addSemanticStepEditHandler: ChatEditToolHandler<AddSemanticStepEdit
   ctx,
   input,
 ) => {
-  if (blockContentVariantCount(input.initial_block) !== 1) {
+  if (blockVariantCount(input.initial_block) !== 1) {
     return fail(
-      "Error: add_semantic_step.initial_block requires exactly one of { markdown, code, diff }.",
+      "Error: add_semantic_step.initial_block requires exactly one of { markdown, code, diff, artifact }.",
     );
   }
-  const initialBlockErr = emptyBlockContentError(input.initial_block);
+  const initialBlockErr = emptyBlockError(input.initial_block);
   if (initialBlockErr) return fail(initialBlockErr);
   const title = input.title.trim();
   if (title.length === 0) {
@@ -150,11 +148,11 @@ export const addSemanticStepEditHandler: ChatEditToolHandler<AddSemanticStepEdit
       .run();
 
     const blockId = blockIdFor(walkthroughId, input.semantic_step_index, 0);
-    const built = buildBlock(blockId, input.semantic_step_index, 0, {
-      ...(input.initial_block.markdown != null ? { markdown: input.initial_block.markdown } : {}),
-      ...(input.initial_block.code != null ? { code: input.initial_block.code } : {}),
-      ...(input.initial_block.diff != null ? { diff: input.initial_block.diff } : {}),
-    });
+    const block = buildBlock(blockId, input.semantic_step_index, 0, input.initial_block);
+    if (!block) {
+      result = fail("Internal error: add_semantic_step built an empty initial block.");
+      return;
+    }
     ctx.db
       .insert(walkthroughBlocks)
       .values({
@@ -164,8 +162,8 @@ export const addSemanticStepEditHandler: ChatEditToolHandler<AddSemanticStepEdit
         order: input.semantic_step_index * 10000,
         semanticStepIndex: input.semantic_step_index,
         stepIndex: 0,
-        type: built.type,
-        data: built.data,
+        type: block.type,
+        data: JSON.stringify(block),
         createdAt: now,
       })
       .run();
@@ -177,7 +175,7 @@ export const addSemanticStepEditHandler: ChatEditToolHandler<AddSemanticStepEdit
       title,
       summary: input.summary ?? null,
     };
-    emitBlock = built.block;
+    emitBlock = block;
   });
   if (result) return result;
   if (!emitChapter || !emitBlock) {
@@ -395,10 +393,12 @@ export const deleteSemanticStepHandler: ChatEditToolHandler<DeleteSemanticStepIn
 // ── Tool: add_block ─────────────────────────────────────────────────────────
 
 export const addBlockHandler: ChatEditToolHandler<AddBlockInput> = async (ctx, input) => {
-  if (blockContentVariantCount(input.content) !== 1) {
-    return fail("Error: add_block.content requires exactly one of { markdown, code, diff }.");
+  if (blockVariantCount(input.content) !== 1) {
+    return fail(
+      "Error: add_block.content requires exactly one of { markdown, code, diff, artifact }.",
+    );
   }
-  const emptyErr = emptyBlockContentError(input.content);
+  const emptyErr = emptyBlockError(input.content);
   if (emptyErr) return fail(emptyErr);
 
   const active = resolveActiveWalkthroughId(ctx.db, ctx.prId);
@@ -472,11 +472,11 @@ export const addBlockHandler: ChatEditToolHandler<AddBlockInput> = async (ctx, i
     }
 
     const blockId = blockIdFor(walkthroughId, input.semantic_step_index, stepIndex);
-    const built = buildBlock(blockId, input.semantic_step_index, stepIndex, {
-      ...(input.content.markdown != null ? { markdown: input.content.markdown } : {}),
-      ...(input.content.code != null ? { code: input.content.code } : {}),
-      ...(input.content.diff != null ? { diff: input.content.diff } : {}),
-    });
+    const block = buildBlock(blockId, input.semantic_step_index, stepIndex, input.content);
+    if (!block) {
+      result = fail("Internal error: add_block built an empty block.");
+      return;
+    }
     const now = new Date().toISOString();
     ctx.db
       .insert(walkthroughBlocks)
@@ -487,13 +487,13 @@ export const addBlockHandler: ChatEditToolHandler<AddBlockInput> = async (ctx, i
         order: input.semantic_step_index * 10000 + stepIndex,
         semanticStepIndex: input.semantic_step_index,
         stepIndex,
-        type: built.type,
-        data: built.data,
+        type: block.type,
+        data: JSON.stringify(block),
         createdAt: now,
       })
       .run();
     stampLastEdited(ctx.db, walkthroughId, ctx.actor);
-    emitBlock = built.block;
+    emitBlock = block;
     resolvedStepIndex = stepIndex;
   });
   if (result) return result;
@@ -506,10 +506,12 @@ export const addBlockHandler: ChatEditToolHandler<AddBlockInput> = async (ctx, i
 // ── Tool: update_block ──────────────────────────────────────────────────────
 
 export const updateBlockHandler: ChatEditToolHandler<UpdateBlockInput> = async (ctx, input) => {
-  if (blockContentVariantCount(input.content) !== 1) {
-    return fail("Error: update_block.content requires exactly one of { markdown, code, diff }.");
+  if (blockVariantCount(input.content) !== 1) {
+    return fail(
+      "Error: update_block.content requires exactly one of { markdown, code, diff, artifact }.",
+    );
   }
-  const emptyErr = emptyBlockContentError(input.content);
+  const emptyErr = emptyBlockError(input.content);
   if (emptyErr) return fail(emptyErr);
 
   const active = resolveActiveWalkthroughId(ctx.db, ctx.prId);
@@ -545,18 +547,18 @@ export const updateBlockHandler: ChatEditToolHandler<UpdateBlockInput> = async (
     }
 
     const blockId = existing.id;
-    const built = buildBlock(blockId, input.semantic_step_index, input.step_index, {
-      ...(input.content.markdown != null ? { markdown: input.content.markdown } : {}),
-      ...(input.content.code != null ? { code: input.content.code } : {}),
-      ...(input.content.diff != null ? { diff: input.content.diff } : {}),
-    });
+    const block = buildBlock(blockId, input.semantic_step_index, input.step_index, input.content);
+    if (!block) {
+      result = fail("Internal error: update_block built an empty block.");
+      return;
+    }
     ctx.db
       .update(walkthroughBlocks)
-      .set({ type: built.type, data: built.data })
+      .set({ type: block.type, data: JSON.stringify(block) })
       .where(eq(walkthroughBlocks.id, blockId))
       .run();
     stampLastEdited(ctx.db, walkthroughId, ctx.actor);
-    emitBlock = built.block;
+    emitBlock = block;
   });
   if (result) return result;
   if (!emitBlock) return fail("Internal error: update_block did not persist.");

--- a/apps/server/src/ai/providers/chat-edit-tools/content-handlers.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/content-handlers.ts
@@ -8,7 +8,7 @@ import { walkthroughBlocks } from "../../../db/schema/walkthrough-blocks";
 import { walkthroughIssues } from "../../../db/schema/walkthrough-issues";
 import { walkthroughSemanticSteps } from "../../../db/schema/walkthrough-semantic-steps";
 import { walkthroughs } from "../../../db/schema/walkthroughs";
-import { blockVariantCount, buildBlock, emptyBlockError } from "../walkthrough-blocks";
+import { blockRow, blockVariantCount, buildBlock, emptyBlockError } from "../walkthrough-blocks";
 import { blockIdFor, unwrapJsonWrappedString } from "../walkthrough-tools";
 import {
   assertStillComplete,
@@ -153,6 +153,7 @@ export const addSemanticStepEditHandler: ChatEditToolHandler<AddSemanticStepEdit
       result = fail("Internal error: add_semantic_step built an empty initial block.");
       return;
     }
+    const { type, data } = blockRow(block);
     ctx.db
       .insert(walkthroughBlocks)
       .values({
@@ -162,8 +163,8 @@ export const addSemanticStepEditHandler: ChatEditToolHandler<AddSemanticStepEdit
         order: input.semantic_step_index * 10000,
         semanticStepIndex: input.semantic_step_index,
         stepIndex: 0,
-        type: block.type,
-        data: JSON.stringify(block),
+        type,
+        data,
         createdAt: now,
       })
       .run();
@@ -477,6 +478,7 @@ export const addBlockHandler: ChatEditToolHandler<AddBlockInput> = async (ctx, i
       result = fail("Internal error: add_block built an empty block.");
       return;
     }
+    const { type, data } = blockRow(block);
     const now = new Date().toISOString();
     ctx.db
       .insert(walkthroughBlocks)
@@ -487,8 +489,8 @@ export const addBlockHandler: ChatEditToolHandler<AddBlockInput> = async (ctx, i
         order: input.semantic_step_index * 10000 + stepIndex,
         semanticStepIndex: input.semantic_step_index,
         stepIndex,
-        type: block.type,
-        data: JSON.stringify(block),
+        type,
+        data,
         createdAt: now,
       })
       .run();
@@ -554,7 +556,7 @@ export const updateBlockHandler: ChatEditToolHandler<UpdateBlockInput> = async (
     }
     ctx.db
       .update(walkthroughBlocks)
-      .set({ type: block.type, data: JSON.stringify(block) })
+      .set(blockRow(block))
       .where(eq(walkthroughBlocks.id, blockId))
       .run();
     stampLastEdited(ctx.db, walkthroughId, ctx.actor);

--- a/apps/server/src/ai/providers/chat-edit-tools/helpers.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/helpers.ts
@@ -3,9 +3,6 @@
 // Shared helper functions and types used by chat-edit tool handlers.
 
 import type {
-  CodeBlock,
-  DiffBlock,
-  MarkdownBlock,
   RatingAxis,
   RatingCitation,
   WalkthroughBlock,
@@ -18,7 +15,7 @@ import type { walkthroughBlocks } from "../../../db/schema/walkthrough-blocks";
 import { walkthroughIssues } from "../../../db/schema/walkthrough-issues";
 import type { walkthroughRatings } from "../../../db/schema/walkthrough-ratings";
 import { walkthroughs } from "../../../db/schema/walkthroughs";
-import type { BlockContentInput, ChatEditToolResult } from "./spec";
+import type { ChatEditToolResult } from "./spec";
 
 // ── Result helpers ──────────────────────────────────────────────────────────
 
@@ -82,94 +79,11 @@ export function stampLastEdited(db: Db, walkthroughId: string, actor: string): v
 }
 
 // ── Block construction ──────────────────────────────────────────────────────
-
-export function blockContentVariantCount(content: BlockContentInput): number {
-  let n = 0;
-  if (content.markdown != null) n++;
-  if (content.code != null) n++;
-  if (content.diff != null) n++;
-  return n;
-}
-
-/**
- * Reject blocks whose payload would render as an empty box. An annotation on
- * a code/diff block reads as commentary about code that isn't there — use a
- * markdown block for prose-only content instead. Mirrors `emptyBlockError`
- * in `walkthrough-tools/phase-b-handlers.ts` for the generation path.
- */
-export function emptyBlockContentError(content: BlockContentInput): string | null {
-  if (content.markdown && content.markdown.content.trim().length === 0) {
-    return "Error: markdown block requires non-empty content. Either fill it in or omit the block.";
-  }
-  if (content.code && content.code.content.trim().length === 0) {
-    return "Error: code block requires non-empty content. Use a markdown block if you only want to write prose; an annotation without code reads as commentary about nothing.";
-  }
-  if (content.diff && content.diff.patch.trim().length === 0) {
-    return "Error: diff block requires a non-empty patch. Use a markdown block for prose-only content.";
-  }
-  return null;
-}
-
-export interface BuiltBlock {
-  readonly block: WalkthroughBlock;
-  readonly type: "markdown" | "code" | "diff";
-  readonly data: string;
-}
-
-export function buildBlock(
-  blockId: string,
-  semanticStepIndex: number,
-  stepIndex: number,
-  content: BlockContentInput,
-): BuiltBlock {
-  const order = semanticStepIndex * 10000 + stepIndex;
-  if (content.markdown) {
-    const md: MarkdownBlock = {
-      type: "markdown",
-      id: blockId,
-      order,
-      phase: "diff_analysis",
-      semanticStepIndex,
-      stepIndex,
-      content: content.markdown.content,
-    };
-    return { block: md, type: "markdown", data: JSON.stringify(md) };
-  }
-  if (content.code) {
-    const code: CodeBlock = {
-      type: "code",
-      id: blockId,
-      order,
-      phase: "diff_analysis",
-      semanticStepIndex,
-      stepIndex,
-      filePath: content.code.file_path,
-      startLine: content.code.start_line,
-      endLine: content.code.end_line,
-      language: content.code.language,
-      content: content.code.content,
-      annotation: content.code.annotation,
-      annotationPosition: content.code.annotation_position,
-    };
-    return { block: code, type: "code", data: JSON.stringify(code) };
-  }
-  if (content.diff) {
-    const diff: DiffBlock = {
-      type: "diff",
-      id: blockId,
-      order,
-      phase: "diff_analysis",
-      semanticStepIndex,
-      stepIndex,
-      filePath: content.diff.file_path,
-      patch: content.diff.patch,
-      annotation: content.diff.annotation,
-      annotationPosition: content.diff.annotation_position,
-    };
-    return { block: diff, type: "diff", data: JSON.stringify(diff) };
-  }
-  throw new Error("buildBlock called with empty content variant");
-}
+//
+// The variant-count, empty/size validation, and typed-block construction are
+// shared with the generation pipeline in `../walkthrough-blocks` so the two
+// MCP write paths can never drift (CLAUDE.md #2, #13). Handlers import
+// `blockVariantCount`, `emptyBlockError`, and `buildBlock` from there directly.
 
 // ── Issue-blockIds JSON helpers ─────────────────────────────────────────────
 

--- a/apps/server/src/ai/providers/chat-edit-tools/spec.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/spec.ts
@@ -77,7 +77,7 @@ export type ChatEditToolSpecRecord = GatewayToolSpec<
 /**
  * Atomic block content variant. Same shape used by the generation pipeline's
  * `add_diff_step` / `add_semantic_step.initial_block`. Exactly one of
- * `markdown`, `code`, or `diff` must be provided.
+ * `markdown`, `code`, `diff`, or `artifact` must be provided.
  */
 export const blockContentSchema = z
   .object({
@@ -86,7 +86,7 @@ export const blockContentSchema = z
       .nullable()
       .optional()
       .describe(
-        "Use for narrative/explanatory content. Mutually exclusive with `code` and `diff`.",
+        "Use for narrative/explanatory content. Mutually exclusive with `code`, `diff`, and `artifact`.",
       ),
     code: z
       .object({
@@ -100,7 +100,9 @@ export const blockContentSchema = z
       })
       .nullable()
       .optional()
-      .describe("Use for source-code excerpts. Mutually exclusive with `markdown` and `diff`."),
+      .describe(
+        "Use for source-code excerpts. Mutually exclusive with `markdown`, `diff`, and `artifact`.",
+      ),
     diff: z
       .object({
         file_path: z.string(),
@@ -110,10 +112,27 @@ export const blockContentSchema = z
       })
       .nullable()
       .optional()
-      .describe("Use for unified-diff hunks. Mutually exclusive with `markdown` and `code`."),
+      .describe(
+        "Use for unified-diff hunks. Mutually exclusive with `markdown`, `code`, and `artifact`.",
+      ),
+    artifact: z
+      .object({
+        html: z
+          .string()
+          .describe(
+            "A complete, self-contained HTML document with inline CSS/JS. Vanilla JS only; no external network/CDN; no localStorage. Renders in a sandboxed iframe. Style with the injected Revv theme variables (`var(--color-*)`, `var(--font-*)`) so it matches the app and follows light/dark — never hardcode colors. See the system prompt for the full token list and design rules.",
+          ),
+        annotation: z.string().nullable(),
+        annotation_position: z.enum(["left", "right"]),
+      })
+      .nullable()
+      .optional()
+      .describe(
+        "Use for an interactive widget when prose/code/diff fall short. Mutually exclusive with markdown, code, and diff.",
+      ),
   })
   .describe(
-    "REQUIRED. Exactly one of { markdown, code, diff } — the same shape add_diff_step uses.",
+    "REQUIRED. Exactly one of { markdown, code, diff, artifact } — the same shape add_diff_step uses.",
   );
 
 /** Composite identifier for an existing diff block (matches walkthrough-tool-spec.ts). */
@@ -381,5 +400,3 @@ export type DeleteIssueInput = z.infer<typeof deleteIssueSchema>;
 export type AddIssueCommentEditInput = z.infer<typeof addIssueCommentEditSchema>;
 export type UpdateIssueCommentInput = z.infer<typeof updateIssueCommentSchema>;
 export type DeleteIssueCommentInput = z.infer<typeof deleteIssueCommentSchema>;
-
-export type BlockContentInput = z.infer<typeof blockContentSchema>;

--- a/apps/server/src/ai/providers/chat-mcp-tools.ts
+++ b/apps/server/src/ai/providers/chat-mcp-tools.ts
@@ -96,9 +96,14 @@ function parseBlock(row: typeof walkthroughBlocks.$inferSelect): ParsedBlock {
     case "diff":
       content = str("patch");
       break;
-    case "artifact":
-      content = str("html");
+    case "artifact": {
+      // An artifact is a full HTML document (up to 256 KB) the chat agent
+      // can't act on; surface a compact placeholder plus the human-readable
+      // annotation instead of dumping the verbatim markup into its context.
+      const note = str("annotation").trim();
+      content = note ? `[interactive artifact: ${note}]` : "[interactive artifact]";
       break;
+    }
     default:
       content = JSON.stringify(parsed);
   }

--- a/apps/server/src/ai/providers/chat-mcp-tools.ts
+++ b/apps/server/src/ai/providers/chat-mcp-tools.ts
@@ -96,6 +96,9 @@ function parseBlock(row: typeof walkthroughBlocks.$inferSelect): ParsedBlock {
     case "diff":
       content = str("patch");
       break;
+    case "artifact":
+      content = str("html");
+      break;
     default:
       content = JSON.stringify(parsed);
   }

--- a/apps/server/src/ai/providers/mcp-walkthrough-codex.ts
+++ b/apps/server/src/ai/providers/mcp-walkthrough-codex.ts
@@ -231,7 +231,10 @@ export function streamWalkthroughViaCodexMCP(
 
             if (ev.source === "builtin" && EXPLORATION_TOOLS.has(ev.toolName)) {
               transitionPhase("exploring", "Reading files and understanding changes...");
-              push({ type: "exploration", data: buildActivity(ev.toolName, ev.input) });
+              push({
+                type: "exploration",
+                data: buildActivity(ev.toolName, ev.input, params.worktreePath),
+              });
               return;
             }
 

--- a/apps/server/src/ai/providers/mcp-walkthrough-opencode.ts
+++ b/apps/server/src/ai/providers/mcp-walkthrough-opencode.ts
@@ -377,7 +377,7 @@ export function streamWalkthroughViaOpencodeMCP(
 
             if (ev.source === "builtin" && EXPLORATION_TOOLS.has(ev.toolName)) {
               transitionPhase("exploring", "Reading files and understanding changes...");
-              const activity = buildActivity(ev.toolName, ev.input);
+              const activity = buildActivity(ev.toolName, ev.input, params.worktreePath);
               push({ type: "exploration", data: activity });
               return;
             }

--- a/apps/server/src/ai/providers/mcp-walkthrough.ts
+++ b/apps/server/src/ai/providers/mcp-walkthrough.ts
@@ -361,7 +361,7 @@ export function streamWalkthroughViaMCP(
             );
             if (transition) push(transition);
           }
-          const activity = buildActivity(ev.toolName, ev.input);
+          const activity = buildActivity(ev.toolName, ev.input, params.worktreePath);
           push({ type: "exploration", data: activity });
           return;
         }

--- a/apps/server/src/ai/providers/walkthrough-blocks.ts
+++ b/apps/server/src/ai/providers/walkthrough-blocks.ts
@@ -1,0 +1,185 @@
+// ── walkthrough-blocks ───────────────────────────────────────────────────────
+//
+// Shared block-variant validation + construction for the two MCP tool surfaces
+// that write `walkthrough_blocks` rows: the generation pipeline
+// (`walkthrough-tools/phase-b-handlers.ts`) and the post-completion chat-edit
+// path (`chat-edit-tools/`). Both accept the same four-variant block-content
+// shape (markdown | code | diff | artifact) and MUST validate and build it
+// identically.
+//
+// Keeping that logic here is the concrete expression of CLAUDE.md invariant #2
+// ("tool handler implementations are always shared in-process code") and #13
+// ("agent-path parity"): the artifact size cap, the variant-exclusivity rule,
+// and the typed-block construction cannot drift between the generation path and
+// the chat-edit path because there is only one copy.
+
+import type {
+  ArtifactBlock,
+  CodeBlock,
+  DiffBlock,
+  MarkdownBlock,
+  WalkthroughBlock,
+} from "@revv/shared";
+
+/**
+ * Max serialized artifact HTML, enforced identically on both write paths. The
+ * document is persisted verbatim and later rendered in a sandboxed iframe; the
+ * cap keeps a runaway model from writing a multi-megabyte block into SQLite.
+ */
+export const MAX_ARTIFACT_HTML_BYTES = 256 * 1024;
+
+/**
+ * The four mutually-exclusive block-content variants. Structurally identical to
+ * the chat-edit `blockContentSchema` inference and the generation pipeline's
+ * `add_diff_step` / `add_semantic_step.initial_block` shapes — both decode
+ * their input straight into this type.
+ */
+export interface BlockVariantInput {
+  readonly markdown?: { readonly content: string } | null | undefined;
+  readonly code?:
+    | {
+        readonly file_path: string;
+        readonly start_line: number;
+        readonly end_line: number;
+        readonly language: string;
+        readonly content: string;
+        readonly annotation: string | null;
+        readonly annotation_position: "left" | "right";
+      }
+    | null
+    | undefined;
+  readonly diff?:
+    | {
+        readonly file_path: string;
+        readonly patch: string;
+        readonly annotation: string | null;
+        readonly annotation_position: "left" | "right";
+      }
+    | null
+    | undefined;
+  readonly artifact?:
+    | {
+        readonly html: string;
+        readonly annotation: string | null;
+        readonly annotation_position: "left" | "right";
+      }
+    | null
+    | undefined;
+}
+
+/** Count the populated variants. Both tool surfaces require exactly 1. */
+export function blockVariantCount(input: BlockVariantInput): number {
+  let n = 0;
+  if (input.markdown != null) n++;
+  if (input.code != null) n++;
+  if (input.diff != null) n++;
+  if (input.artifact != null) n++;
+  return n;
+}
+
+/**
+ * Reject blocks whose payload would render as an empty box. An annotation on a
+ * code/diff block reads as commentary *about* code that isn't there — use a
+ * markdown block for prose-only content instead. Returns a recoverable error
+ * string for the agent, or null when the content is acceptable.
+ */
+export function emptyBlockError(input: BlockVariantInput): string | null {
+  if (input.markdown && input.markdown.content.trim().length === 0) {
+    return "Error: markdown block requires non-empty content. Either fill it in or omit the block.";
+  }
+  if (input.code && input.code.content.trim().length === 0) {
+    return "Error: code block requires non-empty content. Use a markdown block if you only want to write prose; an annotation without code reads as commentary about nothing.";
+  }
+  if (input.diff && input.diff.patch.trim().length === 0) {
+    return "Error: diff block requires a non-empty patch. Use a markdown block for prose-only content.";
+  }
+  if (input.artifact) {
+    const html = input.artifact.html.trim();
+    if (html.length === 0) {
+      return "Error: artifact block requires non-empty html. Use a markdown block for prose-only content.";
+    }
+    const byteLength = new TextEncoder().encode(input.artifact.html).byteLength;
+    if (byteLength > MAX_ARTIFACT_HTML_BYTES) {
+      return `Error: artifact html is too large (${byteLength} bytes). Keep artifacts under ${MAX_ARTIFACT_HTML_BYTES} bytes.`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Construct a typed `WalkthroughBlock` from exactly one populated variant.
+ * Returns null when no variant is present — callers validate variant count
+ * with {@link blockVariantCount} and reject empty content with
+ * {@link emptyBlockError} before calling. `order` is derived deterministically
+ * from `(semanticStepIndex, stepIndex)` so the same block always sorts the same
+ * way regardless of which tool wrote it.
+ */
+export function buildBlock(
+  blockId: string,
+  semanticStepIndex: number,
+  stepIndex: number,
+  input: BlockVariantInput,
+): WalkthroughBlock | null {
+  const order = semanticStepIndex * 10000 + stepIndex;
+
+  if (input.markdown) {
+    const md: MarkdownBlock = {
+      type: "markdown",
+      id: blockId,
+      order,
+      phase: "diff_analysis",
+      semanticStepIndex,
+      stepIndex,
+      content: input.markdown.content,
+    };
+    return md;
+  }
+  if (input.code) {
+    const code: CodeBlock = {
+      type: "code",
+      id: blockId,
+      order,
+      phase: "diff_analysis",
+      semanticStepIndex,
+      stepIndex,
+      filePath: input.code.file_path,
+      startLine: input.code.start_line,
+      endLine: input.code.end_line,
+      language: input.code.language,
+      content: input.code.content,
+      annotation: input.code.annotation,
+      annotationPosition: input.code.annotation_position,
+    };
+    return code;
+  }
+  if (input.diff) {
+    const diff: DiffBlock = {
+      type: "diff",
+      id: blockId,
+      order,
+      phase: "diff_analysis",
+      semanticStepIndex,
+      stepIndex,
+      filePath: input.diff.file_path,
+      patch: input.diff.patch,
+      annotation: input.diff.annotation,
+      annotationPosition: input.diff.annotation_position,
+    };
+    return diff;
+  }
+  if (input.artifact) {
+    const artifact: ArtifactBlock = {
+      type: "artifact",
+      id: blockId,
+      order,
+      phase: "diff_analysis",
+      semanticStepIndex,
+      stepIndex,
+      html: input.artifact.html,
+      annotation: input.artifact.annotation,
+      annotationPosition: input.artifact.annotation_position,
+    };
+    return artifact;
+  }
+  return null;
+}

--- a/apps/server/src/ai/providers/walkthrough-blocks.ts
+++ b/apps/server/src/ai/providers/walkthrough-blocks.ts
@@ -183,3 +183,18 @@ export function buildBlock(
   }
   return null;
 }
+
+/**
+ * The two `walkthrough_blocks` columns derived from a built block: the variant
+ * `type` discriminator and the JSON-serialized payload written to `data`.
+ * Centralized here so no write path hand-writes `JSON.stringify(block)` — the
+ * serialization that turns a typed block into a row is this module's
+ * responsibility, the same way construction is, and must not drift between the
+ * generation and chat-edit paths (CLAUDE.md #2, #13).
+ */
+export function blockRow(block: WalkthroughBlock): {
+  type: WalkthroughBlock["type"];
+  data: string;
+} {
+  return { type: block.type, data: JSON.stringify(block) };
+}

--- a/apps/server/src/ai/providers/walkthrough-tools/phase-b-handlers.ts
+++ b/apps/server/src/ai/providers/walkthrough-tools/phase-b-handlers.ts
@@ -6,10 +6,7 @@
 // comment creation.
 
 import type {
-  CodeBlock,
   CommentThread,
-  DiffBlock,
-  MarkdownBlock,
   ThreadMessage,
   WalkthroughBlock,
   WalkthroughIssue,
@@ -24,6 +21,12 @@ import { walkthroughBlocks } from "../../../db/schema/walkthrough-blocks";
 import { walkthroughIssues } from "../../../db/schema/walkthrough-issues";
 import { walkthroughSemanticSteps } from "../../../db/schema/walkthrough-semantic-steps";
 import { walkthroughs } from "../../../db/schema/walkthroughs";
+import {
+  type BlockVariantInput,
+  blockVariantCount,
+  buildBlock,
+  emptyBlockError,
+} from "../walkthrough-blocks";
 import {
   blockIdFor,
   errorResult,
@@ -46,65 +49,17 @@ import {
 // ── Block persistence helper ─────────────────────────────────────────────────
 //
 // Shared by addSemanticStepHandler (step_index=0 initial block) and
-// addDiffStepHandler (subsequent blocks). Both construct a typed
-// WalkthroughBlock from one of three variant inputs and upsert into
-// walkthroughBlocks with the same conflict target.
-
-interface BlockVariantInput {
-  readonly markdown?: { readonly content: string } | null | undefined;
-  readonly code?:
-    | {
-        readonly file_path: string;
-        readonly start_line: number;
-        readonly end_line: number;
-        readonly language: string;
-        readonly content: string;
-        readonly annotation: string | null;
-        readonly annotation_position: "left" | "right";
-      }
-    | null
-    | undefined;
-  readonly diff?:
-    | {
-        readonly file_path: string;
-        readonly patch: string;
-        readonly annotation: string | null;
-        readonly annotation_position: "left" | "right";
-      }
-    | null
-    | undefined;
-}
-
-function blockVariantCount(input: BlockVariantInput): number {
-  let n = 0;
-  if (input.markdown != null) n++;
-  if (input.code != null) n++;
-  if (input.diff != null) n++;
-  return n;
-}
+// addDiffStepHandler (subsequent blocks). The typed-block construction and
+// variant validation live in `../walkthrough-blocks` so the generation path
+// and the chat-edit path stay byte-for-byte identical (CLAUDE.md #2, #13).
+// This wrapper adds only the generation-path concern: the idempotent upsert
+// into `walkthrough_blocks` on the composite key.
 
 /**
- * Reject blocks whose payload would render as an empty box. An annotation on
- * a code/diff block reads as commentary *about* code that isn't there — use
- * a markdown block for prose-only content instead.
- */
-function emptyBlockError(input: BlockVariantInput): string | null {
-  if (input.markdown && input.markdown.content.trim().length === 0) {
-    return "Error: markdown block requires non-empty content. Either fill it in or omit the block.";
-  }
-  if (input.code && input.code.content.trim().length === 0) {
-    return "Error: code block requires non-empty content. Use a markdown block if you only want to write prose; an annotation without code reads as commentary about nothing.";
-  }
-  if (input.diff && input.diff.patch.trim().length === 0) {
-    return "Error: diff block requires a non-empty patch. Use a markdown block for prose-only content.";
-  }
-  return null;
-}
-
-/**
- * Construct a typed WalkthroughBlock from one of the three variant inputs and
- * upsert it into walkthroughBlocks. Returns the constructed block, or null if
- * no variant was provided (caller must validate beforehand).
+ * Build a typed WalkthroughBlock from one of the four variant inputs (via the
+ * shared {@link buildBlock}) and upsert it into walkthroughBlocks. Returns the
+ * constructed block, or null if no variant was provided (caller must validate
+ * beforehand with {@link blockVariantCount}).
  */
 function persistBlockVariant(
   db: Db,
@@ -120,57 +75,9 @@ function persistBlockVariant(
 ): WalkthroughBlock | null {
   const { walkthroughId, blockId, semanticStepIndex, stepIndex, order, createdAt } = opts;
 
-  let block: WalkthroughBlock;
-  let type: string;
-
-  if (variant.markdown) {
-    const md: MarkdownBlock = {
-      type: "markdown",
-      id: blockId,
-      order,
-      phase: "diff_analysis",
-      semanticStepIndex,
-      stepIndex,
-      content: variant.markdown.content,
-    };
-    block = md;
-    type = "markdown";
-  } else if (variant.code) {
-    const code: CodeBlock = {
-      type: "code",
-      id: blockId,
-      order,
-      phase: "diff_analysis",
-      semanticStepIndex,
-      stepIndex,
-      filePath: variant.code.file_path,
-      startLine: variant.code.start_line,
-      endLine: variant.code.end_line,
-      language: variant.code.language,
-      content: variant.code.content,
-      annotation: variant.code.annotation,
-      annotationPosition: variant.code.annotation_position,
-    };
-    block = code;
-    type = "code";
-  } else if (variant.diff) {
-    const diff: DiffBlock = {
-      type: "diff",
-      id: blockId,
-      order,
-      phase: "diff_analysis",
-      semanticStepIndex,
-      stepIndex,
-      filePath: variant.diff.file_path,
-      patch: variant.diff.patch,
-      annotation: variant.diff.annotation,
-      annotationPosition: variant.diff.annotation_position,
-    };
-    block = diff;
-    type = "diff";
-  } else {
-    return null;
-  }
+  const block = buildBlock(blockId, semanticStepIndex, stepIndex, variant);
+  if (!block) return null;
+  const data = JSON.stringify(block);
 
   db.insert(walkthroughBlocks)
     .values({
@@ -180,8 +87,8 @@ function persistBlockVariant(
       order,
       semanticStepIndex,
       stepIndex,
-      type,
-      data: JSON.stringify(block),
+      type: block.type,
+      data,
       createdAt,
     })
     .onConflictDoUpdate({
@@ -191,7 +98,7 @@ function persistBlockVariant(
         walkthroughBlocks.semanticStepIndex,
         walkthroughBlocks.stepIndex,
       ],
-      set: { type, data: JSON.stringify(block) },
+      set: { type: block.type, data },
     })
     .run();
 
@@ -227,7 +134,7 @@ export const addSemanticStepHandler: WalkthroughToolHandler<AddSemanticStepInput
 
   if (blockVariantCount(input.initial_block) !== 1) {
     return errorResult(
-      "Error: add_semantic_step.initial_block requires exactly one of { markdown, code, diff } — not zero, not two. A chapter cannot be opened without its first block.",
+      "Error: add_semantic_step.initial_block requires exactly one of { markdown, code, diff, artifact } — not zero, not two. A chapter cannot be opened without its first block.",
     );
   }
   const initialBlockErr = emptyBlockError(input.initial_block);
@@ -368,10 +275,10 @@ export const addSemanticStepHandler: WalkthroughToolHandler<AddSemanticStepInput
 // semanticStepIndex, stepIndex)).
 
 export const addDiffStepHandler: WalkthroughToolHandler<AddDiffStepInput> = async (ctx, input) => {
-  // Exactly one of {markdown, code, diff} must be provided.
+  // Exactly one of {markdown, code, diff, artifact} must be provided.
   if (blockVariantCount(input) !== 1) {
     return errorResult(
-      "Error: add_diff_step requires exactly one of { markdown, code, diff } — not zero, not two. Pick the shape that matches the step's intent.",
+      "Error: add_diff_step requires exactly one of { markdown, code, diff, artifact } — not zero, not two. Pick the shape that matches the step's intent.",
     );
   }
   const emptyErr = emptyBlockError(input);
@@ -424,7 +331,7 @@ export const addDiffStepHandler: WalkthroughToolHandler<AddDiffStepInput> = asyn
         order: input.semantic_step_index * 10000 + input.step_index,
         createdAt: now,
       },
-      { markdown: input.markdown, code: input.code, diff: input.diff },
+      { markdown: input.markdown, code: input.code, diff: input.diff, artifact: input.artifact },
     );
   });
   if (result) return result;

--- a/apps/server/src/ai/providers/walkthrough-tools/phase-b-handlers.ts
+++ b/apps/server/src/ai/providers/walkthrough-tools/phase-b-handlers.ts
@@ -23,6 +23,7 @@ import { walkthroughSemanticSteps } from "../../../db/schema/walkthrough-semanti
 import { walkthroughs } from "../../../db/schema/walkthroughs";
 import {
   type BlockVariantInput,
+  blockRow,
   blockVariantCount,
   buildBlock,
   emptyBlockError,
@@ -77,7 +78,7 @@ function persistBlockVariant(
 
   const block = buildBlock(blockId, semanticStepIndex, stepIndex, variant);
   if (!block) return null;
-  const data = JSON.stringify(block);
+  const { type, data } = blockRow(block);
 
   db.insert(walkthroughBlocks)
     .values({
@@ -87,7 +88,7 @@ function persistBlockVariant(
       order,
       semanticStepIndex,
       stepIndex,
-      type: block.type,
+      type,
       data,
       createdAt,
     })
@@ -98,7 +99,7 @@ function persistBlockVariant(
         walkthroughBlocks.semanticStepIndex,
         walkthroughBlocks.stepIndex,
       ],
-      set: { type: block.type, data },
+      set: { type, data },
     })
     .run();
 

--- a/apps/server/src/ai/providers/walkthrough-tools/spec.ts
+++ b/apps/server/src/ai/providers/walkthrough-tools/spec.ts
@@ -1,4 +1,5 @@
 import type {
+  ArtifactBlock,
   CodeBlock,
   DiffBlock,
   MarkdownBlock,
@@ -133,6 +134,22 @@ const setOverviewSchema = z.object({
   risk_level: z.enum(["low", "medium", "high"]).describe("Overall risk assessment"),
 });
 
+const artifactBlockSchema = z
+  .object({
+    html: z
+      .string()
+      .describe(
+        "A complete, self-contained HTML document with inline CSS/JS. Vanilla JS only; no external network/CDN; no localStorage. Renders in a sandboxed iframe. Style with the injected Revv theme variables (`var(--color-*)`, `var(--font-*)`) so it matches the app and follows light/dark — never hardcode colors. See the system prompt for the full token list and design rules.",
+      ),
+    annotation: z.string().nullable(),
+    annotation_position: z.enum(["left", "right"]),
+  })
+  .nullable()
+  .optional()
+  .describe(
+    "Use for an interactive widget when prose/code/diff fall short. Mutually exclusive with markdown, code, and diff.",
+  );
+
 /**
  * Phase B chapter declaration — opens a chapter AND writes its first atomic
  * block in one transaction. This is the ONLY way to create a chapter. The
@@ -166,7 +183,7 @@ const semanticStepInitialBlockSchema = z
       .nullable()
       .optional()
       .describe(
-        "Use for narrative/explanatory opening content. Mutually exclusive with `code` and `diff`.",
+        "Use for narrative/explanatory opening content. Mutually exclusive with `code`, `diff`, and `artifact`.",
       ),
     code: z
       .object({
@@ -181,7 +198,7 @@ const semanticStepInitialBlockSchema = z
       .nullable()
       .optional()
       .describe(
-        "Use for source-code excerpts. Mutually exclusive with `markdown` and `diff`. Annotation REQUIRED (1–3 sentences) — code without annotation is a wall of code.",
+        "Use for source-code excerpts. Mutually exclusive with `markdown`, `diff`, and `artifact`. Annotation REQUIRED (1–3 sentences) — code without annotation is a wall of code.",
       ),
     diff: z
       .object({
@@ -193,11 +210,12 @@ const semanticStepInitialBlockSchema = z
       .nullable()
       .optional()
       .describe(
-        "Use for unified-diff hunks. Mutually exclusive with `markdown` and `code`. Annotation REQUIRED (1–3 sentences).",
+        "Use for unified-diff hunks. Mutually exclusive with `markdown`, `code`, and `artifact`. Annotation REQUIRED (1–3 sentences).",
       ),
+    artifact: artifactBlockSchema,
   })
   .describe(
-    "REQUIRED. Exactly one of { markdown, code, diff }. Becomes the chapter's step_index=0 block, written atomically with the chapter itself.",
+    "REQUIRED. Exactly one of { markdown, code, diff, artifact }. Becomes the chapter's step_index=0 block, written atomically with the chapter itself.",
   );
 
 const addSemanticStepSchema = z.object({
@@ -249,7 +267,7 @@ const addDiffStepSchema = z.object({
     .describe(
       "Monotonic zero-based index for this atomic block *within* its parent chapter. Restart at 0 in each new chapter. Required. Upsert key: a retry with the same (semantic_step_index, step_index) replaces (not duplicates) the prior row.",
     ),
-  /** One of three mutually-exclusive block shapes. Agent picks which to send. */
+  /** One of four mutually-exclusive block shapes. Agent picks which to send. */
   markdown: z
     .object({
       content: z
@@ -260,7 +278,9 @@ const addDiffStepSchema = z.object({
     })
     .nullable()
     .optional()
-    .describe("Use for narrative/explanatory content. Mutually exclusive with `code` and `diff`."),
+    .describe(
+      "Use for narrative/explanatory content. Mutually exclusive with `code`, `diff`, and `artifact`.",
+    ),
   code: z
     .object({
       file_path: z.string(),
@@ -274,7 +294,7 @@ const addDiffStepSchema = z.object({
     .nullable()
     .optional()
     .describe(
-      "Use for source-code excerpts. Mutually exclusive with `markdown` and `diff`. Annotations on issue-target blocks must be LONG (multi-paragraph).",
+      "Use for source-code excerpts. Mutually exclusive with `markdown`, `diff`, and `artifact`. Annotations on issue-target blocks must be LONG (multi-paragraph).",
     ),
   diff: z
     .object({
@@ -286,8 +306,9 @@ const addDiffStepSchema = z.object({
     .nullable()
     .optional()
     .describe(
-      "Use for unified-diff hunks. Mutually exclusive with `markdown` and `code`. Annotations on issue-target blocks must be LONG (multi-paragraph).",
+      "Use for unified-diff hunks. Mutually exclusive with `markdown`, `code`, and `artifact`. Annotations on issue-target blocks must be LONG (multi-paragraph).",
     ),
+  artifact: artifactBlockSchema,
 });
 
 /**
@@ -522,6 +543,7 @@ export async function computeAnchorThreadId(
 // Re-export the canonical types used by handlers so walkthrough-tools.ts does
 // not need separate @revv/shared imports.
 export type {
+  ArtifactBlock,
   CodeBlock,
   DiffBlock,
   MarkdownBlock,

--- a/apps/server/src/services/RemoteWalkthroughCache.ts
+++ b/apps/server/src/services/RemoteWalkthroughCache.ts
@@ -17,7 +17,7 @@
 
 import { createHash } from "node:crypto";
 import { gunzipSync, gzipSync } from "node:zlib";
-import type { WalkthroughSnapshotV1 } from "@revv/shared";
+import type { WalkthroughSnapshotV2 } from "@revv/shared";
 import {
   CACHE_METADATA_KEYS,
   CACHE_SCHEMA_VERSION,
@@ -75,7 +75,7 @@ export class RemoteWalkthroughCache extends Context.Tag("RemoteWalkthroughCache"
     readonly fetch: (
       repoFullName: string,
       headSha: string,
-    ) => Effect.Effect<Option.Option<WalkthroughSnapshotV1>>;
+    ) => Effect.Effect<Option.Option<WalkthroughSnapshotV2>>;
 
     /**
      * Build a snapshot from the local DB and upload. Fire-and-forget at
@@ -131,7 +131,7 @@ export const RemoteWalkthroughCacheLive = Layer.effect(
       fetch: (repoFullName, headSha) =>
         Effect.gen(function* () {
           const ok = yield* isDownloadEnabled();
-          if (!ok) return Option.none<WalkthroughSnapshotV1>();
+          if (!ok) return Option.none<WalkthroughSnapshotV2>();
 
           const live = yield* settings
             .getSettings()
@@ -152,7 +152,7 @@ export const RemoteWalkthroughCacheLive = Layer.effect(
               );
             }),
           );
-          if (Option.isNone(record)) return Option.none<WalkthroughSnapshotV1>();
+          if (Option.isNone(record)) return Option.none<WalkthroughSnapshotV2>();
 
           const { body, metadata } = record.value;
 
@@ -163,7 +163,7 @@ export const RemoteWalkthroughCacheLive = Layer.effect(
               "remote-cache",
               `schemaVersion mismatch key=${key} advertised=${advertisedVersion} expected=${CACHE_SCHEMA_VERSION}`,
             );
-            return Option.none<WalkthroughSnapshotV1>();
+            return Option.none<WalkthroughSnapshotV2>();
           }
 
           // contentSha256 cross-check — defensive against silent corruption.
@@ -175,7 +175,7 @@ export const RemoteWalkthroughCacheLive = Layer.effect(
                 "remote-cache",
                 `contentSha256 mismatch key=${key} advertised=${advertisedSha} actual=${actualSha}`,
               );
-              return Option.none<WalkthroughSnapshotV1>();
+              return Option.none<WalkthroughSnapshotV2>();
             }
           }
 
@@ -192,7 +192,7 @@ export const RemoteWalkthroughCacheLive = Layer.effect(
                   "remote-cache",
                   `unsigned blob in strict mode — treating as miss key=${key}`,
                 );
-                return Option.none<WalkthroughSnapshotV1>();
+                return Option.none<WalkthroughSnapshotV2>();
               }
               // permissive: log and continue
               logError("remote-cache", `unsigned blob accepted in permissive mode key=${key}`);
@@ -203,7 +203,7 @@ export const RemoteWalkthroughCacheLive = Layer.effect(
                   "remote-cache",
                   `signerHost=${signerHost} not in trusted hosts — treating as miss key=${key}`,
                 );
-                return Option.none<WalkthroughSnapshotV1>();
+                return Option.none<WalkthroughSnapshotV2>();
               }
 
               const contentSha = advertisedSha ?? createHash("sha256").update(body).digest("hex");
@@ -227,7 +227,7 @@ export const RemoteWalkthroughCacheLive = Layer.effect(
                     "remote-cache",
                     `signature verification failed in strict mode key=${key}: ${detail}`,
                   );
-                  return Option.none<WalkthroughSnapshotV1>();
+                  return Option.none<WalkthroughSnapshotV2>();
                 }
                 logError(
                   "remote-cache",
@@ -245,7 +245,7 @@ export const RemoteWalkthroughCacheLive = Layer.effect(
                       "remote-cache",
                       `signer ${signerLogin}@${signerHost} lacks write permission on ${repoFullName} — treating as miss key=${key}`,
                     );
-                    return Option.none<WalkthroughSnapshotV1>();
+                    return Option.none<WalkthroughSnapshotV2>();
                   }
                   logError(
                     "remote-cache",
@@ -261,22 +261,22 @@ export const RemoteWalkthroughCacheLive = Layer.effect(
             }
           }
 
-          let parsed: WalkthroughSnapshotV1;
+          let parsed: WalkthroughSnapshotV2;
           try {
             const decompressed = gunzipSync(body);
-            parsed = JSON.parse(decompressed.toString("utf8")) as WalkthroughSnapshotV1;
+            parsed = JSON.parse(decompressed.toString("utf8")) as WalkthroughSnapshotV2;
           } catch (cause) {
             logError(
               "remote-cache",
               `gunzip/parse failed key=${key}: ${cause instanceof Error ? cause.message : String(cause)}`,
             );
-            return Option.none<WalkthroughSnapshotV1>();
+            return Option.none<WalkthroughSnapshotV2>();
           }
 
           const v = validateSnapshot(parsed);
           if (!v.ok) {
             logError("remote-cache", `validation failed key=${key}: ${v.reason}`);
-            return Option.none<WalkthroughSnapshotV1>();
+            return Option.none<WalkthroughSnapshotV2>();
           }
 
           debug(

--- a/apps/server/src/services/WalkthroughSnapshotImporter.ts
+++ b/apps/server/src/services/WalkthroughSnapshotImporter.ts
@@ -22,7 +22,7 @@
 //   • #12 — `complete_walkthrough` validation gate. We replicate the
 //           same checks as a pre-import assertion.
 
-import type { WalkthroughSnapshotV1 } from "@revv/shared";
+import type { WalkthroughSnapshotV2 } from "@revv/shared";
 import { eq } from "drizzle-orm";
 import { Context, Effect, Layer } from "effect";
 import { walkthroughBlocks } from "../db/schema/walkthrough-blocks";
@@ -54,7 +54,7 @@ export class WalkthroughSnapshotImporter extends Context.Tag("WalkthroughSnapsho
      */
     readonly import: (params: {
       readonly walkthroughId: string;
-      readonly snapshot: WalkthroughSnapshotV1;
+      readonly snapshot: WalkthroughSnapshotV2;
     }) => Effect.Effect<void, ImportError, DbService>;
   }
 >() {}

--- a/apps/server/src/services/walkthrough-snapshot.ts
+++ b/apps/server/src/services/walkthrough-snapshot.ts
@@ -1,7 +1,7 @@
 // ─── Walkthrough snapshot exporter ──────────────────────────────────────────
 //
 // Pure (DB-only) translation between an on-disk `walkthroughs`-row family
-// and a `WalkthroughSnapshotV1`. Used by:
+// and a `WalkthroughSnapshotV2`. Used by:
 //
 //   • RemoteWalkthroughCache.push — exports the row before gzip+upload.
 //   • Tests — round-trips a generated walkthrough through
@@ -30,7 +30,7 @@ import type {
   WalkthroughSnapshotIssue,
   WalkthroughSnapshotRating,
   WalkthroughSnapshotSemanticStep,
-  WalkthroughSnapshotV1,
+  WalkthroughSnapshotV2,
   WalkthroughTokenUsage,
 } from "@revv/shared";
 import { CACHE_SCHEMA_VERSION } from "@revv/shared";
@@ -157,7 +157,7 @@ function parseProviderConfig(raw: string | null, modelUsed: string): GenerationP
 }
 
 /**
- * Build a `WalkthroughSnapshotV1` from a completed walkthrough row.
+ * Build a `WalkthroughSnapshotV2` from a completed walkthrough row.
  *
  * Pre-conditions checked by the caller (`RemoteWalkthroughCache.push`):
  *   • `status='complete'` (avoids exporting half-generated rows)
@@ -168,7 +168,7 @@ function parseProviderConfig(raw: string | null, modelUsed: string): GenerationP
  * Synchronous Drizzle reads — wrap in `Effect.try` at the call site if
  * you need an Effect-returning wrapper.
  */
-export function exportWalkthroughSnapshot(db: Db, params: ExportParams): WalkthroughSnapshotV1 {
+export function exportWalkthroughSnapshot(db: Db, params: ExportParams): WalkthroughSnapshotV2 {
   const row = db.select().from(walkthroughs).where(eq(walkthroughs.id, params.walkthroughId)).get();
   if (!row) {
     throw new ExportError(`walkthrough ${params.walkthroughId} not found`);
@@ -310,7 +310,7 @@ export function exportWalkthroughSnapshot(db: Db, params: ExportParams): Walkthr
  * `complete_walkthrough` from the MCP tool surface — same checks).
  */
 export function validateSnapshot(
-  s: WalkthroughSnapshotV1,
+  s: WalkthroughSnapshotV2,
 ): { ok: true } | { ok: false; reason: string } {
   if (s.schemaVersion !== CACHE_SCHEMA_VERSION) {
     return {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
     "dompurify": "^3.4.0",
     "gsap": "3.15.0",
     "marked": "^18.0.0",
+    "mermaid": "^11",
     "remend": "^1.3.0",
     "shiki": "^3.0.0",
     "tailwind-merge": "^3.5.0",

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -905,9 +905,10 @@ diffs-container {
   padding: 8px 0 10px;
   z-index: 10;
   pointer-events: none;
-  transition:
-    left var(--duration-instant) var(--ease-out-expo),
-    right var(--duration-instant) var(--ease-out-expo);
+  /* No left/right transition: the floating bar is pinned to the main-pane
+     bounds (getActionsFloatStyle), so tweening its inset slides it across the
+     main pane while the sidebar/right-panel toggles snap instantly. Snap it
+     too — match the instant pane toggles (see AppShell). */
 }
 .actions-float * {
   pointer-events: auto;

--- a/apps/web/src/lib/actions/mermaid.svelte.ts
+++ b/apps/web/src/lib/actions/mermaid.svelte.ts
@@ -1,0 +1,125 @@
+import type { Action } from "svelte/action";
+
+import { gsap, prefersReducedMotion, tokens } from "$lib/motion";
+import { getResolvedTheme } from "$lib/stores/theme.svelte";
+import { initMermaid, renderMermaid } from "$lib/utils/mermaid.svelte";
+
+type ResolvedTheme = "light" | "dark";
+
+const SELECTOR = ".mermaid-diagram[data-mermaid-src]";
+
+function decodeSource(encoded: string): string | null {
+  try {
+    const binary = atob(encoded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return null;
+  }
+}
+
+function showFallback(container: HTMLElement, source: string, error: string): void {
+  const note = document.createElement("div");
+  note.className = "mermaid-error";
+  note.textContent = error || "Diagram failed to render.";
+
+  const pre = document.createElement("pre");
+  pre.className = "mermaid-fallback-source";
+  const code = document.createElement("code");
+  code.textContent = source;
+  pre.appendChild(code);
+
+  container.replaceChildren(note, pre);
+}
+
+function reveal(container: HTMLElement): void {
+  if (prefersReducedMotion()) return;
+  gsap.fromTo(
+    container,
+    { autoAlpha: 0 },
+    { autoAlpha: 1, duration: tokens.quick, ease: tokens.easeOutExpo },
+  );
+}
+
+export const mermaidDiagrams: Action<HTMLElement, ResolvedTheme | undefined> = (node, theme) => {
+  let currentTheme: ResolvedTheme = theme ?? getResolvedTheme();
+  let destroyed = false;
+  let scheduled = false;
+  let rendering = false;
+  let rerunAfterRender = false;
+
+  const schedule = (): void => {
+    if (destroyed) return;
+    if (rendering) {
+      rerunAfterRender = true;
+      return;
+    }
+    if (scheduled) return;
+    scheduled = true;
+    queueMicrotask(() => {
+      scheduled = false;
+      void renderAll();
+    });
+  };
+
+  const renderAll = async (): Promise<void> => {
+    rendering = true;
+    const themeForRun = currentTheme;
+    try {
+      const containers = Array.from(node.querySelectorAll<HTMLElement>(SELECTOR));
+      const pending = containers.filter(
+        (container) => container.dataset.mermaidTheme !== themeForRun,
+      );
+      if (pending.length === 0) return;
+
+      await initMermaid(themeForRun);
+
+      for (const container of pending) {
+        if (destroyed || !node.contains(container)) return;
+        const encoded = container.dataset.mermaidSrc;
+        if (!encoded) continue;
+
+        const source = decodeSource(encoded);
+        if (source === null) {
+          showFallback(container, "", "Diagram source could not be decoded.");
+          container.dataset.mermaidTheme = themeForRun;
+          continue;
+        }
+
+        container.innerHTML = '<span class="mermaid-loading">Rendering diagram...</span>';
+
+        const result = await renderMermaid(source);
+        if (destroyed || !node.contains(container)) return;
+
+        if ("svg" in result) {
+          container.innerHTML = result.svg;
+          reveal(container);
+        } else {
+          showFallback(container, source, result.error);
+        }
+        container.dataset.mermaidTheme = themeForRun;
+      }
+    } finally {
+      rendering = false;
+      if (rerunAfterRender) {
+        rerunAfterRender = false;
+        schedule();
+      }
+    }
+  };
+
+  const observer = new MutationObserver(schedule);
+  observer.observe(node, { childList: true, subtree: true });
+  schedule();
+
+  return {
+    update(nextTheme) {
+      currentTheme = nextTheme ?? getResolvedTheme();
+      schedule();
+    },
+    destroy() {
+      destroyed = true;
+      observer.disconnect();
+    },
+  };
+};

--- a/apps/web/src/lib/components/ai/thoughts/ThoughtsReveal.svelte
+++ b/apps/web/src/lib/components/ai/thoughts/ThoughtsReveal.svelte
@@ -9,33 +9,47 @@ import {
 
 interface Props {
   open: boolean;
-  blocks: ReadonlyArray<{ id: string; html: string }>;
+  blocks?: ReadonlyArray<{ id: string; html: string }>;
+  children?: Snippet;
   triggerClass: string;
   ariaLabel: string;
   prefix?: Snippet;
+  metaLabel?: string;
 }
 
-let { open = $bindable(), blocks, triggerClass, ariaLabel, prefix }: Props = $props();
+let {
+  open = $bindable(),
+  blocks = [],
+  children,
+  triggerClass,
+  ariaLabel,
+  prefix,
+  metaLabel = "Thoughts",
+}: Props = $props();
 </script>
 
 <Collapsible bind:open>
   <CollapsibleTrigger class={triggerClass} aria-label={ariaLabel}>
     {#if prefix}{@render prefix()}{/if}
     <div class="meta">
-      <span>Thoughts</span>
+      {#if metaLabel}<span>{metaLabel}</span>{/if}
       <span class="chevron-wrap" data-state={open ? "open" : "closed"}>
         <CaretDown class="chevron" aria-hidden="true" />
       </span>
     </div>
   </CollapsibleTrigger>
   <CollapsibleContent class="thought-content">
-    <div class="thought-stream">
-      {#each blocks as block (block.id)}
-        <div class="thought-markdown-block prose prose-sm">
-          {@html block.html}
-        </div>
-      {/each}
-    </div>
+    {#if children}
+      {@render children()}
+    {:else}
+      <div class="thought-stream">
+        {#each blocks as block (block.id)}
+          <div class="thought-markdown-block prose prose-sm">
+            {@html block.html}
+          </div>
+        {/each}
+      </div>
+    {/if}
   </CollapsibleContent>
 </Collapsible>
 

--- a/apps/web/src/lib/components/ai/thoughts/index.ts
+++ b/apps/web/src/lib/components/ai/thoughts/index.ts
@@ -1,0 +1,1 @@
+export { default as ThoughtsReveal } from "./ThoughtsReveal.svelte";

--- a/apps/web/src/lib/components/layout/AppShell.svelte
+++ b/apps/web/src/lib/components/layout/AppShell.svelte
@@ -18,7 +18,6 @@ import {
   getRightPanelOpen,
   getRightPanelWidth,
   getSidebarCollapsed,
-  getSidebarPeekHovering,
   getSidebarWidth,
   RIGHT_PANEL_WIDTH_MAX,
   RIGHT_PANEL_WIDTH_MIN,
@@ -46,14 +45,6 @@ import WalkthroughActionBar from "./WalkthroughActionBar.svelte";
 let { children } = $props();
 
 const sidebarCollapsed = $derived(getSidebarCollapsed());
-// Effective collapsed state: false when the user is hovering a project
-// avatar (or the sidebar itself) so the column expands as a peek without
-// flipping the persistent toggle. Used for layout (grid columns, floating
-// action bar alignment, Sidebar contents). The TopBar toggle and the
-// resize handle stay bound to the real `sidebarCollapsed` so peek is
-// purely visual and never repositions controls.
-const sidebarPeekHovering = $derived(getSidebarPeekHovering());
-const sidebarEffectiveCollapsed = $derived(sidebarCollapsed && !sidebarPeekHovering);
 const rightPanelOpen = $derived(getRightPanelOpen());
 const paletteOpen = $derived(getPaletteOpen());
 const paletteMode = $derived(getPaletteMode());
@@ -126,7 +117,7 @@ $effect(() => {
 });
 
 const gridStyle = $derived(
-  `grid-template-columns: ${RAIL_WIDTH}px ${sidebarEffectiveCollapsed ? 0 : sidebarWidth}px 1fr ${rightPanelOpen ? rightPanelWidth : 0}px; --sidebar-width: ${sidebarWidth}px; --right-panel-width: ${rightPanelWidth}px`,
+  `grid-template-columns: ${RAIL_WIDTH}px ${sidebarCollapsed ? 0 : sidebarWidth}px 1fr ${rightPanelOpen ? rightPanelWidth : 0}px; --sidebar-width: ${sidebarWidth}px; --right-panel-width: ${rightPanelWidth}px`,
 );
 
 function onHandlePointerDown(event: PointerEvent): void {
@@ -188,7 +179,7 @@ function onRightHandleDblClick(): void {
 
 <div
 	class="app-shell"
-	class:sidebar-collapsed={sidebarEffectiveCollapsed}
+	class:sidebar-collapsed={sidebarCollapsed}
 	class:rightpanel-open={rightPanelOpen}
 	style={gridStyle}
 >
@@ -197,7 +188,7 @@ function onRightHandleDblClick(): void {
 	</aside>
 
 	<aside class="sidebar-area">
-		<Sidebar collapsed={sidebarEffectiveCollapsed} />
+		<Sidebar collapsed={sidebarCollapsed} />
 
 		{#if !sidebarCollapsed}
 			<div
@@ -261,7 +252,7 @@ function onRightHandleDblClick(): void {
 	</main>
 
 	<aside class="userbar-area">
-		<UserMenu collapsed={sidebarEffectiveCollapsed} />
+		<UserMenu collapsed={sidebarCollapsed} />
 	</aside>
 
 	<footer class="bottombar-area">

--- a/apps/web/src/lib/components/layout/Sidebar.svelte
+++ b/apps/web/src/lib/components/layout/Sidebar.svelte
@@ -22,11 +22,8 @@ import { getPrScrollPosition, setPrScrollPosition } from "$lib/stores/review.sve
 import { getPaletteOpen } from "$lib/stores/shortcuts.svelte";
 import {
   getAddRepoDialogOpen,
-  getSidebarCollapsed,
-  getSidebarPeekRepoId,
   getSidebarView,
   setAddRepoDialogOpen,
-  setSidebarPeekHovering,
   setSidebarView,
 } from "$lib/stores/sidebar.svelte";
 import {
@@ -54,27 +51,8 @@ const filesViewRepo = $derived(
 // Active project for the PR-list view header / lists. URL-driven by the
 // +layout effect — single source of truth, so the column tracks the rail
 // and deep-links resolve correctly.
-const activeRepo = $derived(getSelectedRepo());
+const displayRepo = $derived(getSelectedRepo());
 const hasRepos = $derived(getRepositories().length > 0);
-// During a rail-avatar peek, render that repo's PRs in the sidebar
-// instead of the URL-selected one — selecting (clicking) still requires
-// navigation; the hover is read-only preview. Peek-swap only applies when
-// the sidebar is collapsed (the "hover-to-reveal" affordance). When the
-// pane is already extended, the user is intentionally looking at the
-// active repo's PRs, so hovering a different avatar in the rail must not
-// swap the list out from under them.
-const peekRepoId = $derived(getSidebarPeekRepoId());
-const peekRepo = $derived(
-  peekRepoId !== null ? (getRepositories().find((r) => r.id === peekRepoId) ?? null) : null,
-);
-const sidebarCollapsed = $derived(getSidebarCollapsed());
-// "Peek active" means a peek is currently swapping the displayed repo —
-// only true while the sidebar is collapsed. When extended, hovering an
-// avatar still sets peekRepoId (the rail button can't know to suppress
-// it), but it has no display effect, so downstream scroll logic must
-// treat it as inactive.
-const peekActive = $derived(sidebarCollapsed && peekRepoId !== null);
-const displayRepo = $derived(peekActive ? (peekRepo ?? activeRepo) : activeRepo);
 
 // ── Per-PR scroll persistence (left pane) ────────────────────────────────
 //
@@ -94,30 +72,13 @@ function handlePrListScroll(): void {
     return;
   }
   if (!prListEl || !selectedPrId) return;
-  // During an active peek the visible list belongs to the peeked repo,
-  // not the selected PR's repo — saving its scroll under selectedPrId
-  // would corrupt the next restore for that PR. (A peek that is set but
-  // not swapping the display — sidebar extended — is harmless.)
-  if (peekActive) return;
   setPrScrollPosition(selectedPrId, "sidebar", prListEl.scrollTop);
 }
 
 $effect(() => {
-  // Peek and PR-restore share this effect so they don't fight each other:
-  //  - peek active → snap to top of the peeked list every time the peek
-  //    repo changes, so the user sees the head of each repo's PRs
-  //  - peek inactive → restore the selected PR's saved scrollTop
-  const swapping = peekActive;
-  const peekId = peekRepoId;
+  // Restore the selected PR's saved scrollTop whenever it changes.
   const prId = selectedPrId;
   if (!prListEl) return;
-  if (swapping) {
-    // Touch peekId so the snap-to-top fires on every peek-target change.
-    void peekId;
-    suppressNextPrListScroll = true;
-    prListEl.scrollTop = 0;
-    return;
-  }
   if (!prId) return;
   const saved = getPrScrollPosition(prId, "sidebar");
   suppressNextPrListScroll = true;
@@ -325,8 +286,6 @@ function handleKeydown(e: KeyboardEvent) {
 	class="sidebar"
 	role="none"
 	onclick={handleSidebarClick}
-	onmouseenter={() => setSidebarPeekHovering(true)}
-	onmouseleave={() => setSidebarPeekHovering(false)}
 >
 	<!-- Header — back-breadcrumb in files mode, ProjectHeader in PR-list
 	     mode. Drops to nothing when collapsed since the column is 0 wide.

--- a/apps/web/src/lib/components/recaps/RecapDetail.svelte
+++ b/apps/web/src/lib/components/recaps/RecapDetail.svelte
@@ -3,6 +3,7 @@ import type { ProjectRecap, RecapPeriod, RecapPrEntry, RecapThemeSummary } from 
 import ArrowLeft from "phosphor-svelte/lib/ArrowLeft";
 import Loader2 from "phosphor-svelte/lib/Spinner";
 import CircleAlert from "phosphor-svelte/lib/WarningCircle";
+import { ThoughtsReveal } from "$lib/components/ai/thoughts";
 import { Button } from "$lib/components/ui/button";
 import { heroMorph } from "$lib/motion";
 import type { RecapStreamEntry } from "$lib/stores/recap-stream.svelte";
@@ -11,7 +12,6 @@ import DotMatrixLoader from "./DotMatrixLoader.svelte";
 import RecapBody from "./RecapBody.svelte";
 import RecapHeroBig from "./RecapHeroBig.svelte";
 import RecapSidebar from "./RecapSidebar.svelte";
-import ThoughtsReveal from "./ThoughtsReveal.svelte";
 
 interface Props {
   recap: ProjectRecap | null;

--- a/apps/web/src/lib/components/review/RequestChanges.svelte
+++ b/apps/web/src/lib/components/review/RequestChanges.svelte
@@ -327,10 +327,10 @@ $effect(() => {
 		background: var(--color-bg-primary);
 	}
 
-	/* Both sections use the SAME viewport-anchored 6-col grid as
+	/* Both sections use the SAME main-area-anchored 6-col grid as
 	   `.walkthrough-content` (see GuidedWalkthrough.svelte for the col_1
-	   derivation — it keeps the content column stable under sidebar toggle/
-	   resize and aligns with the `.page-title-section--narrow` header above).
+	   derivation — it re-centres the content column on every sidebar/right-panel
+	   toggle and aligns with the `.page-title-section--narrow` header above).
 	   Column layout must stay byte-identical to the walkthrough grids so the
 	   title, the Request Changes panels, and the walkthrough content all
 	   land in the same horizontal band.
@@ -350,7 +350,7 @@ $effect(() => {
 	.rc-sections {
 		display: grid;
 		grid-template-columns:
-			max(24px, min(calc(100% - 50vw - 458px), calc(100% - 1312px)))
+			max(24px, min(calc(50% - 458px), calc(100% - 1312px)))
 			48px
 			820px
 			40px

--- a/apps/web/src/lib/components/sidebar/RepoAvatarButton.svelte
+++ b/apps/web/src/lib/components/sidebar/RepoAvatarButton.svelte
@@ -4,7 +4,6 @@ import LinkSimple from "phosphor-svelte/lib/LinkSimple";
 import { goto } from "$app/navigation";
 import RepoGradientAvatar from "$lib/components/shared/RepoGradientAvatar.svelte";
 import * as Tooltip from "$lib/components/ui/tooltip/index.js";
-import { setSidebarPeekHovering, setSidebarPeekRepoId } from "$lib/stores/sidebar.svelte";
 
 interface Props {
   repository: Repository;
@@ -50,13 +49,6 @@ const cloneStatusLabel = $derived.by(() => {
 			class="repo-button"
 			class:repo-button--active={isActive}
 			onclick={handleClick}
-			onmouseenter={() => {
-				setSidebarPeekRepoId(repository.id);
-				setSidebarPeekHovering(true);
-			}}
-			onmouseleave={() => {
-				setSidebarPeekHovering(false);
-			}}
 			aria-label={repository.fullName}
 			aria-current={isActive ? 'page' : undefined}
 		>

--- a/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
+++ b/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
@@ -8,6 +8,7 @@ import RefreshCw from "phosphor-svelte/lib/ArrowsClockwise";
 import CaretDown from "phosphor-svelte/lib/CaretDown";
 import AlertTriangle from "phosphor-svelte/lib/Warning";
 import { toast } from "svelte-sonner";
+import { mermaidDiagrams } from "$lib/actions/mermaid.svelte";
 import { API_BASE_URL } from "$lib/api/base-url";
 import { Shimmer } from "$lib/components/ai/shimmer";
 import { ToolActivityGroup } from "$lib/components/ai/tool";
@@ -23,6 +24,7 @@ import {
   getPendingWalkthroughBlockJump,
   jumpToDiffLine,
 } from "$lib/stores/review.svelte";
+import { getResolvedTheme } from "$lib/stores/theme.svelte";
 import {
   getBlocks,
   getCloneInProgress,
@@ -1245,7 +1247,7 @@ function handleRegenerate(): void {
 							<div class="sentiment-card-header">
 								<h3 class="sentiment-card-title">Overall Sentiment</h3>
 							</div>
-							<div class="sentiment-card-body prose prose-sm">{@html renderedSentiment}</div>
+							<div class="sentiment-card-body prose prose-sm" use:mermaidDiagrams={getResolvedTheme()}>{@html renderedSentiment}</div>
 						</div>
 					{/if}
 					{#if ratings.length > 0 || isStreaming}

--- a/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
+++ b/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
@@ -5,12 +5,12 @@ const TOOL_CALL_ROW_H = 14; // px — 10px font × 1.4 line-height
 
 import type { WalkthroughBlock, WalkthroughSemanticStep } from "@revv/shared";
 import RefreshCw from "phosphor-svelte/lib/ArrowsClockwise";
-import CaretDown from "phosphor-svelte/lib/CaretDown";
 import AlertTriangle from "phosphor-svelte/lib/Warning";
 import { toast } from "svelte-sonner";
 import { mermaidDiagrams } from "$lib/actions/mermaid.svelte";
 import { API_BASE_URL } from "$lib/api/base-url";
 import { Shimmer } from "$lib/components/ai/shimmer";
+import { ThoughtsReveal } from "$lib/components/ai/thoughts";
 import { ToolActivityGroup } from "$lib/components/ai/tool";
 import { Button } from "$lib/components/ui/button";
 import { Dotmatrix } from "$lib/components/ui/dotmatrix/index.js";
@@ -47,7 +47,6 @@ import {
   getStreamError,
   getStreamStartedAt,
   getSummary,
-  getThoughts,
   getTimeline,
   hasBlockAnimated,
   hasContainerAnimated,
@@ -86,7 +85,6 @@ const riskLevel = $derived(getRiskLevel());
 const isStreaming = $derived(getIsStreaming());
 const streamError = $derived(getStreamError());
 const explorationSteps = $derived(getExplorationSteps());
-const thoughts = $derived(getThoughts());
 const timeline = $derived(getTimeline());
 const phase = $derived(getPhase());
 const streamStartedAt = $derived(getStreamStartedAt());
@@ -477,7 +475,6 @@ const interleavedEntries = $derived.by<readonly InterleavedRenderEntry[]>(() => 
   }
   return out;
 });
-const hasThoughtText = $derived(thoughts.trim().length > 0);
 let thoughtsOpen = $state(true);
 
 const blocksWithDelay = $derived.by(() => {
@@ -485,9 +482,10 @@ const blocksWithDelay = $derived.by(() => {
   return visibleBlocks.map((block) => {
     // Pre-render annotation markdown once per block so the template can
     // emit the annotation as a sibling grid item without each re-render
-    // re-parsing markdown. Only code/diff blocks carry annotations.
+    // re-parsing markdown. Only code/diff/artifact blocks carry annotations.
     const renderedAnnotation =
-      (block.type === "code" || block.type === "diff") && block.annotation
+      (block.type === "code" || block.type === "diff" || block.type === "artifact") &&
+      block.annotation
         ? renderMarkdown(block.annotation)
         : null;
     if (hasBlockAnimated(prId, block.id)) {
@@ -1188,39 +1186,32 @@ function handleRegenerate(): void {
 			<div class="block-group">
 				<span class="block-step-dot" aria-hidden="true"></span>
 				<div class="block-wrapper block-wrapper--no-anim walkthrough-skeleton">
-					<button
-						type="button"
-						class="walkthrough-skeleton-trigger"
-						aria-label="Reviewing. Toggle streamed thoughts."
-						aria-expanded={thoughtsOpen}
-						onclick={() => { thoughtsOpen = !thoughtsOpen; }}
+					<ThoughtsReveal
+						bind:open={thoughtsOpen}
+						triggerClass="walkthrough-phase-trigger"
+						ariaLabel="Reviewing. Toggle streamed thoughts."
+						metaLabel=""
 					>
-						<Shimmer class="text-sm" aria-label="Reviewing">Reviewing...</Shimmer>
-						<span class="walkthrough-skeleton-meta">
-							<span>{hasThoughtText ? 'Thoughts' : 'Waiting for thoughts'}</span>
-							<span
-								class="walkthrough-skeleton-chevron-wrap"
-								data-state={thoughtsOpen ? 'open' : 'closed'}
-							>
-								<CaretDown class="walkthrough-skeleton-chevron" aria-hidden="true" />
-							</span>
-						</span>
-					</button>
-
-					{#if thoughtsOpen}
+						{#snippet prefix()}
+							<Shimmer class="text-sm" aria-label="Reviewing">Reviewing...</Shimmer>
+						{/snippet}
 						{#if interleavedEntries.length > 0}
 							<div class="walkthrough-activity-stack">
 								{#each interleavedEntries as entry, entryIdx (entry.id)}
 									{#if entry.kind === 'thought'}
-										<div class="walkthrough-inline-thought prose prose-sm">
-											{@html renderMarkdown(entry.text)}
+										<div class="walkthrough-activity-entry" data-kind="thought">
+											<div class="walkthrough-inline-thought prose prose-sm">
+												{@html renderMarkdown(entry.text)}
+											</div>
 										</div>
 									{:else}
-										<ToolActivityGroup
-											items={entry.items}
-											active={entryIdx === interleavedEntries.length - 1}
-											defaultOpen={false}
-										/>
+										<div class="walkthrough-activity-entry" data-kind="explorations">
+											<ToolActivityGroup
+												items={entry.items}
+												active={entryIdx === interleavedEntries.length - 1}
+												defaultOpen={false}
+											/>
+										</div>
 									{/if}
 								{/each}
 							</div>
@@ -1229,7 +1220,7 @@ function handleRegenerate(): void {
 								No streamed thoughts yet. Tool calls will appear here as they happen.
 							</p>
 						{/if}
-					{/if}
+					</ThoughtsReveal>
 				</div>
 			</div>
 		{/if}
@@ -1293,29 +1284,27 @@ function handleRegenerate(): void {
 	}
 
 	.walkthrough-content {
-		/* 6-col grid that anchors the content column to the VIEWPORT centre
-		   (not the main-area centre), so resizing or toggling the left pane
-		   doesn't shift the content horizontally. Content only moves left —
-		   and only by exactly the required distance — when the main-area
-		   has shrunk enough that rail-plus-content would overflow.
+		/* 6-col grid that centres the content column within the MAIN AREA,
+		   so the content re-centres whenever either flanking pane (sidebar
+		   or right chat panel) toggles. Both panes are real grid columns in
+		   AppShell.svelte, so opening either shrinks the main-area — and the
+		   grid container here (`.review-content`, container-type: inline-size)
+		   shrinks with it. `100%`/`50%` therefore always track the visible
+		   main-area width, which is exactly what we centre against.
 
-		   col 1 = max(24px, min(100% - 50vw - 458px, 100% - 1312px))
-		     - 100% - 50vw - 458px : the col_1 width that places the content
-		         column's centre at viewport x = 50vw. Derivation: sidebar
-		         width S = 100vw - 100% (because 100% = main-area width =
-		         V - S). Content's viewport x-centre = S + col_1 + 48 + 410;
-		         setting that to V/2 = 50vw gives col_1 = 100% - 50vw - 458.
-		         When S changes (sidebar toggle/resize), 100% and 50vw shift
-		         in lockstep so that S + col_1 + 458 stays at V/2 — content
-		         position in the viewport is stable.
+		   col 1 = max(24px, min(50% - 458px, 100% - 1312px))
+		     - 50% - 458px : the col_1 width that places the content column's
+		         centre at the main-area centre (50%). Content x-centre within
+		         the grid = col_1 + 48 + 410; setting that to 50% gives
+		         col_1 = 50% - 458. Because `%` is relative to the main-area
+		         width, this stays centred on every sidebar/right-panel toggle.
 		     - 100% - 1312px : the largest col_1 that still lets the rail end
 		         at exactly 100% - 24 (24px right gutter inside main-area).
-		         When this binds (narrow main-area), content's viewport x
-		         = S + (100% - 1312) + 458 = V - 854 — also independent of S,
-		         so toggling the sidebar still doesn't jump the content.
-		     min() picks whichever binds. They cross when V ≥ 1708 (viewport,
-		     not main-area); above, viewport-centring wins; below, rail
-		     pinning wins. Floor of 24px keeps a minimum left gutter.
+		         Binds on narrower main-areas where pure centring would push
+		         rail-plus-content past the right gutter.
+		     min() picks whichever binds. They cross at a main-area width of
+		         1708; above, centring wins; below, rail pinning wins. Floor
+		         of 24px keeps a minimum left gutter.
 		   col 2 = 48        (severity-dot gutter)
 		   col 3 = 820       (content)
 		   col 4 = 40        (content ↔ rail gap)
@@ -1327,17 +1316,10 @@ function handleRegenerate(): void {
 		   the @container rule at the bottom falls through to a stacked
 		   layout. The breakpoint is on main-area width (100%, via
 		   container-type: inline-size on .review-content) so the collapse
-		   triggers only when the sidebar has eaten enough room to matter.
-
-		   Note: the right pane (chat) is positioned absolutely on top of
-		   the main-area in AppShell.svelte (NOT a grid column), so opening
-		   it does not change `100%` and therefore does not affect any of
-		   the math here. That's by design — the user wants the right-pane
-		   toggle to leave the main-content render byte-identical, which
-		   requires not shrinking main-area. */
+		   triggers only when a flanking pane has eaten enough room to matter. */
 		display: grid;
 		grid-template-columns:
-			max(24px, min(calc(100% - 50vw - 458px), calc(100% - 1312px)))
+			max(24px, min(calc(50% - 458px), calc(100% - 1312px)))
 			48px
 			minmax(0, 820px)
 			40px
@@ -1419,7 +1401,7 @@ function handleRegenerate(): void {
 	.walkthrough-loading {
 		display: grid;
 		grid-template-columns:
-			max(24px, min(calc(100% - 50vw - 458px), calc(100% - 1312px)))
+			max(24px, min(calc(50% - 458px), calc(100% - 1312px)))
 			48px
 			minmax(0, 820px)
 			40px
@@ -1445,7 +1427,7 @@ function handleRegenerate(): void {
 	.walkthrough-stepper-header {
 		display: grid;
 		grid-template-columns:
-			max(24px, min(calc(100% - 50vw - 458px), calc(100% - 1312px)))
+			max(24px, min(calc(50% - 458px), calc(100% - 1312px)))
 			48px
 			minmax(0, 820px)
 			40px
@@ -1831,7 +1813,7 @@ function handleRegenerate(): void {
 		display: grid;
 		grid-column: 1 / -1;
 		grid-template-columns:
-			max(24px, min(calc(100% - 50vw - 458px), calc(100% - 1312px)))
+			max(24px, min(calc(50% - 458px), calc(100% - 1312px)))
 			48px
 			minmax(0, 820px)
 			40px
@@ -1966,10 +1948,10 @@ function handleRegenerate(): void {
 	.walkthrough-skeleton {
 		display: flex;
 		flex-direction: column;
-		gap: 0.5rem;
+		width: 100%;
 	}
 
-	.walkthrough-skeleton-trigger {
+	.walkthrough-phase-trigger {
 		display: flex;
 		width: 100%;
 		align-items: center;
@@ -1984,36 +1966,24 @@ function handleRegenerate(): void {
 		font: inherit;
 	}
 
-	.walkthrough-skeleton-meta {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.35rem;
-		flex-shrink: 0;
-		font-size: 0.75rem;
-		color: var(--color-text-muted);
-	}
-
-	.walkthrough-skeleton-chevron-wrap {
-		display: inline-grid;
-		place-items: center;
-		transition: transform var(--duration-snap) var(--ease-out-expo);
-	}
-
-	.walkthrough-skeleton-chevron-wrap[data-state="open"] {
-		transform: rotate(180deg);
-	}
-
-	.walkthrough-skeleton-chevron-wrap :global(.walkthrough-skeleton-chevron) {
-		width: 0.75rem;
-		height: 0.75rem;
-	}
-
 	.walkthrough-activity-stack {
 		display: flex;
 		flex-direction: column;
-		gap: 0.5rem;
-		max-width: 42rem;
+		margin-top: 0.375rem;
+		padding-left: 0.75rem;
+		border-left: 1px solid var(--color-border);
+	}
+
+	.walkthrough-activity-entry + .walkthrough-activity-entry {
+		margin-top: 0.375rem;
+	}
+
+	.walkthrough-activity-entry[data-kind="thought"] + .walkthrough-activity-entry[data-kind="explorations"] {
 		margin-top: 0.25rem;
+	}
+
+	.walkthrough-activity-entry[data-kind="explorations"] + .walkthrough-activity-entry[data-kind="thought"] {
+		margin-top: 0.875rem;
 	}
 
 	.walkthrough-thought-empty {

--- a/apps/web/src/lib/components/walkthrough/WalkthroughArtifactBlock.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughArtifactBlock.svelte
@@ -1,0 +1,335 @@
+<script lang="ts">
+import type { ArtifactBlock } from "@revv/shared";
+import { convertFileSrc } from "@tauri-apps/api/core";
+import WarningCircle from "phosphor-svelte/lib/WarningCircle";
+import { onDestroy, untrack } from "svelte";
+import { browser } from "$app/environment";
+import { gsap, tokens as motionTokens, prefersReducedMotion } from "$lib/motion";
+import { getResolvedTheme } from "$lib/stores/theme.svelte";
+import { isTauri } from "$lib/utils/platform";
+
+interface Props {
+  block: ArtifactBlock;
+}
+
+type ArtifactTheme = "light" | "dark";
+type ArtifactTokens = Record<string, string>;
+
+type HostMessage =
+  | { kind: "ready" }
+  | { kind: "mounted" }
+  | { kind: "resize"; height: number }
+  | { kind: "error"; message: string };
+
+let { block }: Props = $props();
+
+let iframeEl = $state<HTMLIFrameElement | null>(null);
+let frameReady = $state(false);
+let status = $state<"loading" | "ready" | "error">("loading");
+let errorMessage = $state<string | null>(null);
+let iframeHeight = $state(240);
+// The HTML currently rendered inside the live host document, and a key that
+// forces a fresh iframe when it must be re-rendered. The host injects content
+// via `document.write`, which tears down the host's own message listener — so
+// a second `mount` postMessage is silently dropped. To re-render (a chat-edit
+// changing `block.html`) we recreate the iframe via `{#key reloadKey}` so a
+// fresh host document, with a live listener, receives the new HTML.
+let mountedHtml = $state<string | null>(null);
+let reloadKey = $state(0);
+let shellEl: HTMLDivElement | null = null;
+
+// If the host never reports `mounted` (a dropped postMessage, a webview that
+// swallowed the rAF), reveal the frame anyway after this long rather than
+// leaving the user staring at "Rendering…" forever — the artifact HTML was
+// already injected by `mount`; only the height/reveal handshake is missing.
+const MOUNT_TIMEOUT_MS = 4000;
+let mountWatchdog: ReturnType<typeof setTimeout> | null = null;
+
+const hostUrl = $derived.by(() => {
+  if (!browser) return "about:blank";
+  if (!isTauri()) return "/artifact-host.html";
+  // Tauri addresses custom URI schemes differently per platform: macOS/iOS use
+  // the real `artifact://localhost/...` scheme, while Windows (WebView2) and
+  // Linux (WebKitGTK) expose it at `http://artifact.localhost/...`. Both forms
+  // are allow-listed in tauri.conf.json → frame-src. Let Tauri pick the right
+  // one via `convertFileSrc` (it reads the OS at runtime) rather than sniffing
+  // `window.location.protocol`: in dev the frontend is served from the Vite
+  // dev server, so the protocol is `http:` even inside the macOS app — the old
+  // check then wrongly chose the `http://artifact.localhost` form, which macOS
+  // WKWebView can't resolve, so the iframe never loaded and stuck on "Rendering".
+  return convertFileSrc("artifact-host.html", "artifact");
+});
+
+function collectThemeTokens(): ArtifactTokens {
+  if (!browser) return {};
+  const styles = getComputedStyle(document.documentElement);
+  const names = [
+    // Surfaces
+    "--color-bg-primary",
+    "--color-bg-secondary",
+    "--color-bg-tertiary",
+    "--color-bg-elevated",
+    // Lines
+    "--color-border",
+    "--color-border-subtle",
+    // Text
+    "--color-text-primary",
+    "--color-text-secondary",
+    "--color-text-muted",
+    // Accent (the one accent — no AI violet)
+    "--color-accent",
+    "--color-accent-hover",
+    "--color-accent-muted",
+    // Status
+    "--color-success",
+    "--color-warning",
+    "--color-danger",
+    // Type
+    "--font-sans",
+    "--font-mono",
+    // Geometry (static, injected so artifacts match app metrics)
+    "--radius-card",
+    "--radius-island",
+    "--spacing-island-half",
+    "--spacing-island",
+    "--spacing-inset",
+    "--spacing-island-2x",
+  ];
+  return Object.fromEntries(names.map((name) => [name, styles.getPropertyValue(name).trim()]));
+}
+
+function postMount(html: string): void {
+  const target = iframeEl?.contentWindow;
+  if (!target) return;
+  const theme = getResolvedTheme();
+  target.postMessage(
+    {
+      kind: "mount",
+      html,
+      theme,
+      tokens: collectThemeTokens(),
+    },
+    "*",
+  );
+}
+
+function postTheme(theme: ArtifactTheme): void {
+  const target = iframeEl?.contentWindow;
+  if (!target) return;
+  target.postMessage({ kind: "theme", theme, tokens: collectThemeTokens() }, "*");
+}
+
+function isHostMessage(value: unknown): value is HostMessage {
+  if (typeof value !== "object" || value === null || !("kind" in value)) return false;
+  const kind = value.kind;
+  if (kind === "ready" || kind === "mounted") return true;
+  if (kind === "resize") return "height" in value && typeof value.height === "number";
+  if (kind === "error") return "message" in value && typeof value.message === "string";
+  return false;
+}
+
+function reveal(): void {
+  if (!shellEl || prefersReducedMotion()) return;
+  gsap.fromTo(
+    shellEl,
+    { autoAlpha: 0 },
+    { autoAlpha: 1, duration: motionTokens.quick, ease: motionTokens.easeOutExpo },
+  );
+}
+
+/**
+ * Inject the current HTML into the host. Idempotent: re-running with the
+ * same HTML is a no-op, so it's safe to call from both the iframe `load`
+ * event and the host's `ready` message — whichever wins mounts, the other
+ * is skipped.
+ *
+ * Driving the mount off `load` (not solely the one-shot `ready` postMessage)
+ * removes two races: the host can post `ready` before Svelte's `bind:this`
+ * has assigned `iframeEl` (so `onHostMessage` drops it as `event.source`
+ * mismatches), and a synchronously-served host document (Tauri's custom
+ * `artifact://` scheme) can fire before the listener is even attached. By
+ * `load`, the host's inline script — including its `mount` listener — has
+ * always run, so the post is guaranteed to land.
+ */
+function mountIntoFrame(): void {
+  if (!iframeEl?.contentWindow) return;
+  if (mountedHtml === block.html) return;
+  frameReady = true;
+  status = "loading";
+  errorMessage = null;
+  postMount(block.html);
+  mountedHtml = block.html;
+  if (mountWatchdog) clearTimeout(mountWatchdog);
+  mountWatchdog = setTimeout(() => {
+    if (status === "loading") {
+      status = "ready";
+      reveal();
+    }
+  }, MOUNT_TIMEOUT_MS);
+}
+
+function onHostMessage(event: MessageEvent): void {
+  const source = iframeEl?.contentWindow;
+  if (!source || event.source !== source) return;
+  if (!isHostMessage(event.data)) return;
+
+  if (event.data.kind === "ready") {
+    // Backup path: the iframe `load` handler is the primary mount trigger,
+    // but if `ready` arrives first (and `iframeEl` is bound), mount now.
+    mountIntoFrame();
+    return;
+  }
+
+  if (event.data.kind === "mounted") {
+    if (mountWatchdog) {
+      clearTimeout(mountWatchdog);
+      mountWatchdog = null;
+    }
+    status = "ready";
+    reveal();
+    return;
+  }
+
+  if (event.data.kind === "resize") {
+    iframeHeight = Math.min(Math.max(Math.ceil(event.data.height), 160), 1600);
+    return;
+  }
+
+  if (mountWatchdog) {
+    clearTimeout(mountWatchdog);
+    mountWatchdog = null;
+  }
+  status = "error";
+  errorMessage = event.data.message || "Artifact failed to render.";
+}
+
+$effect(() => {
+  const html = block.html;
+  // Initial mount is driven by the iframe `load` handler; this effect only
+  // handles a later change to `block.html` (e.g. a chat-edit). Because the host
+  // can't receive a second `mount`, recreate the iframe so a fresh host
+  // re-mounts.
+  if (mountedHtml === null) return; // not mounted yet — `load`/`ready` will mount it
+  if (html === mountedHtml) return; // unchanged
+  untrack(() => {
+    if (mountWatchdog) {
+      clearTimeout(mountWatchdog);
+      mountWatchdog = null;
+    }
+    frameReady = false;
+    status = "loading";
+    errorMessage = null;
+    mountedHtml = null;
+    reloadKey++;
+  });
+});
+
+$effect(() => {
+  const theme = getResolvedTheme();
+  if (!frameReady) return;
+  postTheme(theme);
+});
+
+onDestroy(() => {
+  if (mountWatchdog) clearTimeout(mountWatchdog);
+});
+</script>
+
+<svelte:window onmessage={onHostMessage} />
+
+<div class="artifact-block" bind:this={shellEl}>
+  {#if status === "loading"}
+    <div class="artifact-placeholder">Rendering...</div>
+  {/if}
+
+  {#if status === "error"}
+    <div class="artifact-fallback">
+      <div class="artifact-error">
+        <WarningCircle size={16} weight="fill" />
+        <span>{errorMessage ?? "Artifact failed to render."}</span>
+      </div>
+      <pre class="artifact-source"><code>{block.html}</code></pre>
+    </div>
+  {:else}
+    {#key reloadKey}
+      <iframe
+        bind:this={iframeEl}
+        class="artifact-frame"
+        class:artifact-frame--ready={status === "ready"}
+        src={hostUrl}
+        title="Interactive walkthrough artifact"
+        sandbox="allow-scripts"
+        style:height={`${iframeHeight}px`}
+        onload={mountIntoFrame}
+      ></iframe>
+    {/key}
+  {/if}
+</div>
+
+<style>
+  .artifact-block {
+    position: relative;
+    overflow: clip;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    background: var(--color-bg-primary);
+  }
+
+  .artifact-placeholder {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    display: grid;
+    place-items: center;
+    min-height: 160px;
+    padding: 18px;
+    background: color-mix(in srgb, var(--color-bg-secondary) 72%, transparent);
+    color: var(--color-text-muted);
+    font-size: 13px;
+  }
+
+  .artifact-frame {
+    display: block;
+    width: 100%;
+    min-height: 160px;
+    border: 0;
+    opacity: 0;
+    background: var(--color-bg-primary);
+  }
+
+  .artifact-frame--ready {
+    opacity: 1;
+  }
+
+  .artifact-fallback {
+    display: grid;
+    gap: 12px;
+    padding: 14px;
+    background: var(--color-bg-secondary);
+  }
+
+  .artifact-error {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--color-danger);
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  .artifact-source {
+    max-height: 360px;
+    margin: 0;
+    overflow: auto;
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: var(--color-bg-primary);
+    padding: 12px;
+    color: var(--color-text-secondary);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    line-height: 1.55;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+</style>

--- a/apps/web/src/lib/components/walkthrough/WalkthroughCodeBlock.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughCodeBlock.svelte
@@ -2,7 +2,9 @@
 import { DIFFS_TAG_NAME, type FileOptions, File as PierreFile } from "@pierre/diffs";
 import { type CodeBlock, PIERRE_THEME } from "@revv/shared";
 import ArrowUpRight from "phosphor-svelte/lib/ArrowUpRight";
+import { mermaidDiagrams } from "$lib/actions/mermaid.svelte";
 import { jumpToDiffLine } from "$lib/stores/review.svelte";
+import { getResolvedTheme } from "$lib/stores/theme.svelte";
 import { renderMarkdown } from "$lib/utils/markdown";
 import { workerManager } from "$lib/utils/worker-pool";
 
@@ -60,7 +62,7 @@ function mountCodeBlock(el: HTMLDivElement) {
 <div class="annotated-block" class:annotated-block--no-annotation={!block.annotation || hideAnnotation}>
 	{#if !hideAnnotation && block.annotation && block.annotationPosition === 'left'}
 		<div class="annotation annotation--left">
-			<div class="annotation-content prose prose-sm">
+			<div class="annotation-content prose prose-sm" use:mermaidDiagrams={getResolvedTheme()}>
 				{@html renderedAnnotation}
 			</div>
 		</div>
@@ -79,7 +81,7 @@ function mountCodeBlock(el: HTMLDivElement) {
 
 	{#if !hideAnnotation && block.annotation && block.annotationPosition === 'right'}
 		<div class="annotation annotation--right">
-			<div class="annotation-content prose prose-sm">
+			<div class="annotation-content prose prose-sm" use:mermaidDiagrams={getResolvedTheme()}>
 				{@html renderedAnnotation}
 			</div>
 		</div>

--- a/apps/web/src/lib/components/walkthrough/WalkthroughDiffBlock.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughDiffBlock.svelte
@@ -2,8 +2,10 @@
 import { DIFFS_TAG_NAME, FileDiff, type FileDiffOptions, parsePatchFiles } from "@pierre/diffs";
 import { buildGitPatchHeader, type DiffBlock, PIERRE_THEME } from "@revv/shared";
 import ArrowUpRight from "phosphor-svelte/lib/ArrowUpRight";
+import { mermaidDiagrams } from "$lib/actions/mermaid.svelte";
 import FileBadge from "$lib/components/ui/FileBadge.svelte";
 import { jumpToDiffLine } from "$lib/stores/review.svelte";
+import { getResolvedTheme } from "$lib/stores/theme.svelte";
 import { renderMarkdown } from "$lib/utils/markdown";
 import { workerManager } from "$lib/utils/worker-pool";
 
@@ -79,7 +81,7 @@ function mountDiffBlock(el: HTMLDivElement) {
 <div class="annotated-block" class:annotated-block--no-annotation={!block.annotation || hideAnnotation}>
 	{#if !hideAnnotation && block.annotation && block.annotationPosition === 'left'}
 		<div class="annotation annotation--left">
-			<div class="annotation-content prose prose-sm">
+			<div class="annotation-content prose prose-sm" use:mermaidDiagrams={getResolvedTheme()}>
 				{@html renderedAnnotation}
 			</div>
 		</div>
@@ -97,7 +99,7 @@ function mountDiffBlock(el: HTMLDivElement) {
 
 	{#if !hideAnnotation && block.annotation && block.annotationPosition === 'right'}
 		<div class="annotation annotation--right">
-			<div class="annotation-content prose prose-sm">
+			<div class="annotation-content prose prose-sm" use:mermaidDiagrams={getResolvedTheme()}>
 				{@html renderedAnnotation}
 			</div>
 		</div>

--- a/apps/web/src/lib/components/walkthrough/WalkthroughMarkdownBlock.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughMarkdownBlock.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { mermaidDiagrams } from "$lib/actions/mermaid.svelte";
+import { getResolvedTheme } from "$lib/stores/theme.svelte";
 import { isHighlighterReady } from "$lib/utils/code-highlight.svelte";
 import { renderMarkdown } from "$lib/utils/markdown";
 
@@ -19,7 +21,7 @@ const renderedContent = $derived.by(() => {
 <div class="markdown-block">
 	<!-- Markdown styling comes from the app-wide themed @tailwindcss/typography
 	     prose layer (see app.css). -->
-	<div class="prose prose-sm">
+	<div class="prose prose-sm" use:mermaidDiagrams={getResolvedTheme()}>
 		{@html renderedContent}
 	</div>
 </div>

--- a/apps/web/src/lib/components/walkthrough/WalkthroughSection.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughSection.svelte
@@ -4,6 +4,7 @@ import ChevronDown from "phosphor-svelte/lib/CaretDown";
 import { mermaidDiagrams } from "$lib/actions/mermaid.svelte";
 import { getResolvedTheme } from "$lib/stores/theme.svelte";
 import { renderMarkdown } from "$lib/utils/markdown";
+import WalkthroughArtifactBlock from "./WalkthroughArtifactBlock.svelte";
 import WalkthroughCodeBlock from "./WalkthroughCodeBlock.svelte";
 import WalkthroughDiffBlock from "./WalkthroughDiffBlock.svelte";
 import WalkthroughMarkdownBlock from "./WalkthroughMarkdownBlock.svelte";
@@ -157,6 +158,8 @@ $effect(() => {
 							<WalkthroughCodeBlock {block} hideAnnotation />
 						{:else if block.type === 'diff'}
 							<WalkthroughDiffBlock {block} hideAnnotation />
+						{:else if block.type === 'artifact'}
+							<WalkthroughArtifactBlock {block} />
 						{/if}
 					</div>
 

--- a/apps/web/src/lib/components/walkthrough/WalkthroughSection.svelte
+++ b/apps/web/src/lib/components/walkthrough/WalkthroughSection.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import type { WalkthroughBlock, WalkthroughSemanticStep } from "@revv/shared";
 import ChevronDown from "phosphor-svelte/lib/CaretDown";
+import { mermaidDiagrams } from "$lib/actions/mermaid.svelte";
+import { getResolvedTheme } from "$lib/stores/theme.svelte";
 import { renderMarkdown } from "$lib/utils/markdown";
 import WalkthroughCodeBlock from "./WalkthroughCodeBlock.svelte";
 import WalkthroughDiffBlock from "./WalkthroughDiffBlock.svelte";
@@ -117,7 +119,7 @@ $effect(() => {
 			<h3 class="section-title">{section.title}</h3>
 		</div>
 		{#if renderedSummary}
-			<div class="section-summary prose prose-sm prose-dense">{@html renderedSummary}</div>
+			<div class="section-summary prose prose-sm prose-dense" use:mermaidDiagrams={getResolvedTheme()}>{@html renderedSummary}</div>
 		{/if}
 	</button>
 
@@ -165,7 +167,7 @@ $effect(() => {
 							style:--enter-delay="{delay}ms"
 							aria-label="Annotation"
 						>
-							<div class="block-annotation-inner prose prose-sm">
+							<div class="block-annotation-inner prose prose-sm" use:mermaidDiagrams={getResolvedTheme()}>
 								{@html renderedAnnotation}
 							</div>
 						</aside>

--- a/apps/web/src/lib/components/walkthrough/ratings-panel/RatingExpandedBody.svelte
+++ b/apps/web/src/lib/components/walkthrough/ratings-panel/RatingExpandedBody.svelte
@@ -2,9 +2,11 @@
 import type { Confidence, Verdict, WalkthroughBlock, WalkthroughRating } from "@revv/shared";
 import { RATING_AXIS_LABELS } from "@revv/shared";
 import ArrowUpRight from "phosphor-svelte/lib/ArrowUpRight";
+import { mermaidDiagrams } from "$lib/actions/mermaid.svelte";
 import FileBadge from "$lib/components/ui/FileBadge.svelte";
 import * as Tooltip from "$lib/components/ui/tooltip";
 import { jumpToDiffLine } from "$lib/stores/review.svelte";
+import { getResolvedTheme } from "$lib/stores/theme.svelte";
 import { renderMarkdown } from "$lib/utils/markdown";
 
 interface Props {
@@ -114,7 +116,7 @@ function handleJumpToDiff(filePath: string, line: number): void {
     </div>
 
     <div class="rationale">
-        <div class="rationale-text prose prose-sm prose-dense">{@html rationaleHtml}</div>
+        <div class="rationale-text prose prose-sm prose-dense" use:mermaidDiagrams={getResolvedTheme()}>{@html rationaleHtml}</div>
     </div>
 
     {#if detailsHtml}
@@ -122,7 +124,7 @@ function handleJumpToDiff(filePath: string, line: number): void {
             <span class="section-divider-label">details</span>
         </div>
         {#await detailsHtml then html}
-            <div class="rating-details prose prose-sm prose-dense">{@html html}</div>
+            <div class="rating-details prose prose-sm prose-dense" use:mermaidDiagrams={getResolvedTheme()}>{@html html}</div>
         {/await}
     {/if}
 

--- a/apps/web/src/lib/stores/sidebar.svelte.ts
+++ b/apps/web/src/lib/stores/sidebar.svelte.ts
@@ -64,20 +64,6 @@ let rightPanelWidth = $state(loadPersistedRightPanelWidth());
 // expand/collapse pattern survives reloads.
 let collapsedOwners = $state<Set<string>>(loadCollapsedOwners());
 
-// Transient "peek" state: true while the cursor is over a project avatar in
-// the rail or anywhere inside the sidebar. Used to reveal the sidebar while
-// `sidebarCollapsed` is true without changing the persistent toggle. A short
-// close delay covers the gap when the cursor transits between the avatar
-// and the sidebar, or between two avatars.
-//
-// `sidebarPeekRepoId` tracks which repo is currently being previewed — set
-// by the avatar's mouseenter and held across transit into the sidebar so
-// the panel shows that repo's PRs (not the URL-selected one) until the
-// peek closes.
-let sidebarPeekHovering = $state(false);
-let sidebarPeekRepoId = $state<string | null>(null);
-let peekCloseTimer: ReturnType<typeof setTimeout> | undefined;
-
 // Two-view drawer: 'prs' (the PR list) ⇄ 'files' (full repo tree at the
 // selected PR's head SHA). Transient — not persisted across reloads. Resets to
 // 'prs' when the URL leaves a /review/[prId] route (see +layout.svelte).
@@ -119,36 +105,6 @@ export function getSidebarCollapsed(): boolean {
 
 export function toggleSidebar(): void {
   sidebarCollapsed = !sidebarCollapsed;
-}
-
-// ── Sidebar peek (hover-to-reveal) ──────────────────────
-
-export function getSidebarPeekHovering(): boolean {
-  return sidebarPeekHovering;
-}
-
-export function setSidebarPeekHovering(v: boolean): void {
-  if (peekCloseTimer !== undefined) {
-    clearTimeout(peekCloseTimer);
-    peekCloseTimer = undefined;
-  }
-  if (v) {
-    sidebarPeekHovering = true;
-  } else {
-    peekCloseTimer = setTimeout(() => {
-      sidebarPeekHovering = false;
-      sidebarPeekRepoId = null;
-      peekCloseTimer = undefined;
-    }, 200);
-  }
-}
-
-export function getSidebarPeekRepoId(): string | null {
-  return sidebarPeekRepoId;
-}
-
-export function setSidebarPeekRepoId(id: string | null): void {
-  sidebarPeekRepoId = id;
 }
 
 // ── Sidebar width ────────────────────────────────────────
@@ -259,9 +215,8 @@ export function toggleOwnerCollapsed(owner: string): void {
     (e.g. pill tabs) should use to stay aligned with the visible main area.
     Mirrors the grid math in AppShell.svelte. */
 export function getMainAreaBounds(): { left: number; right: number } {
-  const effectiveCollapsed = sidebarCollapsed && !sidebarPeekHovering;
   return {
-    left: RAIL_WIDTH + (effectiveCollapsed ? 0 : sidebarWidth),
+    left: RAIL_WIDTH + (sidebarCollapsed ? 0 : sidebarWidth),
     right: rightPanelOpen ? rightPanelWidth : 0,
   };
 }

--- a/apps/web/src/lib/stores/theme.svelte.ts
+++ b/apps/web/src/lib/stores/theme.svelte.ts
@@ -78,6 +78,10 @@ export function getThemePreference(): ThemePreference {
   return preference;
 }
 
+export function getResolvedTheme(): "light" | "dark" {
+  return _resolved;
+}
+
 export function setThemePreference(pref: ThemePreference): void {
   preference = pref;
   localStorage.setItem(THEME_KEY, pref);

--- a/apps/web/src/lib/stores/walkthrough.svelte.ts
+++ b/apps/web/src/lib/stores/walkthrough.svelte.ts
@@ -66,13 +66,10 @@ export interface WalkthroughEntry {
   superseded: boolean;
   explorationSteps: Activity[];
   /**
-   * Streamed model reasoning text concatenated in arrival order. Drives the
-   * thoughts toggle UI alongside `timeline`. Ephemeral — not persisted.
-   */
-  thoughts: string;
-  /**
    * Chronological mix of thoughts and exploration tool calls for the live
-   * "Reviewing…" feed. See `WalkthroughTimelineEntry`. Ephemeral.
+   * "Reviewing…" feed. See `WalkthroughTimelineEntry`. Ephemeral. The thoughts
+   * toggle UI renders from this directly — there is no separate concatenated
+   * thoughts string.
    */
   timeline: WalkthroughTimelineEntry[];
   issues: WalkthroughIssue[];
@@ -143,7 +140,6 @@ export function freshEntry(): WalkthroughEntry {
     doneReceived: false,
     superseded: false,
     explorationSteps: [],
-    thoughts: "",
     timeline: [],
     issues: [],
     ratings: [],
@@ -480,7 +476,6 @@ export function applyEvents(prId: string, events: WalkthroughStreamEvent[]): voi
               },
             ];
           }
-          entry.thoughts = entry.thoughts + event.data.text;
           break;
         }
         case "issue": {

--- a/apps/web/src/lib/stores/walkthrough.svelte.ts
+++ b/apps/web/src/lib/stores/walkthrough.svelte.ts
@@ -264,9 +264,6 @@ export function getStreamError(): string | null {
 export function getExplorationSteps(): Activity[] {
   return _active?.explorationSteps ?? [];
 }
-export function getThoughts(): string {
-  return _active?.thoughts ?? "";
-}
 export function getTimeline(): WalkthroughTimelineEntry[] {
   return _active?.timeline ?? [];
 }
@@ -886,7 +883,14 @@ async function doHydrateFromCache(
     );
 
     const previous = store.entries.get(prId);
-    const entry = previous ?? freshEntry();
+    // Clone (don't reuse `previous`): `setEntry` writes into a SvelteMap, whose
+    // `set` only fires reactivity when the stored *reference* changes
+    // (`prev_res !== value`). Mutating `previous` in place and re-setting the
+    // same object would land the data in the map but never notify subscribers —
+    // the UI stays on the pre-hydration empty state until a remount reads the
+    // entry fresh (the "reload shows nothing, but switching PRs and back fixes
+    // it" bug). A fresh object guarantees the write is observed.
+    const entry: WalkthroughEntry = previous ? { ...previous } : freshEntry();
     const hasRealSummary = wt.summary !== "";
 
     // Entry-wins merge: SSE events applied to `entry` during the REST fetch

--- a/apps/web/src/lib/styles/prose.css
+++ b/apps/web/src/lib/styles/prose.css
@@ -196,6 +196,56 @@
 }
 
 /* ──────────────────────────────────────────────────────────
+   Mermaid diagrams — placeholders are emitted by the markdown renderer and
+   replaced client-side after the lazy Mermaid bundle renders SVG.
+   ────────────────────────────────────────────────────────── */
+.mermaid-diagram {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+  margin: 0 0 var(--spacing-inset);
+  padding: var(--spacing-inset);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-card);
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+}
+
+.mermaid-diagram:last-child {
+  margin-bottom: 0;
+}
+
+.mermaid-diagram svg {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0 auto;
+}
+
+.mermaid-loading,
+.mermaid-error {
+  display: block;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--color-text-muted);
+}
+
+.mermaid-error {
+  color: var(--color-danger);
+  margin-bottom: var(--spacing-island);
+}
+
+.mermaid-fallback-source {
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--color-text-primary);
+}
+
+/* ──────────────────────────────────────────────────────────
    Prose link styles — the single authority for link appearance
    across every markdown-rendering surface (recap, walkthrough,
    chat, review). Components no longer declare their own

--- a/apps/web/src/lib/utils/markdown.ts
+++ b/apps/web/src/lib/utils/markdown.ts
@@ -25,6 +25,9 @@ marked.use({
   },
   renderer: {
     code({ text, lang }) {
+      if (isMermaidLang(lang)) {
+        return `<div class="mermaid-diagram not-prose" data-mermaid-src="${encodeBase64(text)}"><span class="mermaid-loading">Rendering diagram...</span></div>`;
+      }
       if (lang) {
         const highlighted = highlightCode(text, lang);
         if (highlighted) return highlighted;
@@ -35,6 +38,31 @@ marked.use({
     },
   },
 });
+
+function isMermaidLang(lang: string | undefined): boolean {
+  const normalized = lang?.trim().toLowerCase();
+  return normalized === "mermaid" || normalized === "mmd";
+}
+
+function encodeBase64(source: string): string {
+  const bytes = new TextEncoder().encode(source);
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  let out = "";
+
+  for (let i = 0; i < bytes.length; i += 3) {
+    const first = bytes[i] ?? 0;
+    const second = bytes[i + 1] ?? 0;
+    const third = bytes[i + 2] ?? 0;
+    const triplet = (first << 16) | (second << 8) | third;
+
+    out += alphabet[(triplet >> 18) & 63] ?? "";
+    out += alphabet[(triplet >> 12) & 63] ?? "";
+    out += i + 1 < bytes.length ? (alphabet[(triplet >> 6) & 63] ?? "") : "=";
+    out += i + 2 < bytes.length ? (alphabet[triplet & 63] ?? "") : "=";
+  }
+
+  return out;
+}
 
 export function renderMarkdown(source: string): string {
   // Normalize literal \n escape sequences (AI output artefact) to real newlines

--- a/apps/web/src/lib/utils/markdown.ts
+++ b/apps/web/src/lib/utils/markdown.ts
@@ -44,24 +44,13 @@ function isMermaidLang(lang: string | undefined): boolean {
   return normalized === "mermaid" || normalized === "mmd";
 }
 
+// UTF-8 → base64. Inverse of the decode in mermaid.svelte.ts (atob → bytes →
+// TextDecoder), so multi-byte source survives the data-attribute round-trip.
 function encodeBase64(source: string): string {
   const bytes = new TextEncoder().encode(source);
-  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-  let out = "";
-
-  for (let i = 0; i < bytes.length; i += 3) {
-    const first = bytes[i] ?? 0;
-    const second = bytes[i + 1] ?? 0;
-    const third = bytes[i + 2] ?? 0;
-    const triplet = (first << 16) | (second << 8) | third;
-
-    out += alphabet[(triplet >> 18) & 63] ?? "";
-    out += alphabet[(triplet >> 12) & 63] ?? "";
-    out += i + 1 < bytes.length ? (alphabet[(triplet >> 6) & 63] ?? "") : "=";
-    out += i + 2 < bytes.length ? (alphabet[triplet & 63] ?? "") : "=";
-  }
-
-  return out;
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
 }
 
 export function renderMarkdown(source: string): string {

--- a/apps/web/src/lib/utils/mermaid.svelte.ts
+++ b/apps/web/src/lib/utils/mermaid.svelte.ts
@@ -1,0 +1,60 @@
+type MermaidApi = typeof import("mermaid").default;
+type AppTheme = "light" | "dark";
+type MermaidTheme = "default" | "dark";
+type RenderResult = { svg: string } | { error: string };
+
+let mermaidApi: MermaidApi | null = null;
+let loadPromise: Promise<MermaidApi> | null = null;
+let activeTheme: MermaidTheme | null = null;
+let renderCounter = 0;
+
+const svgCache = new Map<string, string>();
+
+function toMermaidTheme(theme: AppTheme): MermaidTheme {
+  return theme === "dark" ? "dark" : "default";
+}
+
+async function loadMermaid(): Promise<MermaidApi> {
+  if (mermaidApi) return mermaidApi;
+  if (!loadPromise) {
+    loadPromise = import("mermaid").then((mod) => mod.default);
+  }
+  mermaidApi = await loadPromise;
+  return mermaidApi;
+}
+
+export async function initMermaid(theme: AppTheme): Promise<void> {
+  const nextTheme = toMermaidTheme(theme);
+  const api = await loadMermaid();
+  if (activeTheme === nextTheme) return;
+
+  api.initialize({
+    startOnLoad: false,
+    securityLevel: "strict",
+    theme: nextTheme,
+  });
+  activeTheme = nextTheme;
+}
+
+export async function renderMermaid(source: string): Promise<RenderResult> {
+  if (!activeTheme) {
+    await initMermaid("light");
+  }
+
+  const theme = activeTheme ?? "default";
+  const cacheKey = `${theme}\u0000${source}`;
+  const cached = svgCache.get(cacheKey);
+  if (cached) return { svg: cached };
+
+  try {
+    const api = await loadMermaid();
+    const id = `revv-mermaid-${++renderCounter}`;
+    const result = await api.render(id, source);
+    svgCache.set(cacheKey, result.svg);
+    return { svg: result.svg };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : "Diagram failed to render.",
+    };
+  }
+}

--- a/apps/web/src/routes/review/[prId]/+page.svelte
+++ b/apps/web/src/routes/review/[prId]/+page.svelte
@@ -369,13 +369,13 @@ onDestroy(() => {
 	   6-col grid used by every container inside GuidedWalkthrough (content,
 	   loading skeleton, stepper header, blocks, …). See the derivation in
 	   GuidedWalkthrough.svelte → `.walkthrough-content` for the col_1 math
-	   (viewport-anchored centring that stays stable under sidebar toggle/
-	   resize). Template must stay byte-for-byte identical to the walkthrough
+	   (main-area-anchored centring that re-centres on every sidebar/right-panel
+	   toggle). Template must stay byte-for-byte identical to the walkthrough
 	   grids so the title above and the content below align pixel-for-pixel. */
 	.page-title-section--narrow {
 		display: grid;
 		grid-template-columns:
-			max(24px, min(calc(100% - 50vw - 458px), calc(100% - 1312px)))
+			max(24px, min(calc(50% - 458px), calc(100% - 1312px)))
 			48px
 			minmax(0, 820px)
 			40px

--- a/apps/web/static/artifact-host.html
+++ b/apps/web/static/artifact-host.html
@@ -80,6 +80,9 @@
   }
 
   window.addEventListener("message", (event) => {
+    // Only the host frame that wrote us may drive theme changes; ignore any
+    // other window that holds a handle to this opaque-origin frame.
+    if (event.source !== parentWindow) return;
     const data = event.data;
     if (!data || typeof data !== "object" || data.kind !== "theme") return;
     if (data.theme !== "light" && data.theme !== "dark") return;
@@ -174,6 +177,10 @@ ${"<"}/style>`;
         }
 
         window.addEventListener("message", (event) => {
+          // Only accept the mount handshake from the parent that embedded us;
+          // a sibling frame holding our contentWindow must not win the race and
+          // inject arbitrary markup ahead of the legitimate mount.
+          if (event.source !== parentWindow) return;
           const data = event.data;
           if (!data || typeof data !== "object" || data.kind !== "mount") return;
           if (typeof data.html !== "string") return;

--- a/apps/web/static/artifact-host.html
+++ b/apps/web/static/artifact-host.html
@@ -1,0 +1,189 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; font-src data:; connect-src 'none'; media-src data:; object-src 'none'; base-uri 'none'; form-action 'none'"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Revv Artifact Host</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        background: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <script>
+      (() => {
+        const parentWindow = window.parent;
+
+        // The CSP that governs this host (declared once in the <meta> above and
+        // also served as an HTTP header in the Tauri build). We re-inject it
+        // into the document we write below so the policy survives document.write
+        // in every environment — including dev, where the page is served by
+        // Vite with no CSP header and the original <meta> is discarded by the
+        // rewrite. Single-sourced: read from our own meta, never hard-coded.
+        const HOST_CSP = (() => {
+          const meta = document.querySelector(
+            'meta[http-equiv="Content-Security-Policy"]',
+          );
+          return meta ? meta.getAttribute("content") : null;
+        })();
+
+        function post(message) {
+          parentWindow.postMessage(message, "*");
+        }
+
+        function escapeForScript(value) {
+          return JSON.stringify(value)
+            .replace(/</g, "\\u003c")
+            .replace(/>/g, "\\u003e")
+            .replace(/&/g, "\\u0026")
+            .replace(/\u2028/g, "\\u2028")
+            .replace(/\u2029/g, "\\u2029");
+        }
+
+        function bridgeScript(theme, tokens) {
+          const payload = escapeForScript({ theme, tokens });
+          return `<script>
+(() => {
+  const parentWindow = window.parent;
+  let current = ${payload};
+
+  function post(message) {
+    parentWindow.postMessage(message, "*");
+  }
+
+  function applyTheme(payload) {
+    current = payload;
+    document.documentElement.dataset.theme = payload.theme;
+    document.documentElement.style.colorScheme = payload.theme;
+    for (const [name, value] of Object.entries(payload.tokens || {})) {
+      document.documentElement.style.setProperty(name, value);
+    }
+  }
+
+  function reportSize() {
+    const body = document.body;
+    const root = document.documentElement;
+    const height = Math.max(
+      body ? body.scrollHeight : 0,
+      body ? body.offsetHeight : 0,
+      root.scrollHeight,
+      root.offsetHeight
+    );
+    post({ kind: "resize", height: Math.ceil(height) });
+  }
+
+  window.addEventListener("message", (event) => {
+    const data = event.data;
+    if (!data || typeof data !== "object" || data.kind !== "theme") return;
+    if (data.theme !== "light" && data.theme !== "dark") return;
+    if (!data.tokens || typeof data.tokens !== "object") return;
+    applyTheme({ theme: data.theme, tokens: data.tokens });
+    requestAnimationFrame(reportSize);
+  });
+
+  window.addEventListener("error", (event) => {
+    post({ kind: "error", message: event.message || "Artifact script error." });
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason = event.reason;
+    const message = reason instanceof Error ? reason.message : String(reason || "Artifact promise rejection.");
+    post({ kind: "error", message });
+  });
+
+  applyTheme(current);
+  const observer = new ResizeObserver(reportSize);
+  observer.observe(document.documentElement);
+  if (document.body) observer.observe(document.body);
+  requestAnimationFrame(() => {
+    reportSize();
+    post({ kind: "mounted" });
+  });
+})();
+${"<"}/script>`;
+        }
+
+        // The on-brand, theme-aware baseline. Every rule references an injected
+        // CSS variable (the bridge applies them via setProperty on <html> and
+        // re-applies on theme toggle), so a do-nothing artifact is already
+        // styled in Revv's type/colors and flips light↔dark for free instead of
+        // inheriting the UA defaults (Times New Roman, black-on-transparent).
+        // Injected at the top of <head> at lowest specificity, so any artifact
+        // <style> overrides it.
+        function baseStyle() {
+          return `<style>
+*, *::before, *::after { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; }
+body {
+  margin: 0;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+code, pre, kbd, samp { font-family: var(--font-mono); }
+a { color: var(--color-accent); }
+a:hover { color: var(--color-accent-hover); }
+:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 2px; }
+img, svg, canvas { max-width: 100%; }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: .001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+${"<"}/style>`;
+        }
+
+        function injectHead(html) {
+          const meta = HOST_CSP
+            ? `<meta http-equiv="Content-Security-Policy" content="${HOST_CSP.replace(/"/g, "&quot;")}">`
+            : "";
+          // The CSP meta must sit at the top of <head>, before any content it
+          // governs; the baseline follows it at lowest specificity. Insert after
+          // <head>, synthesizing one if the document has none, so a
+          // self-contained artifact is covered either way.
+          const head = `${meta}${baseStyle()}`;
+          if (/<head[^>]*>/i.test(html)) {
+            return html.replace(/<head[^>]*>/i, (match) => `${match}${head}`);
+          }
+          if (/<html[^>]*>/i.test(html)) {
+            return html.replace(/<html[^>]*>/i, (match) => `${match}<head>${head}</head>`);
+          }
+          return `<head>${head}</head>${html}`;
+        }
+
+        function injectArtifact(html, theme, tokens) {
+          const bridge = bridgeScript(theme, tokens);
+          const withBridge = /<\/body\s*>/i.test(html)
+            ? html.replace(/<\/body\s*>/i, `${bridge}</body>`)
+            : `${html}${bridge}`;
+          document.open();
+          document.write(injectHead(withBridge));
+          document.close();
+        }
+
+        window.addEventListener("message", (event) => {
+          const data = event.data;
+          if (!data || typeof data !== "object" || data.kind !== "mount") return;
+          if (typeof data.html !== "string") return;
+          if (data.theme !== "light" && data.theme !== "dark") return;
+          if (!data.tokens || typeof data.tokens !== "object") return;
+          injectArtifact(data.html, data.theme, data.tokens);
+        });
+
+        post({ kind: "ready" });
+      })();
+    </script>
+  </body>
+</html>

--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,7 @@
         "dompurify": "^3.4.0",
         "gsap": "3.15.0",
         "marked": "^18.0.0",
+        "mermaid": "^11",
         "remend": "^1.3.0",
         "shiki": "^3.0.0",
         "tailwind-merge": "^3.5.0",
@@ -158,6 +159,8 @@
     "vite": "^6.3.0",
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.142", "", { "dependencies": { "@anthropic-ai/sdk": "^0.93.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.142", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.142", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.142", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.142", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.142", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.142", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.142", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.142" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-k1xBon6ov0PT/vZNf+Z+SuAqmylGJU/+a+h/k04MW5cBbzOIwiVcGFRTGJ/qbY5pcboJbLtts/yBwSu9AvSipg=="],
 
     "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.142", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yBHOiRqJ8JcD9OAMGJALbypaD3u3K8hyUmcnZ+91AHJtymzWxuMkVi4IY1qp8L5jzkKeTnvYfCspzkbiHLuYWg=="],
@@ -260,6 +263,10 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
     "@effect/language-service": ["@effect/language-service@0.86.2", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-SaPln+8srOqDJDUwNTDmP5e+IYpEDr9+1epGznnsLqu8xvo6VnxyWARdeLpqvZJlb0Pgy9ca7ppqvvdWbHPXAg=="],
@@ -352,6 +359,10 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.3", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw=="],
+
     "@internationalized/date": ["@internationalized/date@3.12.0", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
@@ -363,6 +374,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
@@ -828,7 +841,71 @@
 
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -849,6 +926,8 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
@@ -962,6 +1041,8 @@
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
     "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
@@ -978,6 +1059,8 @@
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
@@ -988,6 +1071,80 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
@@ -997,6 +1154,8 @@
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -1063,6 +1222,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es-toolkit": ["es-toolkit@1.47.0", "", {}, "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -1176,6 +1337,8 @@
 
     "h3-v2": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
@@ -1206,11 +1369,15 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
@@ -1260,11 +1427,17 @@
 
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "knip": ["knip@6.14.1", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.130.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-SN3Ly0ixzj5CQkY/rc4OPHpWrCC0XRIIjgdP76G9Cni5k72ur5jBYOyvJuF5oPTM14v8eHcMUgPbElHa+lnR0g=="],
 
     "kysely": ["kysely@0.28.16", "", {}, "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -1292,6 +1465,8 @@
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
@@ -1311,6 +1486,8 @@
     "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mermaid": ["mermaid@11.15.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.1", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "es-toolkit": "^1.45.1", "katex": "^0.16.25", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw=="],
 
     "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 
@@ -1388,6 +1565,8 @@
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
@@ -1395,6 +1574,8 @@
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
@@ -1411,6 +1592,10 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
@@ -1474,13 +1659,19 @@
 
     "retry-request": ["retry-request@7.0.2", "", { "dependencies": { "@types/request": "^2.48.8", "extend": "^3.0.2", "teeny-request": "^9.0.0" } }, "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "runed": ["runed@0.25.0", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
 
@@ -1564,6 +1755,8 @@
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
     "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "svelte": ["svelte@5.55.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.4", "esm-env": "^1.2.1", "esrap": "^2.2.4", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ=="],
@@ -1590,6 +1783,8 @@
 
     "teeny-request": ["teeny-request@9.0.0", "", { "dependencies": { "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.9", "stream-events": "^1.0.5", "uuid": "^9.0.0" } }, "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g=="],
 
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
@@ -1607,6 +1802,8 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
 
@@ -1776,6 +1973,16 @@
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "drizzle-kit/esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
@@ -1793,6 +2000,10 @@
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "http-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "mermaid/uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "node-abi/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -1863,6 +2074,10 @@
     "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "drizzle-kit/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.19.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA=="],
 

--- a/docs/remote-cache.md
+++ b/docs/remote-cache.md
@@ -15,7 +15,7 @@ no service-account JSON to copy around.
 ## Architecture in one paragraph
 
 The cache key is content-addressable on `<owner>/<repo>/<headSha>.json.gz`. The
-local server gzips a `WalkthroughSnapshotV1` (see
+local server gzips a `WalkthroughSnapshotV2` (see
 `packages/shared/src/cache.ts`) and uploads it to the bucket on every
 successful generation — but only after an eligibility check (the local user
 must currently hold `write` on the repo) and, unless signing is `off`, after

--- a/packages/shared/src/cache.ts
+++ b/packages/shared/src/cache.ts
@@ -1,7 +1,7 @@
 // ─── Remote walkthrough cache (GCS-backed) ──────────────────────────────────
 //
 // Wire format for the team-shared walkthrough cache. The local server
-// gzip-encodes a `WalkthroughSnapshotV1` and uploads it to:
+// gzip-encodes a `WalkthroughSnapshotV2` and uploads it to:
 //
 //   gs://<bucket>/<owner>/<repo>/<headSha>.json.gz
 //
@@ -25,7 +25,7 @@ import type {
 } from "./walkthrough";
 
 /** Bump this when the snapshot shape changes. Importers reject mismatches. */
-export const CACHE_SCHEMA_VERSION = 1 as const;
+export const CACHE_SCHEMA_VERSION = 2 as const;
 
 /**
  * Captured atomically at job start so a settings change mid-run doesn't
@@ -67,7 +67,7 @@ export interface WalkthroughSnapshotBlock {
   semanticStepIndex: number;
   stepIndex: number;
   /** Block type — discriminates the `data` payload. */
-  type: "diff" | "code" | "markdown";
+  type: WalkthroughBlock["type"];
   /** Typed payload — same shape as the on-row JSON. */
   data: WalkthroughBlock;
 }
@@ -115,8 +115,8 @@ export interface WalkthroughSnapshotSemanticStep {
  *   • issues where `submittedAt != null` (per-account GitHub state)
  *   • per-row ids on blocks/issues/ratings (regenerated on import)
  */
-export interface WalkthroughSnapshotV1 {
-  schemaVersion: 1;
+export interface WalkthroughSnapshotV2 {
+  schemaVersion: typeof CACHE_SCHEMA_VERSION;
   /** `"owner/repo"` — pairs with `prHeadSha` to locate the bucket object. */
   repoFullName: string;
   prHeadSha: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,7 +8,7 @@ export type {
   WalkthroughSnapshotIssue,
   WalkthroughSnapshotRating,
   WalkthroughSnapshotSemanticStep,
-  WalkthroughSnapshotV1,
+  WalkthroughSnapshotV2,
 } from "./cache";
 export {
   CACHE_METADATA_KEYS,

--- a/packages/shared/src/walkthrough.ts
+++ b/packages/shared/src/walkthrough.ts
@@ -72,7 +72,17 @@ export interface DiffBlock extends BlockPhaseFields {
   prerenderedHtml?: string;
 }
 
-export type WalkthroughBlock = MarkdownBlock | CodeBlock | DiffBlock;
+export interface ArtifactBlock extends BlockPhaseFields {
+  type: "artifact";
+  id: string;
+  order: number;
+  /** Complete self-contained HTML document rendered in a sandboxed iframe. */
+  html: string;
+  annotation: string | null;
+  annotationPosition: AnnotationPosition;
+}
+
+export type WalkthroughBlock = MarkdownBlock | CodeBlock | DiffBlock | ArtifactBlock;
 
 // ── Semantic step (Phase B chapter) ─────────────────────────────────────────
 


### PR DESCRIPTION
Adds lazy Mermaid rendering for walkthrough markdown fences while keeping diagrams as ordinary markdown content. Mermaid and mmd code fences now become sanitized placeholders, then a client action renders strict-security SVGs with theme sync, reduced-motion-aware reveal, caching, and fallback source display on parse errors. The action is wired into walkthrough markdown blocks, annotations, section summaries, sentiment, and rating details, with shared prose styling and a resolved-theme getter. The walkthrough system prompt now tells agents when to emit small Mermaid diagrams. Verified with bun run typecheck, bun run lint, bun run knip, and bun run build.