### PR TITLE
fix: creator and team filters + search by creator

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.10.0"
+version = "0.12.0"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/routes/github.ts
+++ b/apps/server/src/routes/github.ts
@@ -1,4 +1,4 @@
-import type { Repository, Team } from "@revv/shared";
+import type { Repository } from "@revv/shared";
 import { Effect } from "effect";
 import { Elysia, t } from "elysia";
 import { REPO_CACHE_TTL_MS } from "../constants";
@@ -78,10 +78,7 @@ export const githubRoutes = new Elysia({ prefix: "/api/github" })
         }),
       );
       return { teams };
-    } catch {
-      // Teams are a best-effort enhancement (needs `read:org` and org
-      // membership). Degrade to an empty list rather than failing the
-      // filter UI — the popover just falls back to per-creator filtering.
-      return { teams: [] as Team[] };
+    } catch (e) {
+      return handleAppError(e, ctx);
     }
   });

--- a/apps/server/src/services/GitHub.ts
+++ b/apps/server/src/services/GitHub.ts
@@ -6,7 +6,7 @@ import type {
   Repository,
   Team,
 } from "@revv/shared";
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Either, Layer } from "effect";
 import { serverEnv } from "../config";
 import { type GitHubError, GitHubNotFoundError } from "../domain/errors";
 import type { DbService } from "./Db";
@@ -203,11 +203,9 @@ interface GitHubGatewayFlatService {
   ) => Effect.Effect<Map<string, number>, GitHubError, SettingsService>;
   readonly listUserOrgs: (token: string) => Effect.Effect<Org[], GitHubError, SettingsService>;
   /**
-   * Teams (and their members) for a single org, fetched in one GraphQL call.
-   * Requires the token to carry the `read:org` scope and the user to be an
-   * org member; otherwise GitHub returns `organization: null` and this
-   * resolves to an empty list (callers treat teams as a best-effort
-   * enhancement). Capped at the first 100 teams and 100 members per team.
+   * Teams (and their members) for a single org. Requires the token to carry
+   * the `read:org` scope and the user to be an org member; otherwise GitHub
+   * may deny the request and callers treat teams as a best-effort enhancement.
    */
   readonly listTeamsForOrg: (
     org: string,
@@ -679,7 +677,8 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
   listTeamsForOrg: (org, token, explicitApiBase) =>
     Effect.gen(function* () {
       const apiBase = explicitApiBase ?? (yield* resolveApiBase);
-      const query = `query OrgTeams($org: String!) {
+      const fromGraphql = Effect.gen(function* () {
+        const query = `query OrgTeams($org: String!) {
         organization(login: $org) {
           teams(first: 100, orderBy: { field: NAME, direction: ASC }) {
             nodes {
@@ -691,42 +690,81 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         }
       }`;
 
-      // Fetch directly rather than via the shared `githubGraphql` helper:
-      // for orgs the user can't see teams in (missing `read:org`, SAML, or
-      // non-membership) GitHub answers 200 with `organization: null` and a
-      // top-level `errors` array. The helper rejects on any `errors`; here
-      // we tolerate the partial response and degrade to "no teams".
-      const response = yield* Effect.tryPromise({
-        try: async () => {
-          const res = await fetch(`${apiBase}/graphql`, {
-            method: "POST",
-            headers: { ...githubHeaders(token), "Content-Type": "application/json" },
-            body: JSON.stringify({ query, variables: { org } }),
-          });
-          assertGitHubOk(res, "/graphql");
-          return (await res.json()) as {
-            data?: {
-              organization: {
-                teams: {
-                  nodes: Array<{
-                    slug: string;
-                    name: string;
-                    members: { nodes: Array<{ login: string }> };
-                  }>;
-                };
-              } | null;
+        // Fetch directly rather than via the shared `githubGraphql` helper:
+        // for orgs the user can't see teams in (missing `read:org`, SAML, or
+        // non-membership) GitHub answers 200 with `organization: null` and a
+        // top-level `errors` array. The helper rejects on any `errors`; here
+        // we tolerate the partial response and let the REST fallback decide.
+        const response = yield* Effect.tryPromise({
+          try: async () => {
+            const res = await fetch(`${apiBase}/graphql`, {
+              method: "POST",
+              headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+              body: JSON.stringify({ query, variables: { org } }),
+            });
+            assertGitHubOk(res, "/graphql");
+            return (await res.json()) as {
+              data?: {
+                organization: {
+                  teams: {
+                    nodes: Array<{
+                      slug: string;
+                      name: string;
+                      members: { nodes: Array<{ login: string }> };
+                    }>;
+                  };
+                } | null;
+              };
             };
-          };
-        },
-        catch: toGitHubError,
+          },
+          catch: toGitHubError,
+        });
+
+        const nodes = response.data?.organization?.teams?.nodes ?? [];
+        return nodes.map((team) => ({
+          slug: team.slug,
+          name: team.name,
+          memberLogins: (team.members?.nodes ?? []).map((m) => m.login),
+        }));
       });
 
-      const nodes = response.data?.organization?.teams?.nodes ?? [];
-      return nodes.map((team) => ({
-        slug: team.slug,
-        name: team.name,
-        memberLogins: (team.members?.nodes ?? []).map((m) => m.login),
-      }));
+      const fromRest = Effect.gen(function* () {
+        const teamRows = (yield* githubFetchPaginated(
+          `/orgs/${encodeURIComponent(org)}/teams?per_page=100`,
+          token,
+          5,
+          apiBase,
+        )) as Array<{ slug: string; name: string }>;
+
+        return yield* Effect.forEach(
+          teamRows,
+          (team) =>
+            Effect.gen(function* () {
+              const members = (yield* githubFetchPaginated(
+                `/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(team.slug)}/members?per_page=100`,
+                token,
+                10,
+                apiBase,
+              )) as Array<{ login: string }>;
+
+              return {
+                slug: team.slug,
+                name: team.name,
+                memberLogins: members.map((member) => member.login),
+              };
+            }),
+          { concurrency: 4 },
+        );
+      });
+
+      const graphqlResult = yield* Effect.either(fromGraphql);
+      if (Either.isRight(graphqlResult)) {
+        const graphqlTeams = graphqlResult.right;
+        if (graphqlTeams.some((team) => team.memberLogins.length > 0)) return graphqlTeams;
+        return yield* fromRest.pipe(Effect.catchAll(() => Effect.succeed(graphqlTeams)));
+      }
+
+      return yield* fromRest;
     }).pipe(retryTransient),
 
   getPrMeta: (repoFullName, prNumber, token) =>

--- a/apps/web/src/lib/components/sidebar/AuthorFilter.svelte
+++ b/apps/web/src/lib/components/sidebar/AuthorFilter.svelte
@@ -2,6 +2,8 @@
 import CaretRight from "phosphor-svelte/lib/CaretRight";
 import Check from "phosphor-svelte/lib/Check";
 import Funnel from "phosphor-svelte/lib/Funnel";
+import MagnifyingGlass from "phosphor-svelte/lib/MagnifyingGlass";
+import Spinner from "phosphor-svelte/lib/Spinner";
 import User from "phosphor-svelte/lib/User";
 import UsersThree from "phosphor-svelte/lib/UsersThree";
 import * as Popover from "$lib/components/ui/popover";
@@ -11,6 +13,7 @@ import {
   getAuthorFilterOptions,
   getRepoOwner,
   getSelectedAuthorLogins,
+  getTeamsFetchStateForOrg,
   getTeamsForOrg,
   setAuthorFilters,
   toggleAuthorFilter,
@@ -25,8 +28,15 @@ let open = $state(false);
 let failedAvatars = $state<Set<string>>(new Set());
 let teamsCollapsed = $state(false);
 let creatorsCollapsed = $state(false);
+let creatorQuery = $state("");
 
 const options = $derived(getAuthorFilterOptions(repoId));
+const normalizedCreatorQuery = $derived(creatorQuery.trim().toLowerCase());
+const visibleOptions = $derived(
+  normalizedCreatorQuery === ""
+    ? options
+    : options.filter((option) => option.login.toLowerCase().includes(normalizedCreatorQuery)),
+);
 const selected = $derived(getSelectedAuthorLogins());
 const selectedCount = $derived(selected.size);
 const selectedLabel = $derived(
@@ -40,21 +50,34 @@ const selectedLabel = $derived(
 // Teams for the repo's owning org, narrowed to members who actually have an
 // open PR here — a team you can't filter anyone down to isn't worth showing.
 const owner = $derived(repoId ? getRepoOwner(repoId) : null);
-const optionLogins = $derived(new Set(options.map((o) => o.login)));
+const teamsFetchState = $derived(owner ? getTeamsFetchStateForOrg(owner) : "idle");
+const optionLoginByKey = $derived(
+  new Map(options.map((option) => [option.login.toLowerCase(), option.login])),
+);
 const teamRows = $derived(
   (owner ? getTeamsForOrg(owner) : [])
     .map((team) => ({
       slug: team.slug,
       name: team.name,
-      members: team.memberLogins.filter((login) => optionLogins.has(login)),
+      members: [
+        ...new Set(
+          team.memberLogins
+            .map((login) => optionLoginByKey.get(login.toLowerCase()))
+            .filter((login): login is string => login !== undefined),
+        ),
+      ],
     }))
     .filter((team) => team.members.length > 0)
     .sort((a, b) => b.members.length - a.members.length || a.name.localeCompare(b.name)),
 );
+const showTeamsSection = $derived(
+  owner !== null && (teamsFetchState !== "idle" || teamRows.length > 0),
+);
 
-// Fetch the org's teams the first time the popover opens (idempotent).
+// Fetch the org's teams when the repo filter mounts. The request is
+// idempotent, so the popover usually opens with the team state already known.
 $effect(() => {
-  if (open && owner) void fetchTeamsForOrg(owner);
+  if (owner) void fetchTeamsForOrg(owner);
 });
 
 function markAvatarFailed(login: string): void {
@@ -67,6 +90,10 @@ function isTeamChecked(members: string[]): boolean {
 
 function toggleTeam(members: string[]): void {
   setAuthorFilters(members, !isTeamChecked(members));
+}
+
+function retryTeams(): void {
+  if (owner) void fetchTeamsForOrg(owner, { force: true });
 }
 </script>
 
@@ -86,43 +113,67 @@ function toggleTeam(members: string[]): void {
 {/snippet}
 
 {#snippet creatorRows()}
-	{#each options as option (option.login)}
-		{@const checked = selected.has(option.login)}
-		<button
-			type="button"
-			class="author-option"
-			class:author-option--checked={checked}
-			onclick={() => toggleAuthorFilter(option.login)}
-			aria-pressed={checked}
-		>
-			<span class="check-slot" aria-hidden="true">
-				{#if checked}
-					<Check size={12} weight="bold" />
-				{/if}
-			</span>
-
-			{#if option.avatarContent && !failedAvatars.has(option.login)}
-				<img
-					src={option.avatarContent}
-					alt=""
-					class="avatar"
-					loading="lazy"
-					referrerpolicy="no-referrer"
-					onerror={() => markAvatarFailed(option.login)}
-				/>
-			{:else}
-				<span class="avatar avatar--fallback" aria-hidden="true">
-					<User size={10} />
+	{#if visibleOptions.length > 0}
+		{#each visibleOptions as option (option.login)}
+			{@const checked = selected.has(option.login)}
+			<button
+				type="button"
+				class="author-option"
+				class:author-option--checked={checked}
+				onclick={() => toggleAuthorFilter(option.login)}
+				aria-pressed={checked}
+			>
+				<span class="check-slot" aria-hidden="true">
+					{#if checked}
+						<Check size={12} weight="bold" />
+					{/if}
 				</span>
-			{/if}
 
-			<span class="login" title={option.login}>{option.login}</span>
-			<span class="count">{option.count}</span>
-		</button>
-	{/each}
+				{#if option.avatarContent && !failedAvatars.has(option.login)}
+					<img
+						src={option.avatarContent}
+						alt=""
+						class="avatar"
+						loading="lazy"
+						referrerpolicy="no-referrer"
+						onerror={() => markAvatarFailed(option.login)}
+					/>
+				{:else}
+					<span class="avatar avatar--fallback" aria-hidden="true">
+						<User size={10} />
+					</span>
+				{/if}
+
+				<span class="login" title={option.login}>{option.login}</span>
+				<span class="count">{option.count}</span>
+			</button>
+		{/each}
+	{:else}
+		<div class="team-state-row">
+			<span>No creators match</span>
+		</div>
+	{/if}
 {/snippet}
 
-{#if options.length > 1 || teamRows.length > 0 || selectedCount > 0}
+{#snippet teamStateRow()}
+	{#if teamsFetchState === "loading"}
+		<div class="team-state-row">
+			<Spinner size={12} class="motion-essential-spin" aria-hidden="true" />
+			<span>Loading teams</span>
+		</div>
+	{:else if teamsFetchState === "error"}
+		<button type="button" class="team-state-row team-state-row--button" onclick={retryTeams}>
+			<span>Teams unavailable</span>
+			<span class="team-state-action">Retry</span>
+		</button>
+	{:else if teamRows.length === 0}
+		<div class="team-state-row">
+			<span>No teams match current PR creators</span>
+		</div>
+	{/if}
+{/snippet}
+
+{#if options.length > 1 || showTeamsSection || selectedCount > 0}
 	<Popover.Root bind:open>
 		<Popover.Trigger
 			class={`filter-trigger${selectedCount > 0 ? " filter-trigger--active" : ""}`}
@@ -142,42 +193,57 @@ function toggleTeam(members: string[]): void {
 					<button type="button" class="popover-clear" onclick={clearAuthorFilters}>Clear</button>
 				{/if}
 			</div>
+			<label class="creator-search">
+				<MagnifyingGlass size={12} aria-hidden="true" />
+				<input
+					bind:value={creatorQuery}
+					type="search"
+					placeholder="Search creators"
+					aria-label="Search creators"
+					spellcheck="false"
+					autocomplete="off"
+				/>
+			</label>
 
 			<div class="filter-scroll">
-				{#if teamRows.length > 0}
+				{#if showTeamsSection}
 					{@render sectionHeader("Teams", teamRows.length, teamsCollapsed, () => {
 						teamsCollapsed = !teamsCollapsed;
 					})}
 					{#if !teamsCollapsed}
-						<div class="author-list">
-							{#each teamRows as team (team.slug)}
-								{@const checked = isTeamChecked(team.members)}
-								<button
-									type="button"
-									class="author-option"
-									class:author-option--checked={checked}
-									onclick={() => toggleTeam(team.members)}
-									aria-pressed={checked}
-									title={`Everyone on @${team.name} with an open PR`}
-								>
-									<span class="check-slot" aria-hidden="true">
-										{#if checked}
-											<Check size={12} weight="bold" />
-										{/if}
-									</span>
+						{#if teamRows.length > 0}
+							<div class="author-list">
+								{#each teamRows as team (team.slug)}
+									{@const checked = isTeamChecked(team.members)}
+									<button
+										type="button"
+										class="author-option"
+										class:author-option--checked={checked}
+										onclick={() => toggleTeam(team.members)}
+										aria-pressed={checked}
+										title={`Everyone on @${team.name} with an open PR`}
+									>
+										<span class="check-slot" aria-hidden="true">
+											{#if checked}
+												<Check size={12} weight="bold" />
+											{/if}
+										</span>
 
-									<span class="avatar avatar--fallback" aria-hidden="true">
-										<UsersThree size={11} />
-									</span>
+										<span class="avatar avatar--fallback" aria-hidden="true">
+											<UsersThree size={11} />
+										</span>
 
-									<span class="login" title={team.name}>{team.name}</span>
-									<span class="count">{team.members.length}</span>
-								</button>
-							{/each}
-						</div>
+										<span class="login" title={team.name}>{team.name}</span>
+										<span class="count">{team.members.length}</span>
+									</button>
+								{/each}
+							</div>
+						{:else}
+							{@render teamStateRow()}
+						{/if}
 					{/if}
 
-					{@render sectionHeader("Creators", options.length, creatorsCollapsed, () => {
+					{@render sectionHeader("Creators", visibleOptions.length, creatorsCollapsed, () => {
 						creatorsCollapsed = !creatorsCollapsed;
 					})}
 					{#if !creatorsCollapsed}
@@ -259,6 +325,38 @@ function toggleTeam(members: string[]): void {
 
 	.popover-clear:hover {
 		color: var(--color-text-primary);
+	}
+
+	.creator-search {
+		display: grid;
+		grid-template-columns: 14px minmax(0, 1fr);
+		align-items: center;
+		gap: 6px;
+		min-height: 28px;
+		border: 1px solid var(--color-border);
+		border-radius: 6px;
+		padding: 0 7px;
+		background: var(--color-bg-secondary);
+		color: var(--color-text-muted);
+	}
+
+	.creator-search:focus-within {
+		border-color: var(--color-border-strong);
+		color: var(--color-text-secondary);
+	}
+
+	.creator-search input {
+		min-width: 0;
+		border: 0;
+		outline: 0;
+		background: transparent;
+		color: var(--color-text-primary);
+		font-size: 11px;
+		line-height: 1;
+	}
+
+	.creator-search input::placeholder {
+		color: var(--color-text-muted);
 	}
 
 	/* Single scroll region for both sections: scrolling carries the user past
@@ -343,6 +441,33 @@ function toggleTeam(members: string[]): void {
 	.author-option--checked {
 		background: var(--color-bg-tertiary);
 		color: var(--color-text-primary);
+	}
+
+	.team-state-row {
+		display: flex;
+		align-items: center;
+		gap: 7px;
+		min-height: 30px;
+		padding: 4px 6px 4px 21px;
+		border-radius: 6px;
+		color: var(--color-text-muted);
+		font-size: 11px;
+		text-align: left;
+	}
+
+	.team-state-row--button {
+		width: 100%;
+		justify-content: space-between;
+	}
+
+	.team-state-row--button:hover {
+		background: var(--color-bg-tertiary);
+		color: var(--color-text-secondary);
+	}
+
+	.team-state-action {
+		color: var(--color-accent);
+		font-weight: 600;
 	}
 
 	.check-slot {

--- a/apps/web/src/lib/stores/prs.svelte.ts
+++ b/apps/web/src/lib/stores/prs.svelte.ts
@@ -49,6 +49,7 @@ let selectedAuthorLogins = $state<Set<string>>(new Set());
 // (org has no teams, or the token lacks `read:org`).
 let teamsByOrg = $state<Map<string, Team[]>>(new Map());
 let teamsLoadingByOrg = $state<Map<string, boolean>>(new Map());
+let teamsFailedByOrg = $state<Map<string, boolean>>(new Map());
 let isLoading = $state(false);
 let archivedPrs = $state<PullRequest[]>([]);
 // Cursor for the next page of archived PRs. Null = exhausted or never
@@ -556,27 +557,46 @@ export function getTeamsForOrg(owner: string): Team[] {
   return teamsByOrg.get(owner.toLowerCase()) ?? [];
 }
 
+export function getTeamsFetchStateForOrg(owner: string): "idle" | "loading" | "loaded" | "error" {
+  const key = owner.toLowerCase();
+  if (teamsLoadingByOrg.get(key)) return "loading";
+  if (teamsFailedByOrg.get(key)) return "error";
+  if (teamsByOrg.has(key)) return "loaded";
+  return "idle";
+}
+
 /**
  * Lazily fetch an org's teams (and members) the first time they're needed.
  * Idempotent: no-ops once a result is cached or a request is already in
- * flight. Best-effort — failures resolve to an empty team list so the
- * creator filter keeps working without teams.
+ * flight. Best-effort — failures leave the entry uncached so a later popover
+ * open can retry instead of pinning a transient error as "no teams".
  */
-export async function fetchTeamsForOrg(owner: string): Promise<void> {
+export async function fetchTeamsForOrg(
+  owner: string,
+  options?: { force?: boolean },
+): Promise<void> {
   const key = owner.toLowerCase();
-  if (teamsByOrg.has(key) || teamsLoadingByOrg.get(key)) return;
+  if (!options?.force && (teamsByOrg.has(key) || teamsLoadingByOrg.get(key))) return;
+  if (options?.force) {
+    const nextTeams = new Map(teamsByOrg);
+    nextTeams.delete(key);
+    teamsByOrg = nextTeams;
+  }
   teamsLoadingByOrg = new Map(teamsLoadingByOrg).set(key, true);
+  teamsFailedByOrg = new Map(teamsFailedByOrg).set(key, false);
   try {
-    const { data } = await api.api.github.teams({ org: owner }).get();
-    // Cache the result — including an empty list — so reopening the popover
-    // never re-hits the network. The server already degrades to `{ teams: [] }`
-    // when teams aren't visible (no `read:org`, not a member), so an empty
-    // array here is a real answer, not a failure to retry on every open.
+    const { data, error } = await api.api.github.teams({ org: owner }).get();
+    if (error) {
+      teamsFailedByOrg = new Map(teamsFailedByOrg).set(key, true);
+      return;
+    }
+    // Cache successful results — including an empty list — so reopening the
+    // popover never re-hits the network when GitHub answered cleanly.
     teamsByOrg = new Map(teamsByOrg).set(key, (data as { teams: Team[] } | null)?.teams ?? []);
   } catch {
-    // Network/transport error: cache empty so we don't lag every open. A
-    // later `reset()` (account switch / re-login) clears this to retry.
-    teamsByOrg = new Map(teamsByOrg).set(key, []);
+    // Leave the entry uncached. The popover remains usable with creator rows,
+    // and a later open can retry without requiring account reset/re-login.
+    teamsFailedByOrg = new Map(teamsFailedByOrg).set(key, true);
   } finally {
     teamsLoadingByOrg = new Map(teamsLoadingByOrg).set(key, false);
   }
@@ -937,6 +957,7 @@ export function reset(): void {
   selectedAuthorLogins = new Set();
   teamsByOrg = new Map();
   teamsLoadingByOrg = new Map();
+  teamsFailedByOrg = new Map();
   isLoading = false;
   archivedPrs = [];
   archivedNextCursor = null;


### PR DESCRIPTION
Fixes the PR author filter so team fetch failures are surfaced instead of silently collapsing the UI to creators only.
Adds a REST fallback for GitHub org teams/members and preserves retry/error state in the web store.
Adds a creator search field inside the filter popover so users can find a login without scrolling through the full list.
Validated with `bun run typecheck && bun run lint && bun run knip && bun run build`.
