### PR TITLE
perf(server): cut GitHub poll rate-limit pressure

### DIFF
--- a/apps/server/src/services/GitHub.ts
+++ b/apps/server/src/services/GitHub.ts
@@ -296,7 +296,7 @@ interface GitHubGatewayFlatService {
     prNumber: number,
     since: string | null,
     token: string,
-  ) => Effect.Effect<GhReviewComment[], GitHubError, SettingsService>;
+  ) => Effect.Effect<GhReviewComment[], GitHubError, DbService | GitHubEtagCache | SettingsService>;
   readonly listReviewThreads: (
     repoFullName: string,
     prNumber: number,
@@ -917,11 +917,20 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       const apiBase = yield* resolveApiBase;
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const sinceQ = since ? `&since=${encodeURIComponent(since)}` : "";
-      const data = yield* githubFetchPaginated(
+      // Conditional (ETag) fetch: this is the per-PR REST call the 30s thread
+      // poll fires for every open PR. A conditional request that returns 304
+      // does NOT count against GitHub's primary REST rate limit, so quiet PRs
+      // (the overwhelming majority each tick) become free. The cache key folds
+      // in `since`, which only advances when new comments actually arrive — so
+      // an unchanged PR replays the same key and 304s. `canReplayCached` only
+      // allows the cheap replay when the cached body was a single (<100) page;
+      // a full page means there may be more, so we force a refetch.
+      const data = yield* conditionalFetchPaginated(
         `/repos/${owner}/${repo}/pulls/${prNumber}/comments?per_page=100${sinceQ}`,
         token,
         5,
         apiBase,
+        { canReplayCached: (cached) => cached.length < 100 },
       );
       return (data as Record<string, unknown>[]).map((raw): GhReviewComment => {
         const user = (raw.user as Record<string, unknown> | null) ?? {};

--- a/apps/server/src/services/PollScheduler.ts
+++ b/apps/server/src/services/PollScheduler.ts
@@ -1049,8 +1049,19 @@ export const PollSchedulerLive = Layer.effect(
 
     const startThreadFiber: Effect.Effect<void> = Effect.gen(function* () {
       const schedule = Schedule.spaced(Duration.seconds(THREAD_SYNC_INTERVAL_SECONDS));
+      // Delay the FIRST background thread sweep by one interval. At boot the
+      // PR-sync fiber already fires immediately (repo metadata + user avatars +
+      // listOpen per repo + archive backfill), and running the all-open-PRs
+      // thread sweep concurrently on top of that produces a request burst that
+      // trips GitHub's *secondary* (abuse) rate limit — the "rate limited as
+      // soon as I open Revv" symptom, made worse when an IDE shares the
+      // account. Opening a PR force-syncs its threads on demand, so this delay
+      // never affects the PR the user is actually looking at.
       const fiber: Fiber.RuntimeFiber<number, never> = yield* Effect.fork(
-        syncThreadsForOpenPrs.pipe(Effect.repeat(schedule)),
+        syncThreadsForOpenPrs.pipe(
+          Effect.repeat(schedule),
+          Effect.delay(Duration.seconds(THREAD_SYNC_INTERVAL_SECONDS)),
+        ),
       );
       yield* Ref.set(threadFiberRef, fiber);
     });

--- a/apps/server/src/services/Sync.ts
+++ b/apps/server/src/services/Sync.ts
@@ -6,6 +6,7 @@ import { SyncError } from "../domain/errors";
 import { Broadcaster } from "./Broadcaster";
 import { DbService } from "./Db";
 import { type GhReviewComment, GitHubGateway } from "./GitHub";
+import type { GitHubEtagCache } from "./GitHubEtagCache";
 import { PrContextService } from "./PrContext";
 import { PullRequestService } from "./PullRequest";
 import { RemoteUserService } from "./RemoteUser";
@@ -41,10 +42,10 @@ export class SyncService extends Context.Tag("SyncService")<
     ) => Effect.Effect<void, SyncError, DbService | SettingsService>;
     readonly pullComments: (
       prId: string,
-    ) => Effect.Effect<PullResult, SyncError, DbService | SettingsService>;
+    ) => Effect.Effect<PullResult, SyncError, DbService | GitHubEtagCache | SettingsService>;
     readonly syncThreads: (
       prId: string,
-    ) => Effect.Effect<SyncResult, SyncError, DbService | SettingsService>;
+    ) => Effect.Effect<SyncResult, SyncError, DbService | GitHubEtagCache | SettingsService>;
     readonly getThreadSummary: (
       prId: string,
       userLogin: string | null,
@@ -267,7 +268,7 @@ export const SyncServiceLive = Layer.effect(
 
     const pullComments = (
       prId: string,
-    ): Effect.Effect<PullResult, SyncError, DbService | SettingsService> =>
+    ): Effect.Effect<PullResult, SyncError, DbService | GitHubEtagCache | SettingsService> =>
       Effect.gen(function* () {
         const { pr, repo, token } = yield* resolvePrContext(prId);
         const accountId = yield* repoService.getAccountIdForRepo(repo.id);
@@ -387,8 +388,18 @@ export const SyncServiceLive = Layer.effect(
             .pipe(Effect.catchAll(() => Effect.void));
         }
 
-        // Reconcile resolution status via GraphQL.
-        const ghThreads = yield* github.reviews.listThreads(repo.fullName, pr.externalId, token);
+        // Reconcile resolution status via GraphQL — but only when this PR
+        // actually has local threads to reconcile. The reconciliation loop
+        // matches GitHub threads back to local rows by external comment id;
+        // with zero local threads every match is a miss, so the GraphQL call
+        // is pure waste. Skipping it removes one GraphQL request per quiet PR
+        // on every 30s poll tick — the bulk of PRs most of the time — which is
+        // the single biggest contributor to GitHub rate-limit pressure.
+        const localThreads = yield* reviewService.getThreadsForSession(session.id);
+        const ghThreads =
+          localThreads.length === 0
+            ? []
+            : yield* github.reviews.listThreads(repo.fullName, pr.externalId, token);
         for (const ght of ghThreads) {
           for (const cdbId of ght.commentDatabaseIds) {
             const local = yield* reviewService.getThreadByExternalCommentId(
@@ -438,7 +449,7 @@ export const SyncServiceLive = Layer.effect(
 
     const syncThreads = (
       prId: string,
-    ): Effect.Effect<SyncResult, SyncError, DbService | SettingsService> =>
+    ): Effect.Effect<SyncResult, SyncError, DbService | GitHubEtagCache | SettingsService> =>
       Effect.gen(function* () {
         const pulled = yield* pullComments(prId);
         const summary = yield* getThreadSummary(prId, null);


### PR DESCRIPTION
The 30s thread-sync loop polled every open PR with an uncached REST call plus a GraphQL call, and both poll fibers fired concurrently at boot — exhausting GitHub's primary limit and tripping the secondary (abuse) limit "as soon as Revv opens", worse when an IDE shares the account. This PR ETag-caches the review-comments poll (`listReviewComments` → `conditionalFetchPaginated`) so unchanged PRs return a 304 that doesn't count against the primary REST limit. It also skips the GraphQL thread reconciliation when a PR has no local threads to reconcile, removing one GraphQL request per quiet PR per tick. Finally, it delays the thread loop's first sweep by one interval so it no longer stacks on the boot-time PR-sync burst (opening a PR still force-syncs its threads on demand, so first-view freshness is unaffected). Intervals are unchanged — quiet polls just become nearly free rather than less frequent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)