### PR TITLE
Warn on artifact theming violations

### DIFF
--- a/apps/server/src/ai/prompts/walkthrough-system.md
+++ b/apps/server/src/ai/prompts/walkthrough-system.md
@@ -41,7 +41,7 @@ Each `add_diff_step` persists exactly one unit:
   - `markdown.content` — prose narrative (headings / bullets / inline code — see formatting below).
   - `code` — source-code excerpt (`file_path`, line range, language, content, annotation, annotation_position).
   - `diff` — unified-diff hunk (`file_path`, `patch`, annotation, annotation_position).
-  - `artifact` — an interactive HTML/CSS/JS island (`html`, annotation, annotation_position) for a steppable state machine, toggleable before/after, tiny chart, or other interaction that prose/code/diff cannot express clearly.
+  - `artifact` — an interactive HTML/CSS/JS island (`html`, annotation, annotation_position) for a steppable state machine, toggleable before/after, tiny chart, or other interaction that prose/code/diff cannot express clearly. **Required for every worked example, and the default for any complex explanation** — see "Worked examples" below.
 
 Artifacts are for the interactive piece only; keep the surrounding explanation in `markdown` blocks. Artifact `html` MUST be a single complete self-contained HTML document with inline `<style>` and `<script>`, vanilla JS only, no external network/CDN imports, and no `localStorage` or `sessionStorage` access. The document runs in a sandboxed iframe with an opaque origin, so storage APIs throw and parent DOM/cookies are inaccessible.
 
@@ -225,7 +225,11 @@ Whenever you explain a bug or a non-trivial concept, illustrate it with a concre
  `id` has a B-tree index and the query starts at the leaf, not the root."
 ```
 
-Worked examples belong inside a markdown block, either inline in the narrative or as a dedicated markdown step when the concept warrants it. Use fenced code blocks (` ``` `) with the pseudocode/snippet inside. Length: as short as possible while still being concrete — the goal is "I see exactly what happens", not completeness.
+**ALWAYS pair a worked example with an interactive `artifact` block.** Whenever you write a worked example — a bug trace, a step-by-step scenario, a before/after — add an `artifact` block that makes it interactive: a steppable trace the reader advances one state at a time, a toggleable before/after, a tiny live diagram of the data/control flow. The prose worked example (in a `markdown` block) sets it up; the artifact lets the reader _drive_ it. Don't settle for a static fenced code block when the example can be walked. Keep the surrounding narrative in `markdown` and put only the interaction in the `artifact` (see the artifact styling/sandbox rules above).
+
+The prose half of the worked example still uses fenced code blocks (` ``` `) for the pseudocode/snippet, and stays as short as possible while concrete — the goal is "I see exactly what happens", not completeness.
+
+**Reach for an `artifact` for any complex explanation, not just worked examples.** Any time prose alone would be hard to follow — a multi-step state machine, an ordering/timing subtlety, a tricky data transformation, an interaction between several moving parts — express it with an interactive `artifact` the reader can manipulate, rather than asking them to hold the whole thing in their head from a paragraph.
 
 ### Reuse check (REQUIRED for every new function/helper/utility introduced)
 

--- a/apps/server/src/ai/providers/chat-edit-tools/content-handlers.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/content-handlers.ts
@@ -8,7 +8,13 @@ import { walkthroughBlocks } from "../../../db/schema/walkthrough-blocks";
 import { walkthroughIssues } from "../../../db/schema/walkthrough-issues";
 import { walkthroughSemanticSteps } from "../../../db/schema/walkthrough-semantic-steps";
 import { walkthroughs } from "../../../db/schema/walkthroughs";
-import { blockRow, blockVariantCount, buildBlock, emptyBlockError } from "../walkthrough-blocks";
+import {
+  blockRow,
+  blockVariantCount,
+  buildBlock,
+  emptyBlockError,
+  withArtifactThemingWarning,
+} from "../walkthrough-blocks";
 import { blockIdFor, unwrapJsonWrappedString } from "../walkthrough-tools";
 import {
   assertStillComplete,
@@ -185,7 +191,12 @@ export const addSemanticStepEditHandler: ChatEditToolHandler<AddSemanticStepEdit
 
   ctx.emit(walkthroughId, { type: "semantic-step", data: emitChapter });
   ctx.emit(walkthroughId, { type: "block", data: emitBlock });
-  return ok(`Chapter ${input.semantic_step_index} ('${title}') inserted with its first block.`);
+  return ok(
+    withArtifactThemingWarning(
+      `Chapter ${input.semantic_step_index} ('${title}') inserted with its first block.`,
+      input.initial_block,
+    ),
+  );
 };
 
 // ── Tool: update_semantic_step ──────────────────────────────────────────────
@@ -502,7 +513,12 @@ export const addBlockHandler: ChatEditToolHandler<AddBlockInput> = async (ctx, i
   if (!emitBlock) return fail("Internal error: add_block did not persist.");
 
   ctx.emit(walkthroughId, { type: "block", data: emitBlock });
-  return ok(`Block added at chapter ${input.semantic_step_index}, step ${resolvedStepIndex}.`);
+  return ok(
+    withArtifactThemingWarning(
+      `Block added at chapter ${input.semantic_step_index}, step ${resolvedStepIndex}.`,
+      input.content,
+    ),
+  );
 };
 
 // ── Tool: update_block ──────────────────────────────────────────────────────
@@ -566,7 +582,12 @@ export const updateBlockHandler: ChatEditToolHandler<UpdateBlockInput> = async (
   if (!emitBlock) return fail("Internal error: update_block did not persist.");
 
   ctx.emit(walkthroughId, { type: "block", data: emitBlock });
-  return ok(`Block at chapter ${input.semantic_step_index}, step ${input.step_index} updated.`);
+  return ok(
+    withArtifactThemingWarning(
+      `Block at chapter ${input.semantic_step_index}, step ${input.step_index} updated.`,
+      input.content,
+    ),
+  );
 };
 
 // ── Tool: delete_block ──────────────────────────────────────────────────────

--- a/apps/server/src/ai/providers/chat-edit-tools/spec.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/spec.ts
@@ -120,7 +120,7 @@ export const blockContentSchema = z
         html: z
           .string()
           .describe(
-            "A complete, self-contained HTML document with inline CSS/JS. Vanilla JS only; no external network/CDN; no localStorage. Renders in a sandboxed iframe. Style with the injected Revv theme variables (`var(--color-*)`, `var(--font-*)`) so it matches the app and follows light/dark — never hardcode colors. See the system prompt for the full token list and design rules.",
+            "A complete, self-contained HTML document with inline CSS/JS. Vanilla JS only; no external network/CDN; no localStorage. Renders in a sandboxed iframe. Style with the injected Revv theme variables (`var(--color-*)`, `var(--font-*)`) so it matches the app and follows light/dark — never hardcode colors or font-family. See the system prompt for the full token list and design rules.",
           ),
         annotation: z.string().nullable(),
         annotation_position: z.enum(["left", "right"]),

--- a/apps/server/src/ai/providers/walkthrough-blocks.test.ts
+++ b/apps/server/src/ai/providers/walkthrough-blocks.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "bun:test";
-import { artifactThemingWarning, type BlockVariantInput } from "./walkthrough-blocks";
+import {
+  artifactThemingWarning,
+  type BlockVariantInput,
+  buildBlock,
+  normalizeDiffPatch,
+} from "./walkthrough-blocks";
+
+// A valid unified-diff hunk header must carry `@@ -a,b +c,d @@` ranges. The
+// regex models do not always produce — they emit a bare `@@` — which parses
+// into zero hunks and renders a blank panel. normalizeDiffPatch repairs that.
+const VALID_HEADER = /^@@ -\d+,\d+ \+\d+,\d+ @@/m;
 
 function artifact(html: string): BlockVariantInput {
   return {
@@ -80,5 +90,59 @@ describe("artifactThemingWarning", () => {
         markdown: { content: "This prose mentions #fff and rgba(0,0,0,.5)." },
       }),
     ).toBeNull();
+  });
+});
+
+describe("normalizeDiffPatch", () => {
+  it("synthesizes a header for a bare `@@` hunk (the blank-panel bug)", () => {
+    // The exact shape seen in PR 1105: bare `@@`, one removal, three additions.
+    const patch = ["@@", "-const a = old();", "+// note", "+// note 2", "+const a = new();"].join(
+      "\n",
+    );
+    const out = normalizeDiffPatch(patch);
+    expect(out).toMatch(VALID_HEADER);
+    expect(out).toContain("@@ -1,1 +1,3 @@");
+    // Body is preserved verbatim.
+    expect(out).toContain("-const a = old();");
+    expect(out).toContain("+const a = new();");
+  });
+
+  it("synthesizes a header when the patch has none at all", () => {
+    const patch = ["-removed line", "+added line", " context line"].join("\n");
+    const out = normalizeDiffPatch(patch);
+    expect(out.startsWith("@@ ")).toBe(true);
+    // 1 removed + 1 context = old count 2; 1 added + 1 context = new count 2.
+    expect(out).toContain("@@ -1,2 +1,2 @@");
+  });
+
+  it("uses git's -0,0 convention for a pure insertion", () => {
+    const out = normalizeDiffPatch(["@@", "+only an addition"].join("\n"));
+    expect(out).toContain("@@ -0,0 +1,1 @@");
+  });
+
+  it("leaves a well-formed patch unchanged and is idempotent", () => {
+    const valid = ["@@ -10,2 +10,3 @@", " context", "-old", "+new1", "+new2"].join("\n");
+    expect(normalizeDiffPatch(valid)).toBe(valid);
+    expect(normalizeDiffPatch(normalizeDiffPatch(valid))).toBe(valid);
+  });
+
+  it("repairs only malformed headers in a multi-hunk patch", () => {
+    const patch = ["@@ -1,1 +1,1 @@", "-a", "+b", "@@", "-c", "+d"].join("\n");
+    const out = normalizeDiffPatch(patch);
+    expect(out).toContain("@@ -1,1 +1,1 @@"); // valid one kept
+    expect(out).toContain("@@ -1,1 +1,1 @@\n-a\n+b\n@@ -1,1 +1,1 @@\n-c\n+d");
+  });
+
+  it("is applied when buildBlock constructs a diff block", () => {
+    const block = buildBlock("b1", 0, 0, {
+      diff: {
+        file_path: "a.ts",
+        patch: ["@@", "-x", "+y"].join("\n"),
+        annotation: null,
+        annotation_position: "left",
+      },
+    });
+    expect(block?.type).toBe("diff");
+    if (block?.type === "diff") expect(block.patch).toMatch(VALID_HEADER);
   });
 });

--- a/apps/server/src/ai/providers/walkthrough-blocks.test.ts
+++ b/apps/server/src/ai/providers/walkthrough-blocks.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { artifactThemingWarning, type BlockVariantInput } from "./walkthrough-blocks";
+
+function artifact(html: string): BlockVariantInput {
+  return {
+    artifact: {
+      html,
+      annotation: null,
+      annotation_position: "right",
+    },
+  };
+}
+
+describe("artifactThemingWarning", () => {
+  it("returns null for artifacts styled with injected theme variables", () => {
+    expect(
+      artifactThemingWarning(
+        artifact(`
+          <style>
+            body {
+              color: var(--color-accent);
+              background: var(--color-bg-primary);
+              font-family: var(--font-mono);
+              border-radius: var(--radius-card);
+            }
+          </style>
+        `),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not flag selectors, fragment hrefs, or SVG paint refs", () => {
+    expect(
+      artifactThemingWarning(
+        artifact(`
+          <style>
+            #panel { color: var(--color-fg-primary); }
+          </style>
+          <a href="#section">Jump</a>
+          <svg><rect fill="url(#grad)" /></svg>
+        `),
+      ),
+    ).toBeNull();
+  });
+
+  it("flags hex color literals in CSS value position", () => {
+    expect(artifactThemingWarning(artifact(`<style>body { color: #fff; }</style>`))).toContain(
+      "hex color literal",
+    );
+  });
+
+  it("flags functional color notations", () => {
+    const examples = ["rgba(0,0,0,.5)", "oklch(60% 0.1 180)", "hsl(0 0% 100%)", "hwb(90 10% 10%)"];
+
+    for (const value of examples) {
+      expect(
+        artifactThemingWarning(artifact(`<style>body { background: ${value}; }</style>`)),
+      ).toContain("rgb()/hsl()/oklch() color");
+    }
+  });
+
+  it("flags literal font-family declarations", () => {
+    expect(
+      artifactThemingWarning(artifact(`<style>body { font-family: "Inter", sans-serif; }</style>`)),
+    ).toContain("literal font-family");
+  });
+
+  it("allows theme font variables and generic-only font-family declarations", () => {
+    expect(
+      artifactThemingWarning(artifact(`<style>body { font-family: var(--font-sans); }</style>`)),
+    ).toBeNull();
+    expect(
+      artifactThemingWarning(artifact(`<style>code { font-family: monospace; }</style>`)),
+    ).toBeNull();
+  });
+
+  it("returns null for non-artifact variants", () => {
+    expect(
+      artifactThemingWarning({
+        markdown: { content: "This prose mentions #fff and rgba(0,0,0,.5)." },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/server/src/ai/providers/walkthrough-blocks.ts
+++ b/apps/server/src/ai/providers/walkthrough-blocks.ts
@@ -173,6 +173,73 @@ export function withArtifactThemingWarning(okText: string, input: BlockVariantIn
 }
 
 /**
+ * A unified-diff hunk header carrying explicit ranges: `@@ -a[,b] +c[,d] @@`.
+ * A bare `@@`, a `@@ section label @@`, or a header with missing ranges is
+ * malformed — Pierre's parser yields zero hunks for it and the diff renders as
+ * a blank panel.
+ */
+const VALID_HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/;
+
+const isHunkHeader = (line: string): boolean => line.startsWith("@@");
+
+/**
+ * Synthesize a hunk header from its body line counts. The true source line
+ * numbers are unrecoverable (a diff block carries no anchor), so ranges start
+ * at line 1; git's `-0,0` convention marks an empty side so a pure
+ * insertion/deletion still parses.
+ */
+function synthesizeHunkHeader(body: readonly string[]): string {
+  let removed = 0;
+  let added = 0;
+  let context = 0;
+  for (const line of body) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("\\")) continue; // "\ No newline at end of file"
+    if (line.startsWith("+")) added++;
+    else if (line.startsWith("-")) removed++;
+    else context++;
+  }
+  const oldCount = removed + context;
+  const newCount = added + context;
+  const oldStart = oldCount === 0 ? 0 : 1;
+  const newStart = newCount === 0 ? 0 : 1;
+  return `@@ -${oldStart},${oldCount} +${newStart},${newCount} @@`;
+}
+
+/**
+ * Ensure every hunk in a unified-diff patch has a valid `@@ -a,b +c,d @@`
+ * header. Models hand-writing a "conceptual" diff routinely emit a bare `@@`
+ * (or omit the header entirely); Pierre's `parsePatchFiles` then parses the
+ * file but produces zero hunks, so the diff block renders blank. We rewrite
+ * only malformed headers — valid patches pass through unchanged (idempotent)
+ * and body lines are never modified. Applied on write so stored patches are
+ * always renderable.
+ */
+export function normalizeDiffPatch(patch: string): string {
+  const lines = patch.split("\n");
+  const firstHunk = lines.findIndex(isHunkHeader);
+
+  // No hunk header at all: treat the whole body as one headerless hunk.
+  if (firstHunk === -1) {
+    if (patch.trim().length === 0) return patch;
+    return `${synthesizeHunkHeader(lines)}\n${patch}`;
+  }
+
+  const out: string[] = lines.slice(0, firstHunk);
+  let i = firstHunk;
+  while (i < lines.length) {
+    const header = lines[i] ?? "";
+    let j = i + 1;
+    while (j < lines.length && !isHunkHeader(lines[j] ?? "")) j++;
+    const body = lines.slice(i + 1, j);
+    out.push(VALID_HUNK_HEADER.test(header) ? header : synthesizeHunkHeader(body));
+    out.push(...body);
+    i = j;
+  }
+  return out.join("\n");
+}
+
+/**
  * Construct a typed `WalkthroughBlock` from exactly one populated variant.
  * Returns null when no variant is present — callers validate variant count
  * with {@link blockVariantCount} and reject empty content with
@@ -227,7 +294,7 @@ export function buildBlock(
       semanticStepIndex,
       stepIndex,
       filePath: input.diff.file_path,
-      patch: input.diff.patch,
+      patch: normalizeDiffPatch(input.diff.patch),
       annotation: input.diff.annotation,
       annotationPosition: input.diff.annotation_position,
     };

--- a/apps/server/src/ai/providers/walkthrough-blocks.ts
+++ b/apps/server/src/ai/providers/walkthrough-blocks.ts
@@ -106,6 +106,72 @@ export function emptyBlockError(input: BlockVariantInput): string | null {
   return null;
 }
 
+const FUNCTIONAL_COLOR_RE = /\b(rgb|rgba|hsl|hsla|hwb|oklch|oklab|lab|lch|color)\s*\(/i;
+const HEX_COLOR_VALUE_RE = /[:\s]#[0-9a-fA-F]{3,8}\b/;
+const FONT_FAMILY_DECL_RE = /font-family\s*:\s*([^;{}]+)/gi;
+const GENERIC_FONT_FAMILIES = new Set([
+  "inherit",
+  "initial",
+  "unset",
+  "revert",
+  "sans-serif",
+  "serif",
+  "monospace",
+  "system-ui",
+  "ui-sans-serif",
+  "ui-monospace",
+  "cursive",
+  "fantasy",
+]);
+
+function isGenericFontFamilyList(value: string): boolean {
+  const families = value
+    .split(",")
+    .map((family) => family.trim().toLowerCase())
+    .filter((family) => family.length > 0);
+
+  return families.length > 0 && families.every((family) => GENERIC_FONT_FAMILIES.has(family));
+}
+
+/**
+ * Best-effort theme-safety lint for artifact HTML. Warn-only by design: the
+ * write still succeeds, and callers append the returned message to the MCP
+ * success result so the agent can self-correct on later blocks.
+ */
+export function artifactThemingWarning(input: BlockVariantInput): string | null {
+  if (!input.artifact) return null;
+
+  const html = input.artifact.html;
+  const issues = new Set<string>();
+
+  if (HEX_COLOR_VALUE_RE.test(html)) {
+    // Warn-only accepts the residual false positive where an all-hex id selector
+    // like `#fad { ... }` appears after whitespace.
+    issues.add("hex color literal");
+  }
+  if (FUNCTIONAL_COLOR_RE.test(html)) {
+    issues.add("rgb()/hsl()/oklch() color");
+  }
+
+  for (const match of html.matchAll(FONT_FAMILY_DECL_RE)) {
+    const value = match[1];
+    if (!value) continue;
+    if (value.includes("var(--font")) continue;
+    if (isGenericFontFamilyList(value)) continue;
+    issues.add("literal font-family");
+    break;
+  }
+
+  if (issues.size === 0) return null;
+
+  return `Warning: this artifact hardcodes styling that won't adapt to light/dark theme (found: ${Array.from(issues).join(", ")}). Style with the injected theme variables instead — var(--color-bg-primary), var(--color-accent), var(--font-sans)/var(--font-mono), var(--radius-card) — so it matches the app and flips with the theme. The block was saved; correct it in this or a later block.`;
+}
+
+export function withArtifactThemingWarning(okText: string, input: BlockVariantInput): string {
+  const warning = artifactThemingWarning(input);
+  return warning ? `${okText}\n\n${warning}` : okText;
+}
+
 /**
  * Construct a typed `WalkthroughBlock` from exactly one populated variant.
  * Returns null when no variant is present — callers validate variant count

--- a/apps/server/src/ai/providers/walkthrough-tools/phase-b-handlers.ts
+++ b/apps/server/src/ai/providers/walkthrough-tools/phase-b-handlers.ts
@@ -27,6 +27,7 @@ import {
   blockVariantCount,
   buildBlock,
   emptyBlockError,
+  withArtifactThemingWarning,
 } from "../walkthrough-blocks";
 import {
   blockIdFor,
@@ -264,7 +265,10 @@ export const addSemanticStepHandler: WalkthroughToolHandler<AddSemanticStepInput
     });
   }
   return okResult(
-    `Chapter ${input.semantic_step_index} ('${trimmedTitle}') opened with its first block at step_index=0. Add 1–4 more atomic blocks for this chapter via add_diff_step({ semantic_step_index: ${input.semantic_step_index}, step_index: 1, ... }) — step_index 2, 3, 4 for the rest. When this chapter is full, open the next chapter via another add_semantic_step call. Do not call set_sentiment until every planned chapter is filled.`,
+    withArtifactThemingWarning(
+      `Chapter ${input.semantic_step_index} ('${trimmedTitle}') opened with its first block at step_index=0. Add 1–4 more atomic blocks for this chapter via add_diff_step({ semantic_step_index: ${input.semantic_step_index}, step_index: 1, ... }) — step_index 2, 3, 4 for the rest. When this chapter is full, open the next chapter via another add_semantic_step call. Do not call set_sentiment until every planned chapter is filled.`,
+      input.initial_block,
+    ),
   );
 };
 
@@ -284,6 +288,12 @@ export const addDiffStepHandler: WalkthroughToolHandler<AddDiffStepInput> = asyn
   }
   const emptyErr = emptyBlockError(input);
   if (emptyErr) return errorResult(emptyErr);
+  const variant = {
+    markdown: input.markdown,
+    code: input.code,
+    diff: input.diff,
+    artifact: input.artifact,
+  };
 
   let result: WalkthroughToolResult | null = null;
   let block: WalkthroughBlock | null = null;
@@ -332,7 +342,7 @@ export const addDiffStepHandler: WalkthroughToolHandler<AddDiffStepInput> = asyn
         order: input.semantic_step_index * 10000 + input.step_index,
         createdAt: now,
       },
-      { markdown: input.markdown, code: input.code, diff: input.diff, artifact: input.artifact },
+      variant,
     );
   });
   if (result) return result;
@@ -342,7 +352,10 @@ export const addDiffStepHandler: WalkthroughToolHandler<AddDiffStepInput> = asyn
 
   ctx.emit({ type: "block", data: block });
   return okResult(
-    `Atomic block persisted at chapter ${input.semantic_step_index}, step ${input.step_index}. Continue with more blocks in this chapter, open the next chapter with add_semantic_step, or call set_sentiment when Phase B is done.`,
+    withArtifactThemingWarning(
+      `Atomic block persisted at chapter ${input.semantic_step_index}, step ${input.step_index}. Continue with more blocks in this chapter, open the next chapter with add_semantic_step, or call set_sentiment when Phase B is done.`,
+      variant,
+    ),
   );
 };
 

--- a/apps/server/src/ai/providers/walkthrough-tools/spec.ts
+++ b/apps/server/src/ai/providers/walkthrough-tools/spec.ts
@@ -139,7 +139,7 @@ const artifactBlockSchema = z
     html: z
       .string()
       .describe(
-        "A complete, self-contained HTML document with inline CSS/JS. Vanilla JS only; no external network/CDN; no localStorage. Renders in a sandboxed iframe. Style with the injected Revv theme variables (`var(--color-*)`, `var(--font-*)`) so it matches the app and follows light/dark — never hardcode colors. See the system prompt for the full token list and design rules.",
+        "A complete, self-contained HTML document with inline CSS/JS. Vanilla JS only; no external network/CDN; no localStorage. Renders in a sandboxed iframe. Style with the injected Revv theme variables (`var(--color-*)`, `var(--font-*)`) so it matches the app and follows light/dark — never hardcode colors or font-family. See the system prompt for the full token list and design rules.",
       ),
     annotation: z.string().nullable(),
     annotation_position: z.enum(["left", "right"]),


### PR DESCRIPTION
Adds a warn-only artifact theming lint at the shared walkthrough block write boundary, covering hardcoded color literals, functional color notation, and literal font-family values. Wires the warning into both generation and chat-edit MCP write paths while still persisting the block. Updates tool/prompt guidance so artifacts use injected Revv theme variables and are required for worked examples or complex explanations. Adds focused Bun coverage for clean artifacts, false-positive boundaries, color/function literals, font-family handling, and non-artifact inputs.\n\nVerification: `cd apps/server && bun test src/ai/providers/walkthrough-blocks.test.ts`; `bun run typecheck && bun run lint && bun run knip && bun run build`.