### PR TITLE
fix: large PR file lists

### DIFF
--- a/apps/server/src/routes/prs.ts
+++ b/apps/server/src/routes/prs.ts
@@ -221,7 +221,13 @@ export const prRoutes = new Elysia({ prefix: "/api/prs" })
             // Always the full PR diff (merge-base 3-dot, matching GitHub's
             // "Files changed" tab). No per-commit selection anymore — the
             // commits dropdown is read-only.
-            const files = yield* getOrFetchDiffFiles(pr.id, repo.fullName, pr.externalId, token);
+            const files = yield* getOrFetchDiffFiles(
+              pr.id,
+              repo.fullName,
+              pr.externalId,
+              token,
+              pr.changedFiles,
+            );
             const session = yield* reviewService.getActiveSession(pr.id);
             const threads = session ? yield* reviewService.getThreadsForSession(session.id) : [];
             return { files, threads };

--- a/apps/server/src/services/DiffCache.test.ts
+++ b/apps/server/src/services/DiffCache.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { type CachedDiffFile, hasCompleteCachedFiles } from "./DiffCache";
+import { PR_FILES_MAX_COUNT } from "./GitHub";
+
+function cachedFile(path: string): CachedDiffFile {
+  return {
+    path,
+    oldPath: null,
+    status: "modified",
+    additions: 1,
+    deletions: 0,
+    patch: null,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("hasCompleteCachedFiles", () => {
+  it("accepts cached files when no expected count is available", () => {
+    expect(hasCompleteCachedFiles([cachedFile("src/a.ts")])).toBe(true);
+  });
+
+  it("rejects cached files below the PR changed-files count", () => {
+    expect(hasCompleteCachedFiles([cachedFile("src/a.ts")], 2)).toBe(false);
+  });
+
+  it("caps the expected count to the GitHub files endpoint range", () => {
+    const files = Array.from({ length: PR_FILES_MAX_COUNT }, (_, i) => cachedFile(`src/${i}.ts`));
+    expect(hasCompleteCachedFiles(files, PR_FILES_MAX_COUNT + 1)).toBe(true);
+  });
+});

--- a/apps/server/src/services/DiffCache.ts
+++ b/apps/server/src/services/DiffCache.ts
@@ -4,7 +4,7 @@ import { prDiffFiles } from "../db/schema/index";
 import type { GitHubError } from "../domain/errors";
 import { withDb } from "../effects/with-db";
 import { DbService } from "./Db";
-import { GitHubGateway } from "./GitHub";
+import { GitHubGateway, PR_FILES_MAX_COUNT } from "./GitHub";
 import type { GitHubEtagCache } from "./GitHubEtagCache";
 import type { SettingsService } from "./Settings";
 
@@ -103,6 +103,14 @@ export const DiffCacheServiceLive = Layer.succeed(DiffCacheService, {
     }),
 });
 
+export function hasCompleteCachedFiles(
+  cached: readonly CachedDiffFile[],
+  expectedChangedFiles?: number,
+): boolean {
+  if (expectedChangedFiles === undefined) return true;
+  return cached.length >= Math.min(expectedChangedFiles, PR_FILES_MAX_COUNT);
+}
+
 /**
  * Get diff files from cache, or fetch from GitHub on a cache miss.
  * Errors from GitHub propagate to the caller.
@@ -112,6 +120,7 @@ export const getOrFetchDiffFiles = (
   repoFullName: string,
   prExternalId: number,
   token: string,
+  expectedChangedFiles?: number,
 ): Effect.Effect<
   CachedDiffFile[],
   GitHubError,
@@ -123,7 +132,7 @@ export const getOrFetchDiffFiles = (
     const { db } = yield* DbService;
 
     const cached = yield* withDb(db, diffCache.getCachedFiles(prId));
-    if (cached !== null) return cached;
+    if (cached !== null && hasCompleteCachedFiles(cached, expectedChangedFiles)) return cached;
 
     const fileList = yield* github.prs.files(repoFullName, prExternalId, token);
     const files: CachedDiffFile[] = fileList.map((f) => ({

--- a/apps/server/src/services/GitHub.test.ts
+++ b/apps/server/src/services/GitHub.test.ts
@@ -81,6 +81,16 @@ function rawPr(number: number): Record<string, unknown> {
   };
 }
 
+function rawPrFile(filename: string): Record<string, unknown> {
+  return {
+    filename,
+    status: "modified",
+    additions: 1,
+    deletions: 0,
+    patch: `@@ -1 +1 @@\n-${filename}\n+${filename}`,
+  };
+}
+
 describe("GitHubGateway rate-limit handling", () => {
   it("classifies Retry-After responses as rate limits without retrying", async () => {
     const db = createDb(":memory:");
@@ -115,6 +125,38 @@ describe("GitHubGateway rate-limit handling", () => {
 });
 
 describe("GitHubGateway conditional pagination", () => {
+  it("fetches all changed files across paginated PR files responses", async () => {
+    const db = createDb(":memory:");
+    const firstPage = Array.from({ length: 100 }, (_, i) => rawPrFile(`src/page-${i + 1}.ts`));
+    const secondPage = Array.from({ length: 25 }, (_, i) => rawPrFile(`src/page-${i + 101}.ts`));
+    const calls = stubFetch((_call, index) => {
+      if (index === 0) {
+        return responseJson(firstPage, {
+          headers: {
+            Link: '<https://api.github.test/repos/octo/repo/pulls/1/files?per_page=100&page=2>; rel="next"',
+          },
+        });
+      }
+      return responseJson(secondPage);
+    });
+
+    const files = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        return yield* github.prs.files("octo/repo", 1, "token");
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(files).toHaveLength(125);
+    expect(files[0]?.filename).toBe("src/page-1.ts");
+    expect(files.at(-1)?.filename).toBe("src/page-125.ts");
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.url).toBe("https://api.github.com/repos/octo/repo/pulls/1/files?per_page=100");
+    expect(calls[1]?.url).toBe(
+      "https://api.github.test/repos/octo/repo/pulls/1/files?per_page=100&page=2",
+    );
+  });
+
   it("keeps review comments incremental and uncached", async () => {
     const db = createDb(":memory:");
     const calls = stubFetch((_call, index) => {

--- a/apps/server/src/services/GitHub.ts
+++ b/apps/server/src/services/GitHub.ts
@@ -126,6 +126,10 @@ export interface PrFileMeta {
   readonly patch: string | null;
 }
 
+const PR_FILES_PAGE_SIZE = 100;
+export const PR_FILES_MAX_PAGES = 30;
+export const PR_FILES_MAX_COUNT = PR_FILES_PAGE_SIZE * PR_FILES_MAX_PAGES;
+
 export interface PrCommit {
   readonly sha: string;
   readonly message: string;
@@ -786,9 +790,12 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
     Effect.gen(function* () {
       const apiBase = yield* resolveApiBase;
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
-      const data = yield* conditionalFetch(
-        `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100`,
+      // GitHub returns PR files in 100-file pages. Fetch the endpoint's full
+      // supported range so large PRs don't cache an incomplete sidebar/diff.
+      const data = yield* githubFetchPaginated(
+        `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=${PR_FILES_PAGE_SIZE}`,
         token,
+        PR_FILES_MAX_PAGES,
         apiBase,
       );
       return (data as Record<string, unknown>[]).map((f) => ({

--- a/apps/server/src/services/PrContext.ts
+++ b/apps/server/src/services/PrContext.ts
@@ -5,7 +5,7 @@ import { repositories } from "../db/schema";
 import { GitHubAuthError, type GitHubError, type NotFoundError } from "../domain/errors";
 import { withDb } from "../effects/with-db";
 import { DbService } from "./Db";
-import { type CachedDiffFile, DiffCacheService } from "./DiffCache";
+import { type CachedDiffFile, DiffCacheService, hasCompleteCachedFiles } from "./DiffCache";
 import { GitHubGateway, type PrCommit, type PrFileMeta, type PrMeta } from "./GitHub";
 import type { GitHubEtagCache } from "./GitHubEtagCache";
 import { PullRequestService } from "./PullRequest";
@@ -182,11 +182,12 @@ export const PrContextServiceLive = Layer.effect(
       repoFullName: string,
       prExternalId: number,
       token: string,
+      expectedChangedFiles: number,
     ) =>
       Effect.gen(function* () {
         const { db } = yield* DbService;
         const cached = yield* withDb(db, diffCache.getCachedFiles(prId));
-        if (cached !== null) return cached;
+        if (cached !== null && hasCompleteCachedFiles(cached, expectedChangedFiles)) return cached;
         const fileList = yield* github.prs.files(repoFullName, prExternalId, token);
         const fresh: CachedDiffFile[] = fileList.map((f) => ({
           path: f.filename,
@@ -210,6 +211,7 @@ export const PrContextServiceLive = Layer.effect(
           basic.repo.fullName,
           basic.pr.externalId,
           basic.token,
+          basic.pr.changedFiles,
         );
         const files = cachedFiles.map((f) => ({
           filename: f.path,


### PR DESCRIPTION
Fixes large PR file lists by paginating GitHub PR file responses instead of caching only the first 100 files.
Adds cache completeness checks against the PR changed-file count so existing incomplete caches refetch, including for PR context and review file APIs.
Adds regression coverage for paginated GitHub file responses and cache completeness behavior, and includes the existing desktop Cargo.lock version alignment.
Validated with `bun test apps/server/src/services/GitHub.test.ts apps/server/src/services/DiffCache.test.ts` and `bun run typecheck && bun run lint && bun run knip && bun run build`.