### PR TITLE
refactor: drop legacy claude/opencode/codex refs; consolidate agents onto ACP registry

### DIFF
--- a/apps/server/src/ai/agent-stream/normalized-events.ts
+++ b/apps/server/src/ai/agent-stream/normalized-events.ts
@@ -70,7 +70,7 @@ export type NormalizedAgentEvent =
   | {
       readonly kind: "task-list-update";
       readonly tasks: ReadonlyArray<NormalizedTask>;
-      readonly source: "claude" | "opencode" | "codex" | "acp";
+      readonly source: "acp";
     }
   /**
    * Agent has presented a plan (Claude ExitPlanMode tool, or the opencode
@@ -83,7 +83,7 @@ export type NormalizedAgentEvent =
       readonly kind: "plan-presented";
       readonly markdown: string;
       readonly providerPlanId: string;
-      readonly source: "claude" | "opencode" | "codex";
+      readonly source: "acp";
     }
   /**
    * A sub-agent invocation has started. The driver maintains a closure-side
@@ -96,7 +96,7 @@ export type NormalizedAgentEvent =
       readonly subagentType: string;
       readonly description: string;
       readonly prompt: string;
-      readonly source: "claude" | "opencode" | "codex";
+      readonly source: "acp";
     }
   /**
    * A sub-agent invocation has finished. `ok = false` means the sub-agent
@@ -108,7 +108,7 @@ export type NormalizedAgentEvent =
       readonly providerCallId: string;
       readonly result: string;
       readonly ok: boolean;
-      readonly source: "claude" | "opencode" | "codex";
+      readonly source: "acp";
     }
   /**
    * Agent has asked the user one or more questions and is paused waiting
@@ -126,25 +126,25 @@ export type NormalizedAgentEvent =
   | {
       readonly kind: "user-question-asked";
       readonly providerRequestId: string;
-      readonly source: "claude" | "opencode" | "codex";
+      readonly source: "acp";
       readonly questions: ReadonlyArray<import("@revv/shared").NormalizedQuestion>;
       readonly previewFormat: "markdown" | "html";
       /** Opencode `QuestionRequest.tool.callID`; absent for Claude. */
       readonly providerToolCallId?: string;
     }
   /**
-   * Opencode-only follow-up: the daemon broadcasts `question.replied` /
-   * `question.rejected` after our HTTP POST resolves the question. We emit
+   * Out-of-band resolution follow-up: emitted when the agent surfaces a
+   * question-resolved signal after our reply was POSTed back to it. We emit
    * this so the persistence wrapper can flip the row's status idempotently
    * (the answer endpoint already wrote the DB row on the user-facing path).
    *
-   * Claude doesn't emit this — its resolution lives entirely inside the
-   * answer endpoint (resolve the in-memory deferred and update DB inline).
+   * Agents whose resolution lives entirely inside the answer endpoint
+   * (resolve the in-memory deferred and update DB inline) never emit this.
    */
   | {
       readonly kind: "user-question-resolved";
       readonly providerRequestId: string;
-      readonly source: "opencode";
+      readonly source: "acp";
       readonly status: "answered" | "rejected";
       readonly answers?: Readonly<Record<string, ReadonlyArray<string>>>;
     }

--- a/apps/server/src/ai/providers/chat-edit-tools/spec.ts
+++ b/apps/server/src/ai/providers/chat-edit-tools/spec.ts
@@ -18,11 +18,10 @@ import type { ToolSpec as GatewayToolSpec, McpToolResult } from "../mcp-tool-gat
 // ── Handler execution context ───────────────────────────────────────────────
 
 /**
- * Actor identifier stamped on `walkthroughs.lastEditedBy`. The two values
- * map to the two transports: the in-process Claude SDK and the HTTP MCP
- * route used by the opencode daemon.
+ * Actor identifier stamped on `walkthroughs.lastEditedBy`. All chat edits
+ * run on the unified ACP transport, so the only value today is `'chat:acp'`.
  */
-export type ChatEditActor = "chat:claude" | "chat:opencode" | "chat:codex" | "chat:acp";
+export type ChatEditActor = "chat:acp";
 
 export interface ChatWalkthroughEditContext {
   /** Direct DB handle (Bun sqlite + drizzle). */

--- a/apps/server/src/db/schema/chat-plans.ts
+++ b/apps/server/src/db/schema/chat-plans.ts
@@ -38,7 +38,7 @@ export const chatPlans = sqliteTable(
     planMarkdown: text("plan_markdown").notNull(),
     // 'pending' | 'approved' | 'rejected' | 'superseded'
     status: text("status").notNull().default("pending"),
-    // 'claude' | 'opencode'
+    // Transport that produced the row: always 'acp'.
     source: text("source").notNull(),
     sequence: integer("sequence").notNull(),
     createdAt: text("created_at").notNull(),

--- a/apps/server/src/db/schema/chat-questions.ts
+++ b/apps/server/src/db/schema/chat-questions.ts
@@ -34,7 +34,7 @@ export const chatQuestions = sqliteTable(
       .notNull()
       .references(() => chatSessions.id, { onDelete: "cascade" }),
     turnId: text("turn_id").notNull(),
-    // 'claude' | 'opencode'
+    // Transport that produced the row: always 'acp'.
     source: text("source").notNull(),
     providerRequestId: text("provider_request_id").notNull(),
     // opencode-only — links back to the tool call that issued the question

--- a/apps/server/src/db/schema/chat-sessions.ts
+++ b/apps/server/src/db/schema/chat-sessions.ts
@@ -39,7 +39,7 @@ export const chatSessions = sqliteTable(
     pullRequestId: text("pull_request_id")
       .notNull()
       .references(() => pullRequests.id, { onDelete: "cascade" }),
-    agent: text("agent").notNull(), // 'claude' | 'opencode' | 'codex'
+    agent: text("agent").notNull(), // ACP registry id: 'claude-code' | 'opencode' | 'codex' | 'cursor'
     model: text("model").notNull().default(""),
     sessionId: text("session_id"),
     prHeadSha: text("pr_head_sha").notNull(),

--- a/apps/server/src/db/schema/chat-subagent-invocations.ts
+++ b/apps/server/src/db/schema/chat-subagent-invocations.ts
@@ -46,7 +46,7 @@ export const chatSubagentInvocations = sqliteTable(
     // `content`. Opencode: final assistant text from the sub-agent's
     // message (best-effort). Nullable while running.
     result: text("result"),
-    // 'claude' | 'opencode'
+    // Transport that produced the row: always 'acp'.
     source: text("source").notNull(),
     sequence: integer("sequence").notNull(),
     startedAt: text("started_at").notNull(),

--- a/apps/server/src/db/schema/chat-tasks.ts
+++ b/apps/server/src/db/schema/chat-tasks.ts
@@ -43,7 +43,7 @@ export const chatTasks = sqliteTable(
     status: text("status").notNull(),
     // 'low' | 'medium' | 'high' | NULL
     priority: text("priority"),
-    // 'claude' | 'opencode' — for debugging parity divergence.
+    // Transport that produced the row: always 'acp'.
     source: text("source").notNull(),
     sequence: integer("sequence").notNull(),
     createdAt: text("created_at").notNull(),

--- a/apps/server/src/db/schema/walkthroughs.ts
+++ b/apps/server/src/db/schema/walkthroughs.ts
@@ -103,8 +103,8 @@ export const walkthroughs = sqliteTable(
      */
     lastEditedAt: text("last_edited_at"),
     /**
-     * Actor that performed the most recent chat-driven edit. Typically
-     * `'chat:claude'` or `'chat:opencode'`. Pairs with `lastEditedAt`.
+     * Actor that performed the most recent chat-driven edit — `'chat:acp'`
+     * for chat edits on the ACP transport. Pairs with `lastEditedAt`.
      */
     lastEditedBy: text("last_edited_by"),
     /**

--- a/apps/server/src/routes/chat-helpers.ts
+++ b/apps/server/src/routes/chat-helpers.ts
@@ -297,7 +297,7 @@ export interface ProposedCommit {
  */
 export function wrapStreamWithPersistence(
   source: ReadableStream<RawChatStreamFrame>,
-  ctx: { chatSessionId: string; turnId: string; agent: "claude" | "opencode" | "codex" | "acp" },
+  ctx: { chatSessionId: string; turnId: string; agent: "acp" },
 ): ReadableStream<ChatStreamFrame> {
   return new ReadableStream<ChatStreamFrame>({
     async start(controller) {

--- a/apps/server/src/routes/chat-route-interactions.ts
+++ b/apps/server/src/routes/chat-route-interactions.ts
@@ -3,6 +3,7 @@
 // Elysia sub-router for plan/question/agent interaction endpoints.
 // Composed into the main chatRoute via `.use()`.
 
+import { getAgentCapabilities } from "@revv/shared";
 import { Effect } from "effect";
 import { Elysia, t } from "elysia";
 import { logError } from "../logger";
@@ -243,40 +244,18 @@ export const chatInteractionRoutes = new Elysia()
     },
   )
   // ── Agent availability ─────────────────────────────────────────────────
-  // Lightweight probe the frontend uses to decide whether to enable the
-  // composer's Plan-mode toggle for the opencode path. For Claude the
-  // toggle is always available (the SDK supplies `permissionMode: 'plan'`).
+  // Lightweight lookup the frontend uses to decide whether to enable the
+  // composer's Plan-mode toggle. Plan-mode support is a static per-agent
+  // capability defined once in the shared `ACP_AGENTS` registry, so this
+  // endpoint just echoes the configured agent and its `planMode` flag —
+  // adding a new agent never requires touching this handler.
   .get("/api/chat/agents/available", async (ctx) => {
     try {
       const result = await AppRuntime.runPromise(
         Effect.gen(function* () {
           const settingsService = yield* SettingsService;
           const agent = yield* settingsService.resolveChatAgentId();
-          if (agent === "claude-code") {
-            return {
-              agent: "claude-code" as const,
-              agents: ["plan", "general-purpose"] as readonly string[],
-              // claude-agent-acp advertises a read-only plan mode.
-              planAvailable: true,
-            };
-          }
-          if (agent === "codex") {
-            // Codex currently requires danger-full-access for MCP tool execution,
-            // so there is no enforceable read-only plan turn yet.
-            return {
-              agent: "codex" as const,
-              agents: [] as readonly string[],
-              planAvailable: false,
-            };
-          }
-          // opencode: ships a read-only `plan` agent, which the ACP transport
-          // selects via the session's advertised modes (`findPlanModeId` in
-          // chat-acp). Report it as available without probing a daemon.
-          return {
-            agent: "opencode" as const,
-            agents: ["plan", "general-purpose"] as readonly string[],
-            planAvailable: true,
-          };
+          return { agent, planAvailable: getAgentCapabilities(agent).planMode };
         }),
       );
       return jsonResponse(result, 200);

--- a/apps/server/src/services/ChatMcpTokens.ts
+++ b/apps/server/src/services/ChatMcpTokens.ts
@@ -22,10 +22,10 @@ import { Context, Effect, Layer, Ref } from "effect";
 /**
  * Source transport that minted this token. Stamped on
  * `walkthroughs.lastEditedBy` when an edit MCP tool fires through this
- * registry's HTTP path. The Claude SDK in-process path doesn't go through
- * this registry — it builds its context directly with `actor: 'chat:claude'`.
+ * registry's HTTP path. All chat edits run on the ACP transport, so the
+ * only actor today is `'chat:acp'`.
  */
-export type ChatTokenActor = "chat:opencode" | "chat:codex" | "chat:acp";
+export type ChatTokenActor = "chat:acp";
 
 export interface ChatTokenIssueArgs {
   readonly prId: string;

--- a/apps/server/src/services/ChatSession.ts
+++ b/apps/server/src/services/ChatSession.ts
@@ -100,7 +100,7 @@ export interface ChatTaskRow {
   readonly activeForm: string | null;
   readonly status: "pending" | "in_progress" | "completed";
   readonly priority: "low" | "medium" | "high" | null;
-  readonly source: "claude" | "opencode" | "codex" | "acp";
+  readonly source: "acp";
   readonly sequence: number;
   readonly createdAt: string;
   readonly updatedAt: string;
@@ -112,7 +112,7 @@ export interface ChatPlanRow {
   readonly turnId: string;
   readonly planMarkdown: string;
   readonly status: "pending" | "approved" | "rejected" | "superseded";
-  readonly source: "claude" | "opencode" | "codex" | "acp";
+  readonly source: "acp";
   readonly sequence: number;
   readonly createdAt: string;
   readonly decidedAt: string | null;
@@ -128,7 +128,7 @@ export interface ChatSubagentInvocationRow {
   readonly prompt: string;
   readonly status: "running" | "completed" | "errored";
   readonly result: string | null;
-  readonly source: "claude" | "opencode" | "codex" | "acp";
+  readonly source: "acp";
   readonly sequence: number;
   readonly startedAt: string;
   readonly completedAt: string | null;
@@ -138,7 +138,7 @@ export interface ChatQuestionRow {
   readonly id: string;
   readonly chatSessionId: string;
   readonly turnId: string;
-  readonly source: "claude" | "opencode" | "codex" | "acp";
+  readonly source: "acp";
   readonly providerRequestId: string;
   readonly providerToolCallId: string | null;
   readonly previewFormat: "markdown" | "html";
@@ -292,7 +292,7 @@ export class ChatSessionService extends Context.Tag("ChatSessionService")<
     readonly applyTaskListSnapshot: (params: {
       readonly chatSessionId: string;
       readonly turnId: string;
-      readonly source: "claude" | "opencode" | "codex" | "acp";
+      readonly source: "acp";
       readonly tasks: ReadonlyArray<ChatTask>;
     }) => Effect.Effect<readonly ChatTaskRow[]>;
 
@@ -307,7 +307,7 @@ export class ChatSessionService extends Context.Tag("ChatSessionService")<
     readonly createPlan: (params: {
       readonly chatSessionId: string;
       readonly turnId: string;
-      readonly source: "claude" | "opencode" | "codex" | "acp";
+      readonly source: "acp";
       readonly markdown: string;
     }) => Effect.Effect<ChatPlanRow>;
 
@@ -325,7 +325,7 @@ export class ChatSessionService extends Context.Tag("ChatSessionService")<
     readonly startSubagentInvocation: (params: {
       readonly chatSessionId: string;
       readonly parentTurnId: string;
-      readonly source: "claude" | "opencode" | "codex" | "acp";
+      readonly source: "acp";
       readonly providerCallId: string;
       readonly subagentType: string;
       readonly description: string;
@@ -356,7 +356,7 @@ export class ChatSessionService extends Context.Tag("ChatSessionService")<
     readonly createQuestion: (params: {
       readonly chatSessionId: string;
       readonly turnId: string;
-      readonly source: "claude" | "opencode" | "codex" | "acp";
+      readonly source: "acp";
       readonly providerRequestId: string;
       readonly providerToolCallId?: string | null;
       readonly previewFormat: "markdown" | "html";
@@ -367,8 +367,8 @@ export class ChatSessionService extends Context.Tag("ChatSessionService")<
      * Flip the question's status. Idempotent: if the row is already in a
      * terminal state (anything other than 'pending'), this is a no-op
      * and returns the existing row unchanged. Used by both the user's
-     * answer endpoint and the opencode SSE follow-up handler — whichever
-     * runs second hits the no-op path.
+     * answer endpoint and the agent stream's resolution follow-up —
+     * whichever runs second hits the no-op path.
      */
     readonly decideQuestion: (params: {
       readonly questionId: string;
@@ -1336,7 +1336,7 @@ export const ChatSessionServiceLive = Layer.effect(
           if (existing.status !== "pending") {
             // Idempotent: already resolved — return the existing row
             // untouched so concurrent callers (answer endpoint +
-            // opencode SSE follow-up) settle on the same final state.
+            // stream resolution follow-up) settle on the same final state.
             return rowToQuestionRow(existing);
           }
           const now = nowIso();

--- a/apps/web/src/lib/api/chat.ts
+++ b/apps/web/src/lib/api/chat.ts
@@ -9,6 +9,7 @@
 // from SQLite on mount instead of starting empty after a desktop reload.
 
 import type {
+  AcpAgentId,
   Activity,
   ActivityKind,
   ChatStreamFrame,
@@ -366,8 +367,7 @@ export async function submitQuestionAnswer(
 }
 
 export interface AvailableAgents {
-  agent: "claude" | "opencode" | "codex";
-  agents: readonly string[];
+  agent: AcpAgentId;
   planAvailable: boolean;
 }
 
@@ -425,7 +425,7 @@ export interface PersistedChatPlan {
   turnId: string;
   planMarkdown: string;
   status: "pending" | "approved" | "rejected" | "superseded";
-  source: "claude" | "opencode" | "codex";
+  source: "acp";
   sequence: number;
   createdAt: string;
   decidedAt: string | null;
@@ -442,7 +442,7 @@ export interface PersistedChatSubagent {
   prompt: string;
   status: "running" | "completed" | "errored";
   result: string | null;
-  source: "claude" | "opencode" | "codex";
+  source: "acp";
   sequence: number;
   startedAt: string;
   completedAt: string | null;
@@ -453,7 +453,7 @@ export interface PersistedChatQuestion {
   id: string;
   chatSessionId: string;
   turnId: string;
-  source: "claude" | "opencode" | "codex";
+  source: "acp";
   providerRequestId: string;
   providerToolCallId: string | null;
   previewFormat: "markdown" | "html";

--- a/apps/web/src/lib/stores/chat.svelte.ts
+++ b/apps/web/src/lib/stores/chat.svelte.ts
@@ -254,7 +254,6 @@ export async function loadAvailableAgents(): Promise<void> {
     // Best-effort — the composer falls back to disabled plan mode.
     availableAgents = {
       agent: "opencode",
-      agents: [],
       planAvailable: false,
     };
   } finally {

--- a/packages/shared/src/acp-agents.ts
+++ b/packages/shared/src/acp-agents.ts
@@ -39,6 +39,13 @@ export interface AcpAgentCapabilities {
   readonly contextWindow: boolean;
   /** Thinking-effort tiers offered; empty = no thinking-effort control. */
   readonly thinkingEfforts: readonly ThinkingEffort[];
+  /**
+   * Whether the agent supports a read-only plan turn — i.e. it advertises a
+   * plan/ask/architect mode (`findPlanModeId` in chat-acp) the transport can
+   * select. Drives the composer's Plan-mode toggle; when `false`, requesting
+   * plan mode would 422, so the toggle stays disabled.
+   */
+  readonly planMode: boolean;
 }
 
 export interface AcpAgentDescriptor {
@@ -75,6 +82,8 @@ export const ACP_AGENTS = [
       ],
       contextWindow: true,
       thinkingEfforts: ["ultrathink", "max", "extra-high", "high", "medium", "low"],
+      // claude-agent-acp advertises a read-only plan mode.
+      planMode: true,
     },
   },
   {
@@ -90,6 +99,9 @@ export const ACP_AGENTS = [
       models: "dynamic",
       contextWindow: false,
       thinkingEfforts: [],
+      // opencode ships a read-only `plan` agent, selected via the session's
+      // advertised modes.
+      planMode: true,
     },
   },
   {
@@ -110,6 +122,9 @@ export const ACP_AGENTS = [
       contextWindow: false,
       // Codex maps these onto its `model_reasoning_effort` (no ultrathink/max).
       thinkingEfforts: ["extra-high", "high", "medium", "low"],
+      // Codex requires danger-full-access for MCP tool execution, so there is
+      // no enforceable read-only plan turn yet.
+      planMode: false,
     },
   },
   {
@@ -134,6 +149,9 @@ export const ACP_AGENTS = [
       ],
       contextWindow: false,
       thinkingEfforts: [],
+      // Cursor degrades generically over ACP (no resume, no MCP tools) and
+      // advertises no read-only/plan mode.
+      planMode: false,
     },
   },
 ] as const satisfies readonly AcpAgentDescriptor[];

--- a/packages/shared/src/chat.ts
+++ b/packages/shared/src/chat.ts
@@ -38,7 +38,7 @@ export interface ChatPlan {
   readonly turnId: string;
   readonly planMarkdown: string;
   readonly status: "pending" | "approved" | "rejected" | "superseded";
-  readonly source: "claude" | "opencode" | "codex";
+  readonly source: "acp";
   readonly createdAt: string;
   readonly decidedAt: string | null;
 }
@@ -55,7 +55,7 @@ export interface ChatSubagentInvocation {
   readonly prompt: string;
   readonly status: "running" | "completed" | "errored";
   readonly result: string | null;
-  readonly source: "claude" | "opencode" | "codex";
+  readonly source: "acp";
   readonly startedAt: string;
   readonly completedAt: string | null;
 }
@@ -103,7 +103,7 @@ export interface ChatQuestion {
   readonly id: string;
   readonly turnId: string;
   readonly providerRequestId: string;
-  readonly source: "claude" | "opencode" | "codex";
+  readonly source: "acp";
   readonly questions: ReadonlyArray<NormalizedQuestion>;
   readonly status: "pending" | "answered" | "rejected" | "superseded";
   /** Map question text → labels chosen. Null when status === 'pending'. */


### PR DESCRIPTION
Chat and merge-conflict now run exclusively on the ACP transport, so this narrows the per-row `source` discriminator and the chat-edit actor to their only real values (`acp` / `chat:acp`) across the server service, shared wire types, web persisted types, normalized events, and the MCP token + edit-actor types, while fixing the stale schema/JSDoc comments that still named the deleted bespoke drivers. It also consolidates per-agent facts onto the single `ACP_AGENTS` registry: the web `AvailableAgents.agent` is now `AcpAgentId`, plan-mode support became a `planMode` capability, and `/api/chat/agents/available` derives from it so adding an agent no longer requires editing the endpoint. The `chat_sessions.agent` comment is corrected to the real registry ids (claude-code/opencode/codex/cursor — gemini is a cursor *model*, not an integrated agent), and the dead `agents` field is dropped from the availability response. No behavior change beyond cursor's plan-mode toggle now correctly reporting unavailable instead of being mislabeled as opencode. CI passes locally (typecheck, lint, knip, build, ACP preset tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)