### PR TITLE
feat: add incremental walkthrough review rounds

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/ai/acp/acp-connection.ts
+++ b/apps/server/src/ai/acp/acp-connection.ts
@@ -74,6 +74,8 @@ export interface AcpConnectionHandle {
   readonly setMode: (sessionId: string, modeId: string) => Promise<void>;
   readonly prompt: (sessionId: string, prompt: ContentBlock[]) => Promise<StopReason>;
   readonly cancel: (sessionId: string) => Promise<void>;
+  /** Force-stop this pooled ACP subprocess. Next use will spawn a fresh connection. */
+  readonly stop: () => void;
   /** Register (or clear, with null) the update listener for a session. */
   readonly setListener: (sessionId: string, listener: AcpUpdateListener | null) => void;
   /** Flag a session as plan-mode so the permission handler refuses mode switches. */
@@ -303,6 +305,24 @@ function scheduleIdleStop(entry: ConnectionEntry): void {
   }, IDLE_STOP_MS);
 }
 
+function stopEntry(entry: ConnectionEntry): void {
+  if (!entry.alive) return;
+  entry.alive = false;
+  pool.delete(entry.key);
+  if (entry.idleTimer) {
+    clearTimeout(entry.idleTimer);
+    entry.idleTimer = null;
+  }
+  entry.listeners.clear();
+  entry.availableCommands.clear();
+  entry.planModeSessions.clear();
+  try {
+    entry.proc.kill();
+  } catch {
+    /* already gone */
+  }
+}
+
 function makeHandle(entry: ConnectionEntry): AcpConnectionHandle {
   const { connection } = entry;
   return {
@@ -384,6 +404,10 @@ function makeHandle(entry: ConnectionEntry): AcpConnectionHandle {
         debug("acp-connection", "cancel failed:", err instanceof Error ? err.message : String(err));
       }
     },
+    stop: () => {
+      debug("acp-connection", `force-stopping ${entry.agent} agent for ${entry.cwd}`);
+      stopEntry(entry);
+    },
     setListener: (sessionId, listener) => {
       if (listener) entry.listeners.set(sessionId, listener);
       else entry.listeners.delete(sessionId);
@@ -464,12 +488,7 @@ export function stopAllAcpConnections(): void {
     pool.delete(cwd);
     void pending
       .then((entry) => {
-        entry.alive = false;
-        try {
-          entry.proc.kill();
-        } catch {
-          /* already gone */
-        }
+        stopEntry(entry);
       })
       .catch(() => {
         /* never spawned */

--- a/apps/server/src/ai/agent-stream/agent-turn.test.ts
+++ b/apps/server/src/ai/agent-stream/agent-turn.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+import { withAgentTurn } from "./agent-turn";
+
+describe("withAgentTurn", () => {
+  it("settles on hard timeout even when the provider ignores the abort signal", async () => {
+    let started = 0;
+    let ended = 0;
+    let aborts = 0;
+    const startedAt = Date.now();
+
+    await expect(
+      withAgentTurn({
+        hardTimeoutMs: 20,
+        debugLabel: "agent-turn-test",
+        jobStarted: async () => {
+          started += 1;
+        },
+        jobEnded: async () => {
+          ended += 1;
+        },
+        abortSession: async () => {
+          aborts += 1;
+        },
+        run: async () => new Promise<never>(() => {}),
+      }),
+    ).rejects.toThrow("Agent turn timed out");
+
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(started).toBe(1);
+    expect(ended).toBe(1);
+    expect(aborts).toBe(1);
+  });
+
+  it("settles when the external abort fires even when the provider keeps waiting", async () => {
+    const abortController = new AbortController();
+    let ended = 0;
+    let aborts = 0;
+
+    setTimeout(() => abortController.abort(new Error("manual stop")), 20);
+
+    await expect(
+      withAgentTurn({
+        externalAbort: abortController,
+        hardTimeoutMs: 1_000,
+        debugLabel: "agent-turn-test",
+        jobStarted: async () => {},
+        jobEnded: async () => {
+          ended += 1;
+        },
+        abortSession: async () => {
+          aborts += 1;
+        },
+        run: async () => new Promise<never>(() => {}),
+      }),
+    ).rejects.toThrow("manual stop");
+
+    expect(ended).toBe(1);
+    expect(aborts).toBe(1);
+  });
+});

--- a/apps/server/src/ai/agent-stream/agent-turn.ts
+++ b/apps/server/src/ai/agent-stream/agent-turn.ts
@@ -117,11 +117,50 @@ export async function withAgentTurn<T>(opts: WithAgentTurnOptions<T>): Promise<T
   await opts.jobStarted();
 
   try {
-    return await opts.run({
+    const ctx: AgentTurnContext = {
       signal: composed.signal,
       wasTimeout: () => timedOut,
       wasCancelled: () => cancelled,
+    };
+    const runPromise = opts.run(ctx);
+    let abortSettled = false;
+    const abortPromise = new Promise<never>((_, reject) => {
+      const onAbort = (): void => {
+        abortSettled = true;
+        const reason = composed.signal.reason;
+        reject(
+          reason instanceof Error
+            ? reason
+            : new Error(
+                timedOut
+                  ? `Agent turn timed out after ${Math.round(opts.hardTimeoutMs / 60_000)} minutes`
+                  : cancelled
+                    ? "Agent turn cancelled"
+                    : "Agent turn aborted",
+              ),
+        );
+      };
+      if (composed.signal.aborted) {
+        onAbort();
+        return;
+      }
+      composed.signal.addEventListener("abort", onAbort, { once: true });
+      runPromise.then(
+        () => composed.signal.removeEventListener("abort", onAbort),
+        () => composed.signal.removeEventListener("abort", onAbort),
+      );
     });
+
+    void runPromise.catch((err) => {
+      if (!abortSettled) return;
+      debug(
+        opts.debugLabel,
+        "run settled after abort:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+
+    return await Promise.race([runPromise, abortPromise]);
   } finally {
     clearTimeout(timeoutId);
     if (externalAbort) {

--- a/apps/server/src/ai/prompts/walkthrough-common.md
+++ b/apps/server/src/ai/prompts/walkthrough-common.md
@@ -1,5 +1,7 @@
 ## Shared walkthrough task
 
-Review the current pull request using the perspective-specific instructions below — determined automatically by whether the reader is the PR's own author (self-review) or a separate reviewer, not by a user-chosen mode — together with the strict MCP pipeline from the system prompt. Base the review on the current diff and any repository context you explicitly inspect with tools.
+Review the current pull request using the perspective-specific instructions below — determined automatically by whether the reader is the PR's own author (self-review) or a separate reviewer, not by a user-chosen mode — together with the strict MCP pipeline from the system prompt. Base the review on the changed-files section in this prompt and any repository context you explicitly inspect with tools.
+
+The changed-files section is the authoritative diff input for this walkthrough. Do not use local branch comparisons such as `git diff main...HEAD`, `git diff origin/main...HEAD`, or similar commands to decide the PR scope; local base branches can be stale or unrelated in the review worktree. Use shell/code search only to inspect surrounding context for files already identified by the prompt, or for directly referenced dependencies of those files.
 
 Commit history is intentionally not inlined here. The orchestrator persists it on the walkthrough row at job start; the instructions for your review perspective tell you whether to fetch it through `get_commit_history`.

--- a/apps/server/src/ai/prompts/walkthrough-followup-review.md
+++ b/apps/server/src/ai/prompts/walkthrough-followup-review.md
@@ -1,0 +1,13 @@
+## Follow-Up Review Mode
+
+This prompt is for a round summary rather than a full walkthrough artifact. Use it when the product asks for a visible follow-up review of new commits.
+
+The follow-up review should cover:
+
+1. What changed since the last reviewed SHA.
+2. Status of prior comments and requested changes: addressed, partially addressed, unresolved, or obsolete.
+3. New issues introduced by the latest commits.
+4. Updated global PR assessment.
+5. Final recommendation: approve, request changes, or needs another look.
+
+Do not assume comment resolution means the PR is ready. The new commits may fix local feedback while changing the overall goal, widening scope, or introducing new risks.

--- a/apps/server/src/ai/prompts/walkthrough-incremental-refresh.md
+++ b/apps/server/src/ai/prompts/walkthrough-incremental-refresh.md
@@ -1,0 +1,15 @@
+## Incremental Refresh Mode
+
+You are updating an existing review report for a newer PR head. The report you produce must use the same A -> B -> C -> D walkthrough shape as a full review, but your reasoning should start from the prior walkthrough and the new commit range.
+
+Use this discipline:
+
+1. Call `get_walkthrough_state` first. In incremental mode it includes `priorReview`, `parentWalkthroughId`, and `baseHeadSha`.
+2. Treat the prompt's "Changed Files in Incremental Range" section as the primary diff input. It is already narrowed to `baseHeadSha..HEAD` when the range is available. If it is small, keep exploration and output small. If it is empty, do not re-review the whole PR; verify the prior review state and produce a concise current report.
+3. If the prompt says the range diff fell back to the full PR diff, still treat the prompt's changed-files section as the only diff scope. Do not reconstruct the PR diff with local git branch comparisons; inspect only necessary adjacent context for the listed files.
+4. Identify which prior findings were addressed, partially addressed, still unresolved, or made obsolete. Do not blindly copy old issues.
+5. Preserve conclusions that remain valid, but rewrite any stale summary, walkthrough chapter, sentiment, rating, or issue.
+6. Add new issues introduced by the latest commits.
+7. Recompute the global PR assessment for the whole current PR, not only the new commits.
+
+The user asked for an optimized refresh, not a blind full rerun. The final artifact should read like the current best review of the PR at `HEAD`, with the prior review and narrowed commit range used to avoid wasted re-analysis.

--- a/apps/server/src/ai/prompts/walkthrough-shared-review-principles.md
+++ b/apps/server/src/ai/prompts/walkthrough-shared-review-principles.md
@@ -1,0 +1,6 @@
+## Shared Review Principles
+
+- The visible output is always a complete PR review report, not a raw commit log.
+- Preserve reviewer trust: only make claims grounded in the PR description, diff, repo context, prior walkthrough state, or files you inspected.
+- A follow-up or incremental run must still reassess the whole PR. Fixed comments do not imply the PR is ready if the new commits changed the goal, widened scope, or introduced new failures.
+- Treat prior review content as useful input, not authority. Keep sections that remain true, update stale sections, and remove or revise findings that the new commits resolved.

--- a/apps/server/src/ai/prompts/walkthrough.ts
+++ b/apps/server/src/ai/prompts/walkthrough.ts
@@ -62,6 +62,16 @@ export function buildWalkthroughSystemPrompt(mode: WalkthroughMode = REVIEW_MODE
   return WALKTHROUGH_SYSTEM_COMMON_PROMPT.replace(REVIEW_PERSPECTIVE_MARKER, modePrompt.trim());
 }
 
+const WALKTHROUGH_SHARED_REVIEW_PRINCIPLES: string = readFileSync(
+  `${import.meta.dir}/walkthrough-shared-review-principles.md`,
+  "utf-8",
+);
+
+const WALKTHROUGH_INCREMENTAL_REFRESH_PROMPT: string = readFileSync(
+  `${import.meta.dir}/walkthrough-incremental-refresh.md`,
+  "utf-8",
+);
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
@@ -127,6 +137,13 @@ export function buildWalkthroughPrompt(
     };
     mode?: WalkthroughMode;
     files: PrFileMeta[];
+    reviewMode?: {
+      readonly mode: "full" | "incremental";
+      readonly parentWalkthroughId: string | null;
+      readonly baseHeadSha: string | null;
+      readonly headSha: string;
+      readonly diffSource?: "full_pr" | "incremental_range" | "full_pr_fallback";
+    };
   },
   maxTokenBudget = 40000,
   continuation?: PromptContinuationContext,
@@ -148,8 +165,50 @@ export function buildWalkthroughPrompt(
   if (params.pr.body) {
     lines.push("", "### Description", params.pr.body);
   }
+  lines.push("", WALKTHROUGH_SHARED_REVIEW_PRINCIPLES);
 
-  lines.push("", "### Changed Files (diff — you can read full file contents with your tools)", "");
+  if (params.reviewMode?.mode === "incremental") {
+    lines.push(
+      "",
+      WALKTHROUGH_INCREMENTAL_REFRESH_PROMPT,
+      "",
+      "### Incremental Range",
+      `Previous reviewed head: ${params.reviewMode.baseHeadSha ?? "unknown"}`,
+      `Current head: ${params.reviewMode.headSha}`,
+      `Prior walkthrough id: ${params.reviewMode.parentWalkthroughId ?? "unknown"}`,
+      `Diff input: ${
+        params.reviewMode.diffSource === "full_pr_fallback"
+          ? "full PR diff fallback because the incremental range could not be resolved locally"
+          : params.reviewMode.diffSource === "incremental_range"
+            ? "incremental range only"
+            : "full PR diff"
+      }`,
+    );
+  }
+
+  // Commit history is intentionally NOT inlined here. The orchestrator
+  // persists it on the walkthrough row at job start; the agent fetches it
+  // lazily via the `get_commit_history` MCP read tool when it's about to
+  // open the required "How we got here" journey chapter (chapter 0). This
+  // keeps the prompt token-bounded on long PRs (up to 300 commits) and
+  // resume reruns of the prompt cheap.
+
+  const changedFilesHeading =
+    params.reviewMode?.mode === "incremental"
+      ? params.reviewMode.diffSource === "full_pr_fallback"
+        ? "### Changed Files (full PR diff fallback — incremental range unavailable)"
+        : "### Changed Files in Incremental Range (diff — prior reviewed head to current head)"
+      : "### Changed Files (diff — you can read full file contents with your tools)";
+  lines.push("", changedFilesHeading, "");
+
+  if (params.files.length === 0) {
+    lines.push(
+      params.reviewMode?.mode === "incremental"
+        ? "No files changed in the incremental range. Use the prior review state to confirm whether the current PR assessment still stands, then produce a concise updated report."
+        : "No changed files were returned for this PR.",
+      "",
+    );
+  }
 
   let approxTokens = 0;
   for (const file of params.files) {

--- a/apps/server/src/ai/providers/stream-guard.test.ts
+++ b/apps/server/src/ai/providers/stream-guard.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "bun:test";
+import type { WalkthroughStreamEvent } from "@revv/shared";
+import { ZERO_TOKEN_USAGE } from "../agent-stream";
+import { guardWalkthroughStream } from "./stream-guard";
+
+async function* delayedEvents(
+  events: readonly WalkthroughStreamEvent[],
+  delayMs: number,
+): AsyncGenerator<WalkthroughStreamEvent> {
+  for (const event of events) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    yield event;
+  }
+}
+
+async function collectUntilTerminal(
+  stream: AsyncGenerator<WalkthroughStreamEvent>,
+): Promise<WalkthroughStreamEvent[]> {
+  const events: WalkthroughStreamEvent[] = [];
+  for await (const event of stream) {
+    events.push(event);
+    if (event.type === "error" || event.type === "done") break;
+  }
+  return events;
+}
+
+describe("guardWalkthroughStream", () => {
+  it("does not treat phase heartbeats as report progress", async () => {
+    const stream = guardWalkthroughStream(
+      delayedEvents(
+        [
+          {
+            type: "phase",
+            data: { phase: "exploring", message: "Reading files and understanding changes..." },
+          },
+          { type: "usage", data: { tokenUsage: ZERO_TOKEN_USAGE } },
+          { type: "thought", data: { text: "Still inspecting the diff." } },
+          {
+            type: "phase",
+            data: { phase: "exploring", message: "Reading files and understanding changes..." },
+          },
+        ],
+        15,
+      ),
+      {
+        explorationStallMs: 30,
+        firstEventTimeoutMs: 100,
+        inactivityTimeoutMs: 100,
+        label: "stream-guard-test",
+        synthesizePhases: false,
+      },
+    );
+
+    const events = await collectUntilTerminal(stream);
+
+    expect(events.at(-1)).toMatchObject({
+      type: "error",
+      data: { code: "ExplorationStall" },
+    });
+  });
+
+  it("resets the report-progress stall timer when content arrives", async () => {
+    const stream = guardWalkthroughStream(
+      delayedEvents(
+        [
+          {
+            type: "phase",
+            data: { phase: "exploring", message: "Reading files and understanding changes..." },
+          },
+          {
+            type: "summary",
+            data: { summary: "Adds indexes for range queries.", riskLevel: "low" },
+          },
+          {
+            type: "phase",
+            data: { phase: "exploring", message: "Reading files and understanding changes..." },
+          },
+          {
+            type: "done",
+            data: { walkthroughId: "walkthrough-1", tokenUsage: ZERO_TOKEN_USAGE },
+          },
+        ],
+        15,
+      ),
+      {
+        explorationStallMs: 40,
+        firstEventTimeoutMs: 100,
+        inactivityTimeoutMs: 100,
+        label: "stream-guard-test",
+        synthesizePhases: false,
+      },
+    );
+
+    const events = await collectUntilTerminal(stream);
+
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      data: { walkthroughId: "walkthrough-1" },
+    });
+  });
+});

--- a/apps/server/src/ai/providers/stream-guard.ts
+++ b/apps/server/src/ai/providers/stream-guard.ts
@@ -33,6 +33,23 @@ const PHASE_MESSAGES = {
   rating: { phase: "rating" as const, message: "Scoring the PR across 9 axes..." },
 } satisfies Record<string, { phase: WalkthroughLifecyclePhase; message: string }>;
 
+function isMeaningfulProgressEvent(event: WalkthroughStreamEvent): boolean {
+  switch (event.type) {
+    case "summary":
+    case "sentiment":
+    case "semantic-step":
+    case "block":
+    case "issue":
+    case "rating":
+    case "phase:advanced":
+    case "done":
+    case "error":
+      return true;
+    default:
+      return false;
+  }
+}
+
 // ── Guard wrapper ───────────────────────────────────────────────────────────
 
 /**
@@ -158,26 +175,22 @@ export function guardWalkthroughStream(
 
         yield event;
 
-        // Track exploration-only stalls. Exploration events (tool_use / file reads)
-        // reset the inactivity timer above, so they can prevent it from ever firing.
-        // If the model keeps reading files but never produces meaningful output we
-        // need a separate check: abort if only exploration events have arrived for
-        // longer than explorationStallMs.
-        if (event.type === "exploration") {
-          if (Date.now() - lastProgressTime > explorationStallMs) {
-            debug(label, "Exploration stall — no progress for", explorationStallMs, "ms");
-            yield {
-              type: "error" as const,
-              data: {
-                code: "ExplorationStall",
-                message: `Walkthrough stalled — the model explored files for ${Math.round(explorationStallMs / 60_000)} minutes without producing output. Try regenerating.`,
-              },
-            };
-            return;
-          }
-        } else {
-          // Any non-exploration event counts as meaningful progress
+        // Track stalls independently from transport liveness. Exploration,
+        // reasoning, usage, and phase heartbeat events reset the inactivity
+        // timer above, but they do not prove the report advanced. Without this
+        // distinction a provider can sit on "Reading files..." indefinitely.
+        if (isMeaningfulProgressEvent(event)) {
           lastProgressTime = Date.now();
+        } else if (Date.now() - lastProgressTime > explorationStallMs) {
+          debug(label, "Exploration stall — no report progress for", explorationStallMs, "ms");
+          yield {
+            type: "error" as const,
+            data: {
+              code: "ExplorationStall",
+              message: `Walkthrough stalled — the model explored files for ${Math.round(explorationStallMs / 60_000)} minutes without producing output. Try regenerating.`,
+            },
+          };
+          return;
         }
 
         // Terminal event received — we're done

--- a/apps/server/src/ai/providers/walkthrough-acp.ts
+++ b/apps/server/src/ai/providers/walkthrough-acp.ts
@@ -62,6 +62,7 @@ import {
 import { buildWalkthroughPrompt, buildWalkthroughSystemPrompt } from "../prompts/walkthrough";
 
 const WALKTHROUGH_MCP_SERVER = "revv-walkthrough";
+const ACP_CANCEL_GRACE_MS = 1_500;
 
 // Built-in exploration tools the agent runs natively (NOT via our MCP route).
 // ACP tags these with a `kind` the decoder maps onto canonical names, so they
@@ -359,7 +360,13 @@ export function streamWalkthroughViaAcp(
           cancelled = true;
         },
         abortSession: async () => {
-          if (sessionId) await h.cancel(sessionId);
+          if (sessionId) {
+            await Promise.race([
+              h.cancel(sessionId),
+              new Promise<void>((resolve) => setTimeout(resolve, ACP_CANCEL_GRACE_MS)),
+            ]);
+          }
+          h.stop();
         },
         run: async (ctx) => {
           // ── 1. Issue session token + hand the agent our HTTP MCP endpoint ──

--- a/apps/server/src/ai/providers/walkthrough-tools/read-handler.ts
+++ b/apps/server/src/ai/providers/walkthrough-tools/read-handler.ts
@@ -17,6 +17,7 @@ import { walkthroughBlocks } from "../../../db/schema/walkthrough-blocks";
 import { walkthroughIssues } from "../../../db/schema/walkthrough-issues";
 import { walkthroughRatings } from "../../../db/schema/walkthrough-ratings";
 import { walkthroughSemanticSteps } from "../../../db/schema/walkthrough-semantic-steps";
+import { walkthroughs as walkthroughsTable } from "../../../db/schema/walkthroughs";
 import { errorResult, findIssuesMissingInlineComment, loadWalkthroughRow } from "./helpers";
 import type {
   GetCommitHistoryInput,
@@ -127,11 +128,94 @@ export const getWalkthroughStateHandler: WalkthroughToolHandler<GetWalkthroughSt
   // the orchestrator and `complete_walkthrough` use — single source of
   // truth (see findIssuesMissingInlineComment).
   const issuesNeedingInlineComment = findIssuesMissingInlineComment(ctx.db, ctx.walkthroughId);
+  const priorReview = row.parentWalkthroughId
+    ? (() => {
+        const prior = ctx.db
+          .select()
+          .from(walkthroughsTable)
+          .where(eq(walkthroughsTable.id, row.parentWalkthroughId))
+          .get();
+        if (!prior) return null;
+        const priorSemanticSteps = ctx.db
+          .select({
+            semanticStepIndex: walkthroughSemanticSteps.semanticStepIndex,
+            title: walkthroughSemanticSteps.title,
+            summary: walkthroughSemanticSteps.summary,
+          })
+          .from(walkthroughSemanticSteps)
+          .where(eq(walkthroughSemanticSteps.walkthroughId, prior.id))
+          .orderBy(asc(walkthroughSemanticSteps.semanticStepIndex))
+          .all()
+          .map((s) => ({
+            semanticStepIndex: s.semanticStepIndex,
+            title: s.title,
+            summary: s.summary ?? null,
+          }));
+        const priorIssues = ctx.db
+          .select({
+            id: walkthroughIssues.id,
+            severity: walkthroughIssues.severity,
+            title: walkthroughIssues.title,
+            description: walkthroughIssues.description,
+            filePath: walkthroughIssues.filePath,
+            startLine: walkthroughIssues.startLine,
+            endLine: walkthroughIssues.endLine,
+            submittedAt: walkthroughIssues.submittedAt,
+            order: walkthroughIssues.order,
+          })
+          .from(walkthroughIssues)
+          .where(eq(walkthroughIssues.walkthroughId, prior.id))
+          .orderBy(asc(walkthroughIssues.order))
+          .all()
+          .map((i) => ({
+            id: i.id,
+            severity: i.severity as "info" | "warning" | "critical",
+            title: i.title,
+            description: i.description,
+            filePath: i.filePath,
+            startLine: i.startLine,
+            endLine: i.endLine,
+            submittedAt: i.submittedAt,
+          }));
+        const priorRatings = ctx.db
+          .select({
+            axis: walkthroughRatings.axis,
+            verdict: walkthroughRatings.verdict,
+            confidence: walkthroughRatings.confidence,
+            rationale: walkthroughRatings.rationale,
+            createdAt: walkthroughRatings.createdAt,
+          })
+          .from(walkthroughRatings)
+          .where(eq(walkthroughRatings.walkthroughId, prior.id))
+          .orderBy(asc(walkthroughRatings.createdAt))
+          .all()
+          .map((r) => ({
+            axis: r.axis as RatingAxis,
+            verdict: r.verdict as "pass" | "concern" | "blocker",
+            confidence: r.confidence as "low" | "medium" | "high",
+            rationale: r.rationale,
+          }));
+        return {
+          walkthroughId: prior.id,
+          prHeadSha: prior.prHeadSha,
+          summary: prior.summary,
+          riskLevel: prior.riskLevel as RiskLevel,
+          sentiment: prior.sentiment ?? null,
+          semanticSteps: priorSemanticSteps,
+          issues: priorIssues,
+          ratings: priorRatings,
+        };
+      })()
+    : null;
 
   const state: WalkthroughState = {
     walkthroughId: row.id,
     prHeadSha: row.prHeadSha,
     mode: row.mode as WalkthroughState["mode"],
+    generationMode: row.generationMode as WalkthroughState["generationMode"],
+    parentWalkthroughId: row.parentWalkthroughId ?? null,
+    baseHeadSha: row.baseHeadSha ?? null,
+    priorReview,
     status: row.status as WalkthroughState["status"],
     lastCompletedPhase: row.lastCompletedPhase as WalkthroughPipelinePhase,
     summary: row.summary || null,

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -68,7 +68,15 @@ export const auth = betterAuth({
   // social provider was never wired up on the frontend and required
   // `client_secret`, which we no longer collect.
   plugins: [bearer()],
-  trustedOrigins: ["http://localhost:5173", "tauri://localhost", "https://tauri.localhost"],
+  trustedOrigins: [
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+    "http://localhost:45678",
+    "http://localhost:45679",
+    "tauri://localhost",
+    "http://tauri.localhost",
+    "https://tauri.localhost",
+  ],
   account: {
     // Store OAuth state entirely in an encrypted cookie instead of DB + signed-cookie.
     // This avoids cross-origin cookie mismatch errors when the sign-in fetch originates

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -6,6 +6,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { bearer } from "better-auth/plugins";
 import { serverEnv } from "./config";
 import { createDb } from "./db/index";
+import { AUTH_TRUSTED_ORIGINS } from "./http-origins";
 import { appDataDir } from "./paths";
 
 // Re-exported for the handful of routes that still reach in directly.
@@ -68,15 +69,7 @@ export const auth = betterAuth({
   // social provider was never wired up on the frontend and required
   // `client_secret`, which we no longer collect.
   plugins: [bearer()],
-  trustedOrigins: [
-    "http://localhost:5173",
-    "http://127.0.0.1:5173",
-    "http://localhost:45678",
-    "http://localhost:45679",
-    "tauri://localhost",
-    "http://tauri.localhost",
-    "https://tauri.localhost",
-  ],
+  trustedOrigins: [...AUTH_TRUSTED_ORIGINS],
   account: {
     // Store OAuth state entirely in an encrypted cookie instead of DB + signed-cookie.
     // This avoids cross-origin cookie mismatch errors when the sign-in fetch originates

--- a/apps/server/src/db/index.test.ts
+++ b/apps/server/src/db/index.test.ts
@@ -1,0 +1,134 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { __dbRecoveryTest } from "./index";
+
+function memoryDb(): Database {
+  const db = new Database(":memory:");
+  db.run("PRAGMA foreign_keys = ON");
+  return db;
+}
+
+function migrationCount(db: Database, createdAt: number): number {
+  const row = db
+    .query("SELECT COUNT(*) AS count FROM __drizzle_migrations WHERE created_at = ?")
+    .get(createdAt) as { count: number } | null;
+  return row?.count ?? 0;
+}
+
+describe("review-round migration recovery", () => {
+  it("no-ops when the walkthroughs table does not exist", () => {
+    const db = memoryDb();
+
+    expect(() => __dbRecoveryTest.recoverUnjournaledReviewRoundMigration(db)).not.toThrow();
+    expect(
+      db
+        .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'review_rounds'")
+        .get(),
+    ).toBeNull();
+  });
+
+  it("records the review-round migration when artifacts exist without a journal entry", () => {
+    const db = memoryDb();
+    db.run(`
+      CREATE TABLE walkthroughs (
+        id text PRIMARY KEY,
+        pull_request_id text NOT NULL,
+        pr_head_sha text NOT NULL,
+        mode text DEFAULT 'reviewer' NOT NULL,
+        status text DEFAULT 'complete' NOT NULL,
+        parent_walkthrough_id text
+      )
+    `);
+
+    __dbRecoveryTest.recoverUnjournaledReviewRoundMigration(db);
+
+    expect(
+      __dbRecoveryTest.migrationRecorded(db, __dbRecoveryTest.REVIEW_ROUNDS_MIGRATION_WHEN),
+    ).toBe(true);
+    expect(__dbRecoveryTest.columnExists(db, "walkthroughs", "base_head_sha")).toBe(true);
+    expect(__dbRecoveryTest.columnExists(db, "walkthroughs", "generation_mode")).toBe(true);
+    expect(
+      db
+        .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'review_rounds'")
+        .get(),
+    ).not.toBeNull();
+  });
+
+  it("is idempotent once the review-round migration is journaled", () => {
+    const db = memoryDb();
+    db.run(`
+      CREATE TABLE walkthroughs (
+        id text PRIMARY KEY,
+        pull_request_id text NOT NULL,
+        pr_head_sha text NOT NULL,
+        mode text DEFAULT 'reviewer' NOT NULL,
+        status text DEFAULT 'complete' NOT NULL,
+        parent_walkthrough_id text
+      )
+    `);
+
+    __dbRecoveryTest.recoverUnjournaledReviewRoundMigration(db);
+    __dbRecoveryTest.recoverUnjournaledReviewRoundMigration(db);
+
+    expect(migrationCount(db, __dbRecoveryTest.REVIEW_ROUNDS_MIGRATION_WHEN)).toBe(1);
+  });
+
+  it("keeps ensureReviewRoundSchema idempotent", () => {
+    const db = memoryDb();
+    db.run(`
+      CREATE TABLE walkthroughs (
+        id text PRIMARY KEY,
+        pull_request_id text NOT NULL,
+        pr_head_sha text NOT NULL,
+        mode text DEFAULT 'reviewer' NOT NULL,
+        status text DEFAULT 'complete' NOT NULL
+      )
+    `);
+
+    __dbRecoveryTest.ensureReviewRoundSchema(db);
+    __dbRecoveryTest.ensureReviewRoundSchema(db);
+
+    expect(__dbRecoveryTest.columnExists(db, "walkthroughs", "parent_walkthrough_id")).toBe(true);
+    expect(__dbRecoveryTest.columnExists(db, "walkthroughs", "base_head_sha")).toBe(true);
+    expect(__dbRecoveryTest.columnExists(db, "walkthroughs", "generation_mode")).toBe(true);
+  });
+});
+
+describe("mode migration recovery", () => {
+  it("records walkthrough mode migration when the mode column exists without a journal entry", () => {
+    const db = memoryDb();
+    db.run(`
+      CREATE TABLE walkthroughs (
+        id text PRIMARY KEY,
+        pull_request_id text NOT NULL,
+        pr_head_sha text NOT NULL,
+        mode text DEFAULT 'reviewer' NOT NULL,
+        status text DEFAULT 'complete' NOT NULL
+      )
+    `);
+
+    __dbRecoveryTest.recoverWalkthroughModesMigration(db);
+
+    expect(
+      __dbRecoveryTest.migrationRecorded(db, __dbRecoveryTest.WALKTHROUGH_MODES_MIGRATION_WHEN),
+    ).toBe(true);
+  });
+
+  it("records review-session mode migration when the mode column exists without a journal entry", () => {
+    const db = memoryDb();
+    db.run(`
+      CREATE TABLE review_sessions (
+        id text PRIMARY KEY,
+        pull_request_id text NOT NULL,
+        mode text DEFAULT 'reviewer' NOT NULL,
+        status text DEFAULT 'active' NOT NULL
+      )
+    `);
+
+    __dbRecoveryTest.recoverReviewSessionModesMigration(db);
+
+    expect(
+      __dbRecoveryTest.migrationRecorded(db, __dbRecoveryTest.REVIEW_SESSION_MODES_MIGRATION_WHEN),
+    ).toBe(true);
+  });
+});

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
-import { chmodSync, existsSync, mkdirSync, renameSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/bun-sqlite";
@@ -80,6 +81,17 @@ function hardenDbFile(dbPath: string): void {
 // squashed migrations with higher timestamps.
 
 const FIRST_SQUASHED_WHEN = 1779000000000;
+const MIGRATIONS_FOLDER = fileURLToPath(new URL("./migrations", import.meta.url));
+const GITHUB_CLIENT_ID_MIGRATION_TAG = "0210_github_client_id";
+const GITHUB_CLIENT_ID_MIGRATION_WHEN = 1779590000000;
+const WALKTHROUGH_MODES_MIGRATION_TAG = "0220_walkthrough_modes";
+const WALKTHROUGH_MODES_MIGRATION_WHEN = 1779595000000;
+const REVIEW_SESSION_MODES_MIGRATION_TAG = "0230_review_session_modes";
+const REVIEW_SESSION_MODES_MIGRATION_WHEN = 1779600000000;
+const REPOSITORY_AVATAR_CONTENT_MIGRATION_TAG = "0240_repository_avatar_content";
+const REPOSITORY_AVATAR_CONTENT_MIGRATION_WHEN = 1779610000000;
+const REVIEW_ROUNDS_MIGRATION_TAG = "0300_review_rounds";
+const REVIEW_ROUNDS_MIGRATION_WHEN = 1779640000000;
 
 interface Recovered {
   users: Array<Record<string, unknown>>;
@@ -272,6 +284,273 @@ function insertData(freshDb: ReturnType<typeof drizzle>, d: Recovered) {
   ]);
 }
 
+function tableExists(sqlite: Database, table: string): boolean {
+  const row = sqlite
+    .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(table);
+  return row !== null;
+}
+
+function columnExists(sqlite: Database, table: string, column: string): boolean {
+  const rows = sqlite.query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return rows.some((row) => row.name === column);
+}
+
+function indexExists(sqlite: Database, index: string): boolean {
+  const row = sqlite
+    .query("SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?")
+    .get(index);
+  return row !== null;
+}
+
+function indexColumns(sqlite: Database, index: string): string[] {
+  const rows = sqlite.query(`PRAGMA index_info(${index})`).all() as Array<{ name: string }>;
+  return rows.map((row) => row.name);
+}
+
+function migrationRecorded(sqlite: Database, createdAt: number): boolean {
+  if (!tableExists(sqlite, "__drizzle_migrations")) return false;
+  const row = sqlite
+    .query("SELECT 1 FROM __drizzle_migrations WHERE created_at = ? LIMIT 1")
+    .get(createdAt);
+  return row !== null;
+}
+
+function migrationHash(tag: string): string {
+  const sql = readFileSync(`${MIGRATIONS_FOLDER}/${tag}.sql`, "utf8");
+  return createHash("sha256").update(sql).digest("hex");
+}
+
+function recordMigration(sqlite: Database, tag: string, createdAt: number): void {
+  sqlite.run(`
+    CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+      id SERIAL PRIMARY KEY,
+      hash text NOT NULL,
+      created_at numeric
+    )
+  `);
+  if (migrationRecorded(sqlite, createdAt)) return;
+  sqlite
+    .prepare('INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES (?, ?)')
+    .run(migrationHash(tag), createdAt);
+}
+
+function refreshMigrationHash(sqlite: Database, tag: string, createdAt: number): void {
+  if (!migrationRecorded(sqlite, createdAt)) return;
+  sqlite
+    .prepare('UPDATE "__drizzle_migrations" SET "hash" = ? WHERE "created_at" = ?')
+    .run(migrationHash(tag), createdAt);
+}
+
+function ensureGithubClientIdColumn(sqlite: Database): void {
+  if (!tableExists(sqlite, "user_settings")) return;
+  if (columnExists(sqlite, "user_settings", "github_client_id")) return;
+  sqlite.run("ALTER TABLE `user_settings` ADD `github_client_id` text DEFAULT '' NOT NULL");
+}
+
+function recoverGithubClientIdMigration(sqlite: Database): void {
+  if (!tableExists(sqlite, "user_settings")) return;
+
+  const hasColumn = columnExists(sqlite, "user_settings", "github_client_id");
+  const isRecorded = migrationRecorded(sqlite, GITHUB_CLIENT_ID_MIGRATION_WHEN);
+
+  if (hasColumn && !isRecorded) {
+    recordMigration(sqlite, GITHUB_CLIENT_ID_MIGRATION_TAG, GITHUB_CLIENT_ID_MIGRATION_WHEN);
+  }
+  if (!hasColumn && isRecorded) {
+    ensureGithubClientIdColumn(sqlite);
+  }
+}
+
+function hasAnyReviewRoundMigrationArtifact(sqlite: Database): boolean {
+  return (
+    columnExists(sqlite, "walkthroughs", "parent_walkthrough_id") ||
+    columnExists(sqlite, "walkthroughs", "base_head_sha") ||
+    columnExists(sqlite, "walkthroughs", "generation_mode") ||
+    tableExists(sqlite, "review_rounds") ||
+    indexExists(sqlite, "walkthroughs_active_pr_head_sha_unique")
+  );
+}
+
+function ensureWalkthroughModesSchema(sqlite: Database): void {
+  if (!tableExists(sqlite, "walkthroughs")) return;
+
+  if (!columnExists(sqlite, "walkthroughs", "mode")) {
+    sqlite.run("ALTER TABLE `walkthroughs` ADD `mode` text DEFAULT 'reviewer' NOT NULL");
+  }
+
+  sqlite.run("DROP INDEX IF EXISTS `walkthroughs_pr_head_sha_unique`");
+  if (!hasAnyReviewRoundMigrationArtifact(sqlite)) {
+    sqlite.run("DROP INDEX IF EXISTS `walkthroughs_pr_head_sha_mode_unique`");
+    sqlite.run(`
+      CREATE UNIQUE INDEX \`walkthroughs_pr_head_sha_mode_unique\`
+        ON \`walkthroughs\` (\`pull_request_id\`, \`pr_head_sha\`, \`mode\`)
+    `);
+  }
+}
+
+function recoverWalkthroughModesMigration(sqlite: Database): void {
+  if (!tableExists(sqlite, "walkthroughs")) return;
+
+  const hasMode = columnExists(sqlite, "walkthroughs", "mode");
+  const isRecorded = migrationRecorded(sqlite, WALKTHROUGH_MODES_MIGRATION_WHEN);
+  if (!hasMode && (isRecorded || hasAnyReviewRoundMigrationArtifact(sqlite))) {
+    ensureWalkthroughModesSchema(sqlite);
+    recordMigration(sqlite, WALKTHROUGH_MODES_MIGRATION_TAG, WALKTHROUGH_MODES_MIGRATION_WHEN);
+    refreshMigrationHash(sqlite, WALKTHROUGH_MODES_MIGRATION_TAG, WALKTHROUGH_MODES_MIGRATION_WHEN);
+  }
+}
+
+function ensureReviewSessionModesSchema(sqlite: Database): void {
+  if (!tableExists(sqlite, "review_sessions")) return;
+
+  if (!columnExists(sqlite, "review_sessions", "mode")) {
+    sqlite.run("ALTER TABLE `review_sessions` ADD `mode` text DEFAULT 'reviewer' NOT NULL");
+  }
+  sqlite.run(`
+    CREATE INDEX IF NOT EXISTS \`review_sessions_pr_mode_status_idx\`
+      ON \`review_sessions\` (\`pull_request_id\`, \`mode\`, \`status\`)
+  `);
+}
+
+function recoverReviewSessionModesMigration(sqlite: Database): void {
+  if (!tableExists(sqlite, "review_sessions")) return;
+
+  const hasMode = columnExists(sqlite, "review_sessions", "mode");
+  const isRecorded = migrationRecorded(sqlite, REVIEW_SESSION_MODES_MIGRATION_WHEN);
+  if (!hasMode && (isRecorded || hasAnyReviewRoundMigrationArtifact(sqlite))) {
+    ensureReviewSessionModesSchema(sqlite);
+    recordMigration(
+      sqlite,
+      REVIEW_SESSION_MODES_MIGRATION_TAG,
+      REVIEW_SESSION_MODES_MIGRATION_WHEN,
+    );
+    refreshMigrationHash(
+      sqlite,
+      REVIEW_SESSION_MODES_MIGRATION_TAG,
+      REVIEW_SESSION_MODES_MIGRATION_WHEN,
+    );
+  }
+}
+
+function ensureAvatarContentSchema(sqlite: Database): void {
+  if (
+    tableExists(sqlite, "repositories") &&
+    !columnExists(sqlite, "repositories", "avatar_content")
+  ) {
+    sqlite.run("ALTER TABLE `repositories` ADD `avatar_content` text");
+  }
+  if (
+    tableExists(sqlite, "remote_users") &&
+    !columnExists(sqlite, "remote_users", "avatar_content")
+  ) {
+    sqlite.run("ALTER TABLE `remote_users` ADD `avatar_content` text");
+  }
+}
+
+function recoverAvatarContentMigrations(sqlite: Database): void {
+  if (
+    tableExists(sqlite, "remote_users") &&
+    !columnExists(sqlite, "remote_users", "avatar_content")
+  ) {
+    sqlite.run("ALTER TABLE `remote_users` ADD `avatar_content` text");
+  }
+
+  if (!tableExists(sqlite, "repositories")) return;
+  const hasColumn = columnExists(sqlite, "repositories", "avatar_content");
+  const isRecorded = migrationRecorded(sqlite, REPOSITORY_AVATAR_CONTENT_MIGRATION_WHEN);
+
+  if (hasColumn && !isRecorded) {
+    recordMigration(
+      sqlite,
+      REPOSITORY_AVATAR_CONTENT_MIGRATION_TAG,
+      REPOSITORY_AVATAR_CONTENT_MIGRATION_WHEN,
+    );
+  }
+  if (!hasColumn && isRecorded) {
+    sqlite.run("ALTER TABLE `repositories` ADD `avatar_content` text");
+  }
+}
+
+/**
+ * Defensive repair for local databases that already received part or all of
+ * the review-round schema outside the Drizzle journal. Keep this idempotent
+ * and narrow: clean DBs no-op, poisoned DBs get the missing review-round
+ * schema before services start touching it.
+ */
+function ensureReviewRoundSchema(sqlite: Database) {
+  if (!tableExists(sqlite, "walkthroughs")) return;
+
+  if (!columnExists(sqlite, "walkthroughs", "parent_walkthrough_id")) {
+    sqlite.run(
+      "ALTER TABLE `walkthroughs` ADD `parent_walkthrough_id` text REFERENCES `walkthroughs`(`id`) ON DELETE set null",
+    );
+  }
+  if (!columnExists(sqlite, "walkthroughs", "base_head_sha")) {
+    sqlite.run("ALTER TABLE `walkthroughs` ADD `base_head_sha` text");
+  }
+  if (!columnExists(sqlite, "walkthroughs", "generation_mode")) {
+    sqlite.run("ALTER TABLE `walkthroughs` ADD `generation_mode` text DEFAULT 'full' NOT NULL");
+  }
+
+  sqlite.run("DROP INDEX IF EXISTS `walkthroughs_pr_head_sha_unique`");
+  sqlite.run("DROP INDEX IF EXISTS `walkthroughs_pr_head_sha_mode_unique`");
+  const activeIndexColumns = indexColumns(sqlite, "walkthroughs_active_pr_head_sha_unique");
+  const expectedActiveIndexColumns = ["pull_request_id", "pr_head_sha", "mode", "generation_mode"];
+  if (activeIndexColumns.join("\0") !== expectedActiveIndexColumns.join("\0")) {
+    sqlite.run("DROP INDEX IF EXISTS `walkthroughs_active_pr_head_sha_unique`");
+    sqlite.run(`
+      CREATE UNIQUE INDEX \`walkthroughs_active_pr_head_sha_unique\`
+        ON \`walkthroughs\` (\`pull_request_id\`, \`pr_head_sha\`, \`mode\`, \`generation_mode\`)
+        WHERE \`status\` <> 'superseded'
+    `);
+  }
+
+  sqlite.run(`
+    CREATE TABLE IF NOT EXISTS \`review_rounds\` (
+      \`id\` text PRIMARY KEY NOT NULL,
+      \`pull_request_id\` text NOT NULL,
+      \`review_session_id\` text NOT NULL,
+      \`walkthrough_id\` text NOT NULL,
+      \`previous_walkthrough_id\` text,
+      \`round_number\` integer NOT NULL,
+      \`kind\` text DEFAULT 'full' NOT NULL,
+      \`visibility\` text DEFAULT 'visible' NOT NULL,
+      \`status\` text DEFAULT 'generating' NOT NULL,
+      \`from_sha\` text,
+      \`to_sha\` text NOT NULL,
+      \`created_at\` text NOT NULL,
+      \`completed_at\` text,
+      FOREIGN KEY (\`pull_request_id\`) REFERENCES \`pull_requests\`(\`id\`) ON UPDATE no action ON DELETE cascade,
+      FOREIGN KEY (\`review_session_id\`) REFERENCES \`review_sessions\`(\`id\`) ON UPDATE no action ON DELETE cascade,
+      FOREIGN KEY (\`walkthrough_id\`) REFERENCES \`walkthroughs\`(\`id\`) ON UPDATE no action ON DELETE cascade,
+      FOREIGN KEY (\`previous_walkthrough_id\`) REFERENCES \`walkthroughs\`(\`id\`) ON UPDATE no action ON DELETE set null
+    )
+  `);
+  sqlite.run(`
+    CREATE INDEX IF NOT EXISTS \`review_rounds_pr_round_idx\`
+      ON \`review_rounds\` (\`pull_request_id\`, \`round_number\`)
+  `);
+  sqlite.run(`
+    CREATE INDEX IF NOT EXISTS \`review_rounds_walkthrough_idx\`
+      ON \`review_rounds\` (\`walkthrough_id\`)
+  `);
+}
+
+/**
+ * Older local builds repaired the review-round schema after Drizzle ran but
+ * did not write the matching migration journal entry. Those databases crash
+ * on the next boot because Drizzle replays 0240 and hits duplicate columns.
+ */
+function recoverUnjournaledReviewRoundMigration(sqlite: Database): void {
+  if (!tableExists(sqlite, "walkthroughs")) return;
+  if (migrationRecorded(sqlite, REVIEW_ROUNDS_MIGRATION_WHEN)) return;
+  if (!hasAnyReviewRoundMigrationArtifact(sqlite)) return;
+
+  ensureReviewRoundSchema(sqlite);
+  recordMigration(sqlite, REVIEW_ROUNDS_MIGRATION_TAG, REVIEW_ROUNDS_MIGRATION_WHEN);
+}
+
 export function createDb(path?: string) {
   const dbPath = resolveDbPath(path);
 
@@ -312,7 +591,17 @@ export function createDb(path?: string) {
     fresh.run("PRAGMA foreign_keys = ON");
     fresh.run("PRAGMA busy_timeout = 5000");
     const db = drizzle(fresh, { schema });
-    migrate(db, { migrationsFolder: fileURLToPath(new URL("./migrations", import.meta.url)) });
+    recoverGithubClientIdMigration(fresh);
+    recoverWalkthroughModesMigration(fresh);
+    recoverReviewSessionModesMigration(fresh);
+    recoverAvatarContentMigrations(fresh);
+    recoverUnjournaledReviewRoundMigration(fresh);
+    migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+    ensureGithubClientIdColumn(fresh);
+    ensureAvatarContentSchema(fresh);
+    ensureWalkthroughModesSchema(fresh);
+    ensureReviewSessionModesSchema(fresh);
+    ensureReviewRoundSchema(fresh);
     insertData(db, data);
     hardenDbFile(dbPath);
     return db;
@@ -320,7 +609,17 @@ export function createDb(path?: string) {
 
   // ── Normal path ──────────────────────────────────────────
   const db = drizzle(sqlite, { schema });
-  migrate(db, { migrationsFolder: fileURLToPath(new URL("./migrations", import.meta.url)) });
+  recoverGithubClientIdMigration(sqlite);
+  recoverWalkthroughModesMigration(sqlite);
+  recoverReviewSessionModesMigration(sqlite);
+  recoverAvatarContentMigrations(sqlite);
+  recoverUnjournaledReviewRoundMigration(sqlite);
+  migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+  ensureGithubClientIdColumn(sqlite);
+  ensureAvatarContentSchema(sqlite);
+  ensureWalkthroughModesSchema(sqlite);
+  ensureReviewSessionModesSchema(sqlite);
+  ensureReviewRoundSchema(sqlite);
   hardenDbFile(dbPath);
   return db;
 }

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -401,11 +401,16 @@ function recoverWalkthroughModesMigration(sqlite: Database): void {
 
   const hasMode = columnExists(sqlite, "walkthroughs", "mode");
   const isRecorded = migrationRecorded(sqlite, WALKTHROUGH_MODES_MIGRATION_WHEN);
-  if (!hasMode && (isRecorded || hasAnyReviewRoundMigrationArtifact(sqlite))) {
+  const shouldRecover = hasMode || isRecorded || hasAnyReviewRoundMigrationArtifact(sqlite);
+  if (!shouldRecover) return;
+
+  if (!hasMode) {
     ensureWalkthroughModesSchema(sqlite);
-    recordMigration(sqlite, WALKTHROUGH_MODES_MIGRATION_TAG, WALKTHROUGH_MODES_MIGRATION_WHEN);
-    refreshMigrationHash(sqlite, WALKTHROUGH_MODES_MIGRATION_TAG, WALKTHROUGH_MODES_MIGRATION_WHEN);
   }
+  if (!isRecorded) {
+    recordMigration(sqlite, WALKTHROUGH_MODES_MIGRATION_TAG, WALKTHROUGH_MODES_MIGRATION_WHEN);
+  }
+  refreshMigrationHash(sqlite, WALKTHROUGH_MODES_MIGRATION_TAG, WALKTHROUGH_MODES_MIGRATION_WHEN);
 }
 
 function ensureReviewSessionModesSchema(sqlite: Database): void {
@@ -425,19 +430,24 @@ function recoverReviewSessionModesMigration(sqlite: Database): void {
 
   const hasMode = columnExists(sqlite, "review_sessions", "mode");
   const isRecorded = migrationRecorded(sqlite, REVIEW_SESSION_MODES_MIGRATION_WHEN);
-  if (!hasMode && (isRecorded || hasAnyReviewRoundMigrationArtifact(sqlite))) {
+  const shouldRecover = hasMode || isRecorded || hasAnyReviewRoundMigrationArtifact(sqlite);
+  if (!shouldRecover) return;
+
+  if (!hasMode) {
     ensureReviewSessionModesSchema(sqlite);
+  }
+  if (!isRecorded) {
     recordMigration(
       sqlite,
       REVIEW_SESSION_MODES_MIGRATION_TAG,
       REVIEW_SESSION_MODES_MIGRATION_WHEN,
     );
-    refreshMigrationHash(
-      sqlite,
-      REVIEW_SESSION_MODES_MIGRATION_TAG,
-      REVIEW_SESSION_MODES_MIGRATION_WHEN,
-    );
   }
+  refreshMigrationHash(
+    sqlite,
+    REVIEW_SESSION_MODES_MIGRATION_TAG,
+    REVIEW_SESSION_MODES_MIGRATION_WHEN,
+  );
 }
 
 function ensureAvatarContentSchema(sqlite: Database): void {
@@ -776,3 +786,15 @@ export function createDb(path?: string) {
 }
 
 export type Db = ReturnType<typeof createDb>;
+
+export const __dbRecoveryTest = {
+  columnExists,
+  ensureReviewRoundSchema,
+  migrationRecorded,
+  recoverReviewSessionModesMigration,
+  recoverUnjournaledReviewRoundMigration,
+  recoverWalkthroughModesMigration,
+  REVIEW_ROUNDS_MIGRATION_WHEN,
+  REVIEW_SESSION_MODES_MIGRATION_WHEN,
+  WALKTHROUGH_MODES_MIGRATION_WHEN,
+};

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -90,6 +90,13 @@ const REVIEW_SESSION_MODES_MIGRATION_TAG = "0230_review_session_modes";
 const REVIEW_SESSION_MODES_MIGRATION_WHEN = 1779600000000;
 const REPOSITORY_AVATAR_CONTENT_MIGRATION_TAG = "0240_repository_avatar_content";
 const REPOSITORY_AVATAR_CONTENT_MIGRATION_WHEN = 1779610000000;
+const CHAT_SESSION_MODEL_MIGRATION_TAG = "0260_chat_session_model";
+const CHAT_SESSION_MODEL_MIGRATION_WHEN = 1779620000000;
+const UNIFY_AGENT_IDS_MIGRATION_WHEN = 1779625000000;
+const CHAT_MESSAGE_ATTACHMENTS_MIGRATION_TAG = "0280_chat_message_attachments";
+const CHAT_MESSAGE_ATTACHMENTS_MIGRATION_WHEN = 1779630000000;
+const CHAT_ACTIVITY_RESULTS_MIGRATION_TAG = "0290_chat_activity_results";
+const CHAT_ACTIVITY_RESULTS_MIGRATION_WHEN = 1779635000000;
 const REVIEW_ROUNDS_MIGRATION_TAG = "0300_review_rounds";
 const REVIEW_ROUNDS_MIGRATION_WHEN = 1779640000000;
 
@@ -472,6 +479,138 @@ function recoverAvatarContentMigrations(sqlite: Database): void {
   }
 }
 
+function hasAnyChatSessionModelMigrationArtifact(sqlite: Database): boolean {
+  return (
+    columnExists(sqlite, "chat_sessions", "model") ||
+    indexExists(sqlite, "chat_sessions_pr_agent_model_sha_unique")
+  );
+}
+
+function hasLaterChatSessionMigration(sqlite: Database): boolean {
+  return (
+    migrationRecorded(sqlite, UNIFY_AGENT_IDS_MIGRATION_WHEN) ||
+    migrationRecorded(sqlite, CHAT_MESSAGE_ATTACHMENTS_MIGRATION_WHEN) ||
+    migrationRecorded(sqlite, CHAT_ACTIVITY_RESULTS_MIGRATION_WHEN) ||
+    migrationRecorded(sqlite, REVIEW_ROUNDS_MIGRATION_WHEN) ||
+    hasAnyReviewRoundMigrationArtifact(sqlite)
+  );
+}
+
+function ensureChatSessionModelSchema(sqlite: Database): void {
+  if (!tableExists(sqlite, "chat_sessions")) return;
+
+  if (!columnExists(sqlite, "chat_sessions", "model")) {
+    sqlite.run("ALTER TABLE `chat_sessions` ADD `model` text DEFAULT '' NOT NULL");
+  }
+
+  sqlite.run("DROP INDEX IF EXISTS `chat_sessions_pr_agent_sha_unique`");
+
+  const expectedColumns = ["pull_request_id", "agent", "model", "pr_head_sha"];
+  const currentColumns = indexColumns(sqlite, "chat_sessions_pr_agent_model_sha_unique");
+  if (currentColumns.join("\0") !== expectedColumns.join("\0")) {
+    sqlite.run("DROP INDEX IF EXISTS `chat_sessions_pr_agent_model_sha_unique`");
+    sqlite.run(`
+      CREATE UNIQUE INDEX \`chat_sessions_pr_agent_model_sha_unique\`
+        ON \`chat_sessions\` (\`pull_request_id\`, \`agent\`, \`model\`, \`pr_head_sha\`)
+    `);
+  }
+}
+
+function recoverChatSessionModelMigration(sqlite: Database): void {
+  if (!tableExists(sqlite, "chat_sessions")) return;
+
+  const isRecorded = migrationRecorded(sqlite, CHAT_SESSION_MODEL_MIGRATION_WHEN);
+  const hasArtifacts = hasAnyChatSessionModelMigrationArtifact(sqlite);
+  if (!isRecorded && !hasArtifacts && !hasLaterChatSessionMigration(sqlite)) return;
+
+  ensureChatSessionModelSchema(sqlite);
+  recordMigration(sqlite, CHAT_SESSION_MODEL_MIGRATION_TAG, CHAT_SESSION_MODEL_MIGRATION_WHEN);
+  refreshMigrationHash(sqlite, CHAT_SESSION_MODEL_MIGRATION_TAG, CHAT_SESSION_MODEL_MIGRATION_WHEN);
+}
+
+function hasLaterChatMessageMigration(sqlite: Database): boolean {
+  return (
+    migrationRecorded(sqlite, CHAT_ACTIVITY_RESULTS_MIGRATION_WHEN) ||
+    migrationRecorded(sqlite, REVIEW_ROUNDS_MIGRATION_WHEN) ||
+    hasAnyReviewRoundMigrationArtifact(sqlite)
+  );
+}
+
+function ensureChatMessageAttachmentsSchema(sqlite: Database): void {
+  if (!tableExists(sqlite, "chat_messages")) return;
+  if (columnExists(sqlite, "chat_messages", "attachments_json")) return;
+  sqlite.run("ALTER TABLE `chat_messages` ADD `attachments_json` text");
+}
+
+function recoverChatMessageAttachmentsMigration(sqlite: Database): void {
+  if (!tableExists(sqlite, "chat_messages")) return;
+
+  const isRecorded = migrationRecorded(sqlite, CHAT_MESSAGE_ATTACHMENTS_MIGRATION_WHEN);
+  const hasColumn = columnExists(sqlite, "chat_messages", "attachments_json");
+  if (!isRecorded && !hasColumn && !hasLaterChatMessageMigration(sqlite)) return;
+
+  ensureChatMessageAttachmentsSchema(sqlite);
+  recordMigration(
+    sqlite,
+    CHAT_MESSAGE_ATTACHMENTS_MIGRATION_TAG,
+    CHAT_MESSAGE_ATTACHMENTS_MIGRATION_WHEN,
+  );
+  refreshMigrationHash(
+    sqlite,
+    CHAT_MESSAGE_ATTACHMENTS_MIGRATION_TAG,
+    CHAT_MESSAGE_ATTACHMENTS_MIGRATION_WHEN,
+  );
+}
+
+function ensureChatActivityResultsSchema(sqlite: Database): void {
+  if (!tableExists(sqlite, "chat_activities")) return;
+
+  if (!columnExists(sqlite, "chat_activities", "call_id")) {
+    sqlite.run("ALTER TABLE `chat_activities` ADD `call_id` text");
+  }
+  if (!columnExists(sqlite, "chat_activities", "output")) {
+    sqlite.run("ALTER TABLE `chat_activities` ADD `output` text");
+  }
+  if (!columnExists(sqlite, "chat_activities", "is_error")) {
+    sqlite.run("ALTER TABLE `chat_activities` ADD `is_error` integer");
+  }
+  sqlite.run(`
+    CREATE INDEX IF NOT EXISTS \`chat_activities_session_call_idx\`
+      ON \`chat_activities\` (\`chat_session_id\`, \`call_id\`)
+  `);
+}
+
+function recoverChatActivityResultsMigration(sqlite: Database): void {
+  if (!tableExists(sqlite, "chat_activities")) return;
+
+  const isRecorded = migrationRecorded(sqlite, CHAT_ACTIVITY_RESULTS_MIGRATION_WHEN);
+  const hasArtifacts =
+    columnExists(sqlite, "chat_activities", "call_id") ||
+    columnExists(sqlite, "chat_activities", "output") ||
+    columnExists(sqlite, "chat_activities", "is_error") ||
+    indexExists(sqlite, "chat_activities_session_call_idx");
+  if (
+    !isRecorded &&
+    !hasArtifacts &&
+    !migrationRecorded(sqlite, REVIEW_ROUNDS_MIGRATION_WHEN) &&
+    !hasAnyReviewRoundMigrationArtifact(sqlite)
+  ) {
+    return;
+  }
+
+  ensureChatActivityResultsSchema(sqlite);
+  recordMigration(
+    sqlite,
+    CHAT_ACTIVITY_RESULTS_MIGRATION_TAG,
+    CHAT_ACTIVITY_RESULTS_MIGRATION_WHEN,
+  );
+  refreshMigrationHash(
+    sqlite,
+    CHAT_ACTIVITY_RESULTS_MIGRATION_TAG,
+    CHAT_ACTIVITY_RESULTS_MIGRATION_WHEN,
+  );
+}
+
 /**
  * Defensive repair for local databases that already received part or all of
  * the review-round schema outside the Drizzle journal. Keep this idempotent
@@ -595,10 +734,16 @@ export function createDb(path?: string) {
     recoverWalkthroughModesMigration(fresh);
     recoverReviewSessionModesMigration(fresh);
     recoverAvatarContentMigrations(fresh);
+    recoverChatSessionModelMigration(fresh);
+    recoverChatMessageAttachmentsMigration(fresh);
+    recoverChatActivityResultsMigration(fresh);
     recoverUnjournaledReviewRoundMigration(fresh);
     migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
     ensureGithubClientIdColumn(fresh);
     ensureAvatarContentSchema(fresh);
+    ensureChatSessionModelSchema(fresh);
+    ensureChatMessageAttachmentsSchema(fresh);
+    ensureChatActivityResultsSchema(fresh);
     ensureWalkthroughModesSchema(fresh);
     ensureReviewSessionModesSchema(fresh);
     ensureReviewRoundSchema(fresh);
@@ -613,10 +758,16 @@ export function createDb(path?: string) {
   recoverWalkthroughModesMigration(sqlite);
   recoverReviewSessionModesMigration(sqlite);
   recoverAvatarContentMigrations(sqlite);
+  recoverChatSessionModelMigration(sqlite);
+  recoverChatMessageAttachmentsMigration(sqlite);
+  recoverChatActivityResultsMigration(sqlite);
   recoverUnjournaledReviewRoundMigration(sqlite);
   migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
   ensureGithubClientIdColumn(sqlite);
   ensureAvatarContentSchema(sqlite);
+  ensureChatSessionModelSchema(sqlite);
+  ensureChatMessageAttachmentsSchema(sqlite);
+  ensureChatActivityResultsSchema(sqlite);
   ensureWalkthroughModesSchema(sqlite);
   ensureReviewSessionModesSchema(sqlite);
   ensureReviewRoundSchema(sqlite);

--- a/apps/server/src/db/migrations/0300_review_rounds.sql
+++ b/apps/server/src/db/migrations/0300_review_rounds.sql
@@ -1,0 +1,39 @@
+ALTER TABLE `walkthroughs` ADD `parent_walkthrough_id` text REFERENCES `walkthroughs`(`id`) ON DELETE set null;
+--> statement-breakpoint
+ALTER TABLE `walkthroughs` ADD `base_head_sha` text;
+--> statement-breakpoint
+ALTER TABLE `walkthroughs` ADD `generation_mode` text DEFAULT 'full' NOT NULL;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `walkthroughs_pr_head_sha_unique`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `walkthroughs_pr_head_sha_mode_unique`;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `walkthroughs_active_pr_head_sha_unique`
+  ON `walkthroughs` (`pull_request_id`, `pr_head_sha`, `mode`, `generation_mode`)
+  WHERE `status` <> 'superseded';
+--> statement-breakpoint
+CREATE TABLE `review_rounds` (
+  `id` text PRIMARY KEY NOT NULL,
+  `pull_request_id` text NOT NULL,
+  `review_session_id` text NOT NULL,
+  `walkthrough_id` text NOT NULL,
+  `previous_walkthrough_id` text,
+  `round_number` integer NOT NULL,
+  `kind` text DEFAULT 'full' NOT NULL,
+  `visibility` text DEFAULT 'visible' NOT NULL,
+  `status` text DEFAULT 'generating' NOT NULL,
+  `from_sha` text,
+  `to_sha` text NOT NULL,
+  `created_at` text NOT NULL,
+  `completed_at` text,
+  FOREIGN KEY (`pull_request_id`) REFERENCES `pull_requests`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`review_session_id`) REFERENCES `review_sessions`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`walkthrough_id`) REFERENCES `walkthroughs`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`previous_walkthrough_id`) REFERENCES `walkthroughs`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `review_rounds_pr_round_idx`
+  ON `review_rounds` (`pull_request_id`, `round_number`);
+--> statement-breakpoint
+CREATE INDEX `review_rounds_walkthrough_idx`
+  ON `review_rounds` (`walkthrough_id`);

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1779635000000,
       "tag": "0290_chat_activity_results",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1779640000000,
+      "tag": "0300_review_rounds",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/index.ts
+++ b/apps/server/src/db/schema/index.ts
@@ -25,6 +25,7 @@ export { recapPrEntries } from "./recap-pr-entries";
 export { recapThemeSummaries } from "./recap-theme-summaries";
 export { remoteUsers } from "./remote-users";
 export { repositories } from "./repositories";
+export { reviewRounds } from "./review-rounds";
 export { reviewSessions } from "./review-sessions";
 export { threadMessages } from "./thread-messages";
 export { userSettings } from "./user-settings";

--- a/apps/server/src/db/schema/review-rounds.ts
+++ b/apps/server/src/db/schema/review-rounds.ts
@@ -1,0 +1,43 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { pullRequests } from "./pull-requests";
+import { reviewSessions } from "./review-sessions";
+import { walkthroughs } from "./walkthroughs";
+
+/**
+ * Durable timeline of review attempts for a PR.
+ *
+ * The walkthrough remains the visible report artifact. Review rounds are the
+ * hidden history/control-plane layer: they record which SHA range was reviewed,
+ * which walkthrough artifact resulted, and whether the row should be surfaced
+ * in future history UI.
+ */
+export const reviewRounds = sqliteTable(
+  "review_rounds",
+  {
+    id: text("id").primaryKey(),
+    pullRequestId: text("pull_request_id")
+      .notNull()
+      .references(() => pullRequests.id, { onDelete: "cascade" }),
+    reviewSessionId: text("review_session_id")
+      .notNull()
+      .references(() => reviewSessions.id, { onDelete: "cascade" }),
+    walkthroughId: text("walkthrough_id")
+      .notNull()
+      .references(() => walkthroughs.id, { onDelete: "cascade" }),
+    previousWalkthroughId: text("previous_walkthrough_id").references(() => walkthroughs.id, {
+      onDelete: "set null",
+    }),
+    roundNumber: integer("round_number").notNull(),
+    kind: text("kind").notNull().default("full"),
+    visibility: text("visibility").notNull().default("visible"),
+    status: text("status").notNull().default("generating"),
+    fromSha: text("from_sha"),
+    toSha: text("to_sha").notNull(),
+    createdAt: text("created_at").notNull(),
+    completedAt: text("completed_at"),
+  },
+  (t) => ({
+    prRoundIdx: index("review_rounds_pr_round_idx").on(t.pullRequestId, t.roundNumber),
+    walkthroughIdx: index("review_rounds_walkthrough_idx").on(t.walkthroughId),
+  }),
+);

--- a/apps/server/src/db/schema/walkthroughs.ts
+++ b/apps/server/src/db/schema/walkthroughs.ts
@@ -1,4 +1,5 @@
 import { REVIEW_MODE, type WalkthroughMode } from "@revv/shared";
+import { sql } from "drizzle-orm";
 import {
   type AnySQLiteColumn,
   integer,
@@ -74,6 +75,28 @@ export const walkthroughs = sqliteTable(
     supersededBy: text("superseded_by").references((): AnySQLiteColumn => walkthroughs.id, {
       onDelete: "set null",
     }),
+    /**
+     * Optional parent row used by incremental refreshes. The parent is the
+     * previous review artifact the agent should treat as its starting point;
+     * this row remains a separate immutable artifact for the new head SHA.
+     */
+    parentWalkthroughId: text("parent_walkthrough_id").references(
+      (): AnySQLiteColumn => walkthroughs.id,
+      {
+        onDelete: "set null",
+      },
+    ),
+    /**
+     * The prior PR head used as the incremental base. Null for fresh full
+     * generations and for legacy rows.
+     */
+    baseHeadSha: text("base_head_sha"),
+    /**
+     * `full` is the original from-scratch pipeline. `incremental` produces
+     * the same visible report shape, seeded by `parentWalkthroughId` and the
+     * `baseHeadSha..prHeadSha` commit range.
+     */
+    generationMode: text("generation_mode").notNull().default("full"),
     generatedAt: text("generated_at").notNull(),
     /**
      * ISO 8601 timestamp set when {@link WalkthroughJobs.setStatus} transitions
@@ -166,10 +189,8 @@ export const walkthroughs = sqliteTable(
      * Superseded rows share the PR but differ on head_sha, so this uniqueness
      * doesn't block new-commit flows.
      */
-    prHeadShaUnique: uniqueIndex("walkthroughs_pr_head_sha_mode_unique").on(
-      t.pullRequestId,
-      t.prHeadSha,
-      t.mode,
-    ),
+    activePrHeadShaUnique: uniqueIndex("walkthroughs_active_pr_head_sha_unique")
+      .on(t.pullRequestId, t.prHeadSha, t.mode, t.generationMode)
+      .where(sql`${t.status} <> 'superseded'`),
   }),
 );

--- a/apps/server/src/domain/errors.ts
+++ b/apps/server/src/domain/errors.ts
@@ -16,6 +16,11 @@ export class GitHubNetworkError extends Data.TaggedError("GitHubNetworkError")<{
   readonly cause: unknown;
 }> {}
 
+export class GitHubAccessDeniedError extends Data.TaggedError("GitHubAccessDeniedError")<{
+  readonly resource: string;
+  readonly message: string;
+}> {}
+
 export class GitHubNotFoundError extends Data.TaggedError("GitHubNotFoundError")<{
   readonly resource: string;
   readonly id: string;
@@ -24,6 +29,7 @@ export class GitHubNotFoundError extends Data.TaggedError("GitHubNotFoundError")
 export type GitHubError =
   | GitHubRateLimitError
   | GitHubAuthError
+  | GitHubAccessDeniedError
   | GitHubNetworkError
   | GitHubNotFoundError;
 

--- a/apps/server/src/http-origins.ts
+++ b/apps/server/src/http-origins.ts
@@ -1,0 +1,25 @@
+import { API_PORT, DEV_API_PORT } from "@revv/shared";
+
+const WEB_DEV_ORIGINS = ["http://localhost:5173", "http://127.0.0.1:5173"] as const;
+const API_CHANNEL_ORIGINS = [
+  `http://localhost:${API_PORT}`,
+  `http://localhost:${DEV_API_PORT}`,
+] as const;
+const TAURI_ORIGINS = [
+  "tauri://localhost",
+  "http://tauri.localhost",
+  "https://tauri.localhost",
+] as const;
+
+export const AUTH_TRUSTED_ORIGINS = [
+  ...WEB_DEV_ORIGINS,
+  ...API_CHANNEL_ORIGINS,
+  ...TAURI_ORIGINS,
+] as const;
+
+export const CORS_ORIGINS = [
+  ...WEB_DEV_ORIGINS,
+  "http://[::1]:5173",
+  ...API_CHANNEL_ORIGINS,
+  ...TAURI_ORIGINS,
+] as const;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -5,6 +5,7 @@ import { stopAllAcpConnections } from "./ai/acp/acp-connection";
 import { auth } from "./auth";
 import { serverEnv } from "./config";
 import { resolveDbPath } from "./db/index";
+import { CORS_ORIGINS } from "./http-origins";
 import { logError } from "./logger";
 import { recordSpan } from "./observability/tracer";
 import { chatRoute } from "./routes/chat";
@@ -50,16 +51,7 @@ logError("server", `starting on port ${port}`);
 const app = new Elysia()
   .use(
     cors({
-      origin: [
-        "http://localhost:5173",
-        "http://127.0.0.1:5173",
-        "http://[::1]:5173",
-        "http://localhost:45678",
-        "http://localhost:45679",
-        "tauri://localhost",
-        "http://tauri.localhost",
-        "https://tauri.localhost",
-      ],
+      origin: [...CORS_ORIGINS],
       credentials: true,
       allowedHeaders: ["Content-Type", "Authorization"],
       methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -57,6 +57,7 @@ const app = new Elysia()
         "http://localhost:45678",
         "http://localhost:45679",
         "tauri://localhost",
+        "http://tauri.localhost",
         "https://tauri.localhost",
       ],
       credentials: true,

--- a/apps/server/src/routes/device-auth.ts
+++ b/apps/server/src/routes/device-auth.ts
@@ -132,6 +132,22 @@ function rejectedClientIdBody(host: string): {
   };
 }
 
+function githubDeviceFlowErrorMessage(host: string, res: Response, bodyText: string): string {
+  let detail = bodyText.trim();
+  try {
+    const parsed = JSON.parse(bodyText) as { error?: string; error_description?: string };
+    detail = parsed.error_description ?? parsed.error ?? detail;
+  } catch {
+    // Keep the raw text below.
+  }
+
+  const suffix = detail ? `: ${detail.slice(0, 300)}` : "";
+  return (
+    `GitHub device flow failed for ${host} (${res.status} ${res.statusText}${suffix}). ` +
+    "Check that the client ID belongs to this GitHub host and that Device Flow is enabled."
+  );
+}
+
 interface GitHubDeviceCodeResponse {
   device_code: string;
   user_code: string;
@@ -571,7 +587,7 @@ const publicAuthRoutes = new Elysia()
         if (res.status === 400 || res.status === 401) {
           return status(400, rejectedClientIdBody(urls.host));
         }
-        return status(502, { error: "Failed to initiate device flow" });
+        return status(502, { error: githubDeviceFlowErrorMessage(urls.host, res, text) });
       }
 
       const data = (await res.json()) as GitHubDeviceCodeResponse;

--- a/apps/server/src/routes/middleware.ts
+++ b/apps/server/src/routes/middleware.ts
@@ -6,6 +6,7 @@ import {
   CloneError,
   CloneInProgressError,
   CloneNotReadyError,
+  GitHubAccessDeniedError,
   GitHubAuthError,
   GitHubNetworkError,
   GitHubNotFoundError,
@@ -148,6 +149,11 @@ export function handleAppError(
   if (e instanceof GitHubNotFoundError) {
     ctx.set.status = 404;
     return { error: "Not found on GitHub" };
+  }
+
+  if (e instanceof GitHubAccessDeniedError) {
+    ctx.set.status = 403;
+    return { error: e.message };
   }
 
   if (e instanceof AiNotConfiguredError) {

--- a/apps/server/src/routes/reviews.ts
+++ b/apps/server/src/routes/reviews.ts
@@ -2,8 +2,10 @@ import { Effect } from "effect";
 import { Elysia, t } from "elysia";
 import { AppRuntime } from "../runtime";
 import { Broadcaster } from "../services/Broadcaster";
+import { PrContextService } from "../services/PrContext";
 import { ReviewService } from "../services/Review";
 import { SyncService } from "../services/Sync";
+import { WalkthroughService } from "../services/Walkthrough";
 import { WalkthroughJobs } from "../services/WalkthroughJobs";
 import { handleAppError, withAccount } from "./middleware";
 import { activeSessionHandler, coerceReviewMode } from "./reviews/handlers/active-session";
@@ -233,6 +235,7 @@ export const reviewRoutes = new Elysia({ prefix: "/api/reviews" })
   // events moved to the unified bus.
   .post("/:id/walkthrough/start", async (ctx) => {
     try {
+      const body = ctx.body as { generationMode?: "full" | "incremental" } | undefined;
       const result = await AppRuntime.runPromise(
         Effect.gen(function* () {
           const jobs = yield* WalkthroughJobs;
@@ -248,6 +251,7 @@ export const reviewRoutes = new Elysia({ prefix: "/api/reviews" })
             userId: ctx.session.user.id,
             trigger: "user",
             mode,
+            generationMode: body?.generationMode ?? "full",
           });
         }),
       );
@@ -269,6 +273,56 @@ export const reviewRoutes = new Elysia({ prefix: "/api/reviews" })
     }
   })
 
+  .get("/:id/walkthrough/rounds", async (ctx) => {
+    try {
+      return await AppRuntime.runPromise(
+        Effect.gen(function* () {
+          const prContext = yield* PrContextService;
+          const walkthroughService = yield* WalkthroughService;
+          const mode = coerceWalkthroughMode(ctx.query.mode);
+          const { pr, repo, token } = yield* prContext.resolveBasic(
+            ctx.params.id,
+            ctx.session.user.id,
+          );
+          const commits = yield* prContext
+            .prCommits(repo.fullName, pr.externalId, token)
+            .pipe(Effect.catchAll(() => Effect.succeed([])));
+          return yield* walkthroughService.listReviewRounds(pr.id, pr.headSha, commits, mode);
+        }),
+      );
+    } catch (e) {
+      return handleAppError(e, ctx);
+    }
+  })
+
+  .get("/:id/walkthrough/report/:walkthroughId", async (ctx) => {
+    try {
+      return await AppRuntime.runPromise(
+        Effect.gen(function* () {
+          const prContext = yield* PrContextService;
+          const walkthroughService = yield* WalkthroughService;
+          const mode = coerceWalkthroughMode(ctx.query.mode);
+          const { pr } = yield* prContext.resolveBasic(ctx.params.id, ctx.session.user.id);
+          const report = yield* walkthroughService.getReport(pr.id, ctx.params.walkthroughId, mode);
+          if (!report) return { status: "not_found" as const };
+          const seqAt = yield* walkthroughService.getSeqAt(report.walkthrough.id);
+          return {
+            status: report.status as "complete" | "generating" | "error" | "superseded",
+            walkthrough: report.walkthrough,
+            snapshotAt: new Date().toISOString(),
+            seqAt,
+            stale:
+              report.status === "superseded" ||
+              (pr.headSha !== null && report.walkthrough.prHeadSha !== pr.headSha),
+            historical: true as const,
+          };
+        }),
+      );
+    } catch (e) {
+      return handleAppError(e, ctx);
+    }
+  })
+
   .get("/:id/walkthrough/cached", async (ctx) => {
     try {
       return await getCachedWalkthroughHandler(
@@ -283,11 +337,14 @@ export const reviewRoutes = new Elysia({ prefix: "/api/reviews" })
 
   .post("/:id/walkthrough/regenerate", async (ctx) => {
     try {
+      const body = ctx.body as
+        | { mode?: unknown; generationMode?: "full" | "incremental" }
+        | undefined;
       await regenerateWalkthroughHandler(
         ctx.params.id,
-        (ctx.body as { mode?: unknown } | undefined)?.mode === undefined
-          ? undefined
-          : coerceWalkthroughMode((ctx.body as { mode?: unknown }).mode),
+        ctx.session.user.id,
+        body?.mode === undefined ? undefined : coerceWalkthroughMode(body.mode),
+        body?.generationMode ?? "incremental",
       );
       return { success: true };
     } catch (e) {

--- a/apps/server/src/routes/reviews/handlers/github-submit.test.ts
+++ b/apps/server/src/routes/reviews/handlers/github-submit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { GitHubNetworkError } from "../../../domain/errors";
+import { isExistingPendingReviewError } from "./github-submit";
+
+describe("isExistingPendingReviewError", () => {
+  it("matches GitHub's exact pending-review response", () => {
+    expect(
+      isExistingPendingReviewError(
+        new GitHubNetworkError({
+          cause:
+            '422 Unprocessable Entity: {"errors":["User can only have one pending review per pull request"]}',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches broader 422 pending-review wording", () => {
+    expect(
+      isExistingPendingReviewError(
+        new GitHubNetworkError({
+          cause: "422 Unprocessable Entity: pending review already exists for this pull request",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated 422 responses", () => {
+    expect(
+      isExistingPendingReviewError(
+        new GitHubNetworkError({
+          cause: "422 Unprocessable Entity: validation failed",
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/routes/reviews/handlers/github-submit.ts
+++ b/apps/server/src/routes/reviews/handlers/github-submit.ts
@@ -29,11 +29,18 @@ export interface SubmitReviewInput {
   issueIds?: string[];
 }
 
-function isExistingPendingReviewError(error: unknown): boolean {
+export function isExistingPendingReviewError(error: unknown): boolean {
+  if (!(error instanceof GitHubNetworkError) || typeof error.cause !== "string") {
+    return false;
+  }
+
+  const cause = error.cause;
+  if (cause.includes("User can only have one pending review per pull request")) {
+    return true;
+  }
+
   return (
-    error instanceof GitHubNetworkError &&
-    typeof error.cause === "string" &&
-    error.cause.includes("User can only have one pending review per pull request")
+    cause.includes("422 Unprocessable Entity") && cause.toLowerCase().includes("pending review")
   );
 }
 

--- a/apps/server/src/routes/reviews/handlers/github-submit.ts
+++ b/apps/server/src/routes/reviews/handlers/github-submit.ts
@@ -29,11 +29,6 @@ export interface SubmitReviewInput {
   issueIds?: string[];
 }
 
-interface SubmittedCommentLink {
-  readonly threadId: string;
-  readonly externalCommentId: string;
-}
-
 function isExistingPendingReviewError(error: unknown): boolean {
   return (
     error instanceof GitHubNetworkError &&
@@ -93,7 +88,6 @@ export function submitGithubReviewHandler(prId: string, userId: string, body: Su
         return comment;
       });
 
-      const submittedCommentLinks: SubmittedCommentLink[] = [];
       const reviewInput = {
         event: eventMap[body.action],
         body: body.body ?? "",
@@ -120,80 +114,30 @@ export function submitGithubReviewHandler(prId: string, userId: string, body: Su
                 );
               }
 
-              const submitted = yield* github.reviews.submitPending(
+              yield* github.reviews.deletePending(
                 repo.fullName,
                 pr.externalId,
                 pending.id,
-                {
-                  event: reviewInput.event,
-                  body: reviewInput.body,
-                },
                 ghToken,
               );
-
-              const commitSha = pr.headSha;
-              if (!commitSha) {
-                return yield* Effect.fail(
-                  new GitHubNetworkError({
-                    cause:
-                      "Cannot post review comments because the pull request head SHA is missing locally. Sync the PR and retry.",
-                  }),
-                );
-              }
-
-              for (const [index, comment] of comments.entries()) {
-                const input = inputComments[index];
-                if (!input) continue;
-                const posted = yield* github.reviews.createComment(
-                  repo.fullName,
-                  pr.externalId,
-                  {
-                    ...comment,
-                    commitSha,
-                  },
-                  ghToken,
-                );
-                submittedCommentLinks.push({
-                  threadId: input.threadId,
-                  externalCommentId: String(posted.id),
-                });
-              }
-
-              return submitted;
+              return yield* github.reviews.submit(
+                repo.fullName,
+                pr.externalId,
+                reviewInput,
+                ghToken,
+              );
             }),
           ),
         );
 
       // Link local threads to GitHub comment IDs so that the subsequent
       // sync-threads call doesn't create duplicate entries.
-      for (const link of submittedCommentLinks) {
-        yield* reviewService
-          .setThreadExternalIds(link.threadId, {
-            externalCommentId: link.externalCommentId,
-          })
-          .pipe(Effect.orElseSucceed(() => undefined));
-
-        const messages = yield* reviewService
-          .getMessages(link.threadId)
-          .pipe(Effect.orElseSucceed(() => []));
-        const unsyncedMsg = [...messages]
-          .reverse()
-          .find((m) => m.authorRole === "reviewer" && m.externalId == null);
-        if (unsyncedMsg) {
-          yield* reviewService
-            .setMessageExternalId(unsyncedMsg.id, link.externalCommentId)
-            .pipe(Effect.orElseSucceed(() => undefined));
-        }
-      }
-
       if (inputComments.length > 0) {
-        const linkedThreadIds = new Set(submittedCommentLinks.map((link) => link.threadId));
         const ghComments = yield* github.reviews
           .commentsForReview(repo.fullName, pr.externalId, review.id, ghToken)
           .pipe(Effect.orElseSucceed(() => []));
 
         for (const input of inputComments) {
-          if (linkedThreadIds.has(input.threadId)) continue;
           const effectiveLine = input.line;
           // Prefer an exact path+line+body match; fall back to path+line, then
           // path+body. The `/reviews/:id/comments` response can return a null

--- a/apps/server/src/routes/reviews/handlers/github-submit.ts
+++ b/apps/server/src/routes/reviews/handlers/github-submit.ts
@@ -1,4 +1,5 @@
 import { Effect } from "effect";
+import { GitHubNetworkError } from "../../../domain/errors";
 import { AppRuntime } from "../../../runtime";
 import { Broadcaster } from "../../../services/Broadcaster";
 import { GitHubGateway } from "../../../services/GitHub";
@@ -26,6 +27,19 @@ export interface SubmitReviewInput {
    * PR-switches. Empty / missing for pure approve flows with no issue list.
    */
   issueIds?: string[];
+}
+
+interface SubmittedCommentLink {
+  readonly threadId: string;
+  readonly externalCommentId: string;
+}
+
+function isExistingPendingReviewError(error: unknown): boolean {
+  return (
+    error instanceof GitHubNetworkError &&
+    typeof error.cause === "string" &&
+    error.cause.includes("User can only have one pending review per pull request")
+  );
 }
 
 /**
@@ -57,7 +71,8 @@ export function submitGithubReviewHandler(prId: string, userId: string, body: Su
         comment: "COMMENT",
       } as const;
 
-      const comments = (body.comments ?? []).map((c) => {
+      const inputComments = body.comments ?? [];
+      const comments = inputComments.map((c) => {
         const comment: {
           path: string;
           body: string;
@@ -78,26 +93,107 @@ export function submitGithubReviewHandler(prId: string, userId: string, body: Su
         return comment;
       });
 
-      const review = yield* github.reviews.submit(
-        repo.fullName,
-        pr.externalId,
-        {
-          event: eventMap[body.action],
-          body: body.body ?? "",
-          comments,
-        },
-        ghToken,
-      );
+      const submittedCommentLinks: SubmittedCommentLink[] = [];
+      const reviewInput = {
+        event: eventMap[body.action],
+        body: body.body ?? "",
+        comments,
+      };
+      const review = yield* github.reviews
+        .submit(repo.fullName, pr.externalId, reviewInput, ghToken)
+        .pipe(
+          Effect.catchIf(isExistingPendingReviewError, () =>
+            Effect.gen(function* () {
+              const reviewer = yield* github.users.authenticatedFresh(ghToken);
+              const pending = yield* github.reviews.findPending(
+                repo.fullName,
+                pr.externalId,
+                reviewer.login,
+                ghToken,
+              );
+              if (!pending) {
+                return yield* Effect.fail(
+                  new GitHubNetworkError({
+                    cause:
+                      "GitHub reported an existing pending review, but Revv could not find it for the authenticated user.",
+                  }),
+                );
+              }
+
+              const submitted = yield* github.reviews.submitPending(
+                repo.fullName,
+                pr.externalId,
+                pending.id,
+                {
+                  event: reviewInput.event,
+                  body: reviewInput.body,
+                },
+                ghToken,
+              );
+
+              const commitSha = pr.headSha;
+              if (!commitSha) {
+                return yield* Effect.fail(
+                  new GitHubNetworkError({
+                    cause:
+                      "Cannot post review comments because the pull request head SHA is missing locally. Sync the PR and retry.",
+                  }),
+                );
+              }
+
+              for (const [index, comment] of comments.entries()) {
+                const input = inputComments[index];
+                if (!input) continue;
+                const posted = yield* github.reviews.createComment(
+                  repo.fullName,
+                  pr.externalId,
+                  {
+                    ...comment,
+                    commitSha,
+                  },
+                  ghToken,
+                );
+                submittedCommentLinks.push({
+                  threadId: input.threadId,
+                  externalCommentId: String(posted.id),
+                });
+              }
+
+              return submitted;
+            }),
+          ),
+        );
 
       // Link local threads to GitHub comment IDs so that the subsequent
       // sync-threads call doesn't create duplicate entries.
-      const inputComments = body.comments ?? [];
+      for (const link of submittedCommentLinks) {
+        yield* reviewService
+          .setThreadExternalIds(link.threadId, {
+            externalCommentId: link.externalCommentId,
+          })
+          .pipe(Effect.orElseSucceed(() => undefined));
+
+        const messages = yield* reviewService
+          .getMessages(link.threadId)
+          .pipe(Effect.orElseSucceed(() => []));
+        const unsyncedMsg = [...messages]
+          .reverse()
+          .find((m) => m.authorRole === "reviewer" && m.externalId == null);
+        if (unsyncedMsg) {
+          yield* reviewService
+            .setMessageExternalId(unsyncedMsg.id, link.externalCommentId)
+            .pipe(Effect.orElseSucceed(() => undefined));
+        }
+      }
+
       if (inputComments.length > 0) {
+        const linkedThreadIds = new Set(submittedCommentLinks.map((link) => link.threadId));
         const ghComments = yield* github.reviews
           .commentsForReview(repo.fullName, pr.externalId, review.id, ghToken)
           .pipe(Effect.orElseSucceed(() => []));
 
         for (const input of inputComments) {
+          if (linkedThreadIds.has(input.threadId)) continue;
           const effectiveLine = input.line;
           // Prefer an exact path+line+body match; fall back to path+line, then
           // path+body. The `/reviews/:id/comments` response can return a null

--- a/apps/server/src/routes/reviews/handlers/walkthrough-cache.ts
+++ b/apps/server/src/routes/reviews/handlers/walkthrough-cache.ts
@@ -109,9 +109,24 @@ export function getCachedWalkthroughHandler(
  * change in the background, so the user-clicked Pull and the
  * polling-detected commit produce identical externally-observable state.
  */
-export function regenerateWalkthroughHandler(prId: string, mode?: WalkthroughMode) {
+export function regenerateWalkthroughHandler(
+  prId: string,
+  userId: string,
+  mode?: WalkthroughMode,
+  generationMode: "full" | "incremental" = "incremental",
+) {
   return AppRuntime.runPromise(
-    Effect.flatMap(WalkthroughJobs, (jobs) => jobs.supersedeForPr(prId, undefined, mode)),
+    Effect.gen(function* () {
+      const jobs = yield* WalkthroughJobs;
+      if (generationMode === "full") {
+        yield* jobs.supersedeForPr(prId, undefined, mode);
+        return;
+      }
+
+      const prContext = yield* PrContextService;
+      const { pr } = yield* prContext.resolveBasic(prId, userId);
+      yield* jobs.supersedeForPr(prId, pr.headSha ?? undefined, mode);
+    }),
   );
 }
 

--- a/apps/server/src/routes/reviews/handlers/walkthrough-current.ts
+++ b/apps/server/src/routes/reviews/handlers/walkthrough-current.ts
@@ -6,12 +6,13 @@ import { WalkthroughService } from "../../../services/Walkthrough";
 import { WalkthroughJobs } from "../../../services/WalkthroughJobs";
 
 /**
- * GET /api/reviews/:id/walkthrough/current — full current state for any
- * non-superseded walkthrough at the PR's HEAD SHA.
+ * GET /api/reviews/:id/walkthrough/current — full current state for the PR.
  *
  * Four response shapes:
  *   • `status: 'complete'`   → finished walkthrough; client renders immediately,
- *                              no SSE needed.
+ *                              no SSE needed. May include `stale: true` when
+ *                              it is the latest historical walkthrough rather
+ *                              than a walkthrough for the current PR HEAD.
  *   • `status: 'generating'` → in-flight job; client hydrates partial content
  *                              and opens SSE from `snapshotAt` cursor so only
  *                              race-window events arrive over the wire.
@@ -96,6 +97,22 @@ export function getCurrentWalkthroughHandler(
             seqAt,
           };
         }
+      }
+
+      // 4. New commits have invalidated the latest generated row, but the
+      //    user has not started the incremental walkthrough yet. Keep the
+      //    last reviewed artifact visible and mark it stale so the action bar
+      //    offers "Review new commits" instead of making the page feel empty.
+      const latest = yield* walkthroughService.getLatestDisplayable(pr.id, mode);
+      if (latest && latest.prHeadSha !== headSha) {
+        const seqAt = yield* walkthroughService.getSeqAt(latest.id);
+        return {
+          status: "complete" as const,
+          walkthrough: latest,
+          snapshotAt: new Date().toISOString(),
+          seqAt,
+          stale: true as const,
+        };
       }
 
       return { status: "not_found" as const };

--- a/apps/server/src/routes/walkthroughs.ts
+++ b/apps/server/src/routes/walkthroughs.ts
@@ -4,9 +4,8 @@
 //   • GET /api/walkthroughs/active — list in-flight jobs for the user's
 //     account so the SSE client can seed sidebar spinners + `lastSeenSeq`
 //     cursors on (re)connect. Returns the cursor `seqAt = next_seq - 1` per
-//     row; future SSE envelopes with `seq > seqAt` apply normally; any
-//     in-flight envelope with `seq <= seqAt` is dropped defensively by
-//     the client reducer.
+//     row; clients must pair that cursor with a REST snapshot before dropping
+//     older envelopes.
 
 import { Effect } from "effect";
 import { Elysia } from "elysia";

--- a/apps/server/src/services/Ai.ts
+++ b/apps/server/src/services/Ai.ts
@@ -113,6 +113,13 @@ export class AiService extends Context.Tag("AiService")<
       mode: WalkthroughMode;
       files: PrFileMeta[];
       worktreePath: string;
+      reviewMode?: {
+        readonly mode: "full" | "incremental";
+        readonly parentWalkthroughId: string | null;
+        readonly baseHeadSha: string | null;
+        readonly headSha: string;
+        readonly diffSource?: "full_pr" | "incremental_range" | "full_pr_fallback";
+      };
       continuation?: ContinuationContext;
       onSessionId?: (sessionId: string) => void;
       /**

--- a/apps/server/src/services/GitHub.ts
+++ b/apps/server/src/services/GitHub.ts
@@ -15,6 +15,7 @@ import {
   assertGitHubOk,
   conditionalFetch,
   conditionalFetchPaginated,
+  githubDelete,
   githubFetch,
   githubFetchPaginated,
   githubGraphql,
@@ -273,16 +274,12 @@ interface GitHubGatewayFlatService {
     reviewerLogin: string,
     token: string,
   ) => Effect.Effect<{ id: number; htmlUrl: string } | null, GitHubError, SettingsService>;
-  readonly submitPendingReview: (
+  readonly deletePendingReview: (
     repoFullName: string,
     prNumber: number,
     reviewId: number,
-    review: {
-      readonly body: string;
-      readonly event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
-    },
     token: string,
-  ) => Effect.Effect<{ id: number; htmlUrl: string }, GitHubError, SettingsService>;
+  ) => Effect.Effect<void, GitHubError, SettingsService>;
   readonly listReviewCommentsForReview: (
     repoFullName: string,
     prNumber: number,
@@ -1010,24 +1007,15 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
-  submitPendingReview: (repoFullName, prNumber, reviewId, review, token) =>
+  deletePendingReview: (repoFullName, prNumber, reviewId, token) =>
     Effect.gen(function* () {
       const apiBase = yield* resolveApiBase;
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
-      const data = yield* githubPost(
-        `/repos/${owner}/${repo}/pulls/${prNumber}/reviews/${reviewId}/events`,
+      yield* githubDelete(
+        `/repos/${owner}/${repo}/pulls/${prNumber}/reviews/${reviewId}`,
         token,
-        {
-          event: review.event,
-          body: review.body,
-        },
         apiBase,
       );
-      const raw = data as Record<string, unknown>;
-      return {
-        id: raw.id as number,
-        htmlUrl: (raw.html_url as string | undefined) ?? "",
-      };
     }),
 
   listReviewCommentsForReview: (repoFullName, prNumber, reviewId, token) =>
@@ -1438,7 +1426,7 @@ export interface GitHubGatewayService {
   readonly reviews: {
     readonly submit: GitHubGatewayFlat["postReview"];
     readonly findPending: GitHubGatewayFlat["findPendingReview"];
-    readonly submitPending: GitHubGatewayFlat["submitPendingReview"];
+    readonly deletePending: GitHubGatewayFlat["deletePendingReview"];
     readonly commentsForReview: GitHubGatewayFlat["listReviewCommentsForReview"];
     readonly createComment: GitHubGatewayFlat["postReviewComment"];
     readonly replyToComment: GitHubGatewayFlat["replyToComment"];
@@ -1490,7 +1478,7 @@ export const GitHubGatewayLive = Layer.succeed(GitHubGateway, {
   reviews: {
     submit: githubGatewayFlat.postReview,
     findPending: githubGatewayFlat.findPendingReview,
-    submitPending: githubGatewayFlat.submitPendingReview,
+    deletePending: githubGatewayFlat.deletePendingReview,
     commentsForReview: githubGatewayFlat.listReviewCommentsForReview,
     createComment: githubGatewayFlat.postReviewComment,
     replyToComment: githubGatewayFlat.replyToComment,

--- a/apps/server/src/services/GitHub.ts
+++ b/apps/server/src/services/GitHub.ts
@@ -267,6 +267,22 @@ interface GitHubGatewayFlatService {
     },
     token: string,
   ) => Effect.Effect<{ id: number; htmlUrl: string }, GitHubError, SettingsService>;
+  readonly findPendingReview: (
+    repoFullName: string,
+    prNumber: number,
+    reviewerLogin: string,
+    token: string,
+  ) => Effect.Effect<{ id: number; htmlUrl: string } | null, GitHubError, SettingsService>;
+  readonly submitPendingReview: (
+    repoFullName: string,
+    prNumber: number,
+    reviewId: number,
+    review: {
+      readonly body: string;
+      readonly event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT";
+    },
+    token: string,
+  ) => Effect.Effect<{ id: number; htmlUrl: string }, GitHubError, SettingsService>;
   readonly listReviewCommentsForReview: (
     repoFullName: string,
     prNumber: number,
@@ -506,7 +522,12 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         token,
         50,
         apiBase,
-        { canReplayCached: (cached) => cached.length < 100 },
+        // This endpoint is sorted by updated_at desc, so any new or recently
+        // changed PR changes page 1's ETag. Replaying a 304 is therefore safe
+        // even for large repos with 100+ open PRs; forcing a full refetch on
+        // every poll burns rate limit and leaves those repos stuck on stale DB
+        // state once GitHub starts returning 403 rate-limit responses.
+        { canReplayCached: () => true },
       );
       return (data as Record<string, unknown>[]).map((pr) => mapPr(pr, repositoryId));
     }).pipe(retryTransient),
@@ -966,6 +987,49 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
+  findPendingReview: (repoFullName, prNumber, reviewerLogin, token) =>
+    Effect.gen(function* () {
+      const apiBase = yield* resolveApiBase;
+      const { owner, repo } = yield* parseRepoFullName(repoFullName);
+      const data = yield* githubFetchPaginated(
+        `/repos/${owner}/${repo}/pulls/${prNumber}/reviews?per_page=100`,
+        token,
+        10,
+        apiBase,
+      );
+      const pending = (data as Record<string, unknown>[])
+        .filter((raw) => {
+          const user = raw.user as Record<string, unknown> | null | undefined;
+          return raw.state === "PENDING" && user?.login === reviewerLogin;
+        })
+        .sort((a, b) => Number(b.id ?? 0) - Number(a.id ?? 0))[0];
+      if (!pending) return null;
+      return {
+        id: pending.id as number,
+        htmlUrl: (pending.html_url as string | undefined) ?? "",
+      };
+    }),
+
+  submitPendingReview: (repoFullName, prNumber, reviewId, review, token) =>
+    Effect.gen(function* () {
+      const apiBase = yield* resolveApiBase;
+      const { owner, repo } = yield* parseRepoFullName(repoFullName);
+      const data = yield* githubPost(
+        `/repos/${owner}/${repo}/pulls/${prNumber}/reviews/${reviewId}/events`,
+        token,
+        {
+          event: review.event,
+          body: review.body,
+        },
+        apiBase,
+      );
+      const raw = data as Record<string, unknown>;
+      return {
+        id: raw.id as number,
+        htmlUrl: (raw.html_url as string | undefined) ?? "",
+      };
+    }),
+
   listReviewCommentsForReview: (repoFullName, prNumber, reviewId, token) =>
     Effect.gen(function* () {
       const apiBase = yield* resolveApiBase;
@@ -1373,6 +1437,8 @@ export interface GitHubGatewayService {
   };
   readonly reviews: {
     readonly submit: GitHubGatewayFlat["postReview"];
+    readonly findPending: GitHubGatewayFlat["findPendingReview"];
+    readonly submitPending: GitHubGatewayFlat["submitPendingReview"];
     readonly commentsForReview: GitHubGatewayFlat["listReviewCommentsForReview"];
     readonly createComment: GitHubGatewayFlat["postReviewComment"];
     readonly replyToComment: GitHubGatewayFlat["replyToComment"];
@@ -1423,6 +1489,8 @@ export const GitHubGatewayLive = Layer.succeed(GitHubGateway, {
   },
   reviews: {
     submit: githubGatewayFlat.postReview,
+    findPending: githubGatewayFlat.findPendingReview,
+    submitPending: githubGatewayFlat.submitPendingReview,
     commentsForReview: githubGatewayFlat.listReviewCommentsForReview,
     createComment: githubGatewayFlat.postReviewComment,
     replyToComment: githubGatewayFlat.replyToComment,

--- a/apps/server/src/services/GitOps.ts
+++ b/apps/server/src/services/GitOps.ts
@@ -143,12 +143,54 @@ export async function revParse(
   return (await runGitCapture(["rev-parse", ref], worktreePath, timeoutMs)).trim();
 }
 
+export async function commitExists(worktreePath: string, sha: string): Promise<boolean> {
+  try {
+    await runGit(["cat-file", "-e", `${sha}^{commit}`], worktreePath, 10_000);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function fetchRefspec(
   worktreePath: string,
   authedUrl: string,
   refspec: string,
 ): Promise<void> {
   await runGit(["fetch", authedUrl, refspec], worktreePath);
+}
+
+export async function fetchCommit(
+  worktreePath: string,
+  authedUrl: string,
+  sha: string,
+): Promise<void> {
+  await runGit(["fetch", "--no-tags", authedUrl, sha], worktreePath);
+}
+
+export async function diffNameStatusZ(
+  worktreePath: string,
+  baseRef: string,
+  headRef: string,
+): Promise<string> {
+  return runGitCapture(
+    ["diff", "--find-renames", "--name-status", "-z", baseRef, headRef],
+    worktreePath,
+    30_000,
+  );
+}
+
+export async function diffPatchForPath(
+  worktreePath: string,
+  baseRef: string,
+  headRef: string,
+  path: string,
+): Promise<string> {
+  return runGitCapture(
+    ["diff", "--find-renames", "--unified=80", baseRef, headRef, "--", path],
+    worktreePath,
+    30_000,
+  );
 }
 
 export async function checkoutBranch(worktreePath: string, branch: string): Promise<void> {

--- a/apps/server/src/services/PollScheduler.ts
+++ b/apps/server/src/services/PollScheduler.ts
@@ -4,9 +4,9 @@ import { eq, inArray } from "drizzle-orm";
 import { Cause, Chunk, Context, Duration, Effect, Fiber, Layer, Ref, Schedule } from "effect";
 import { repositories } from "../db/schema";
 import { account, user } from "../db/schema/auth";
-import { GitHubAuthError, GitHubRateLimitError } from "../domain/errors";
+import { GitHubAccessDeniedError, GitHubAuthError, GitHubRateLimitError } from "../domain/errors";
 import { withDb as withDbHelper } from "../effects/with-db";
-import { logError } from "../logger";
+import { debug, logError } from "../logger";
 import { Broadcaster } from "./Broadcaster";
 import { DbService } from "./Db";
 import { DiffCacheService } from "./DiffCache";
@@ -359,17 +359,26 @@ export const PollSchedulerLive = Layer.effect(
           ): Effect.Effect<A | null, never, R> =>
             eff.pipe(
               Effect.tap(() => clearStaleReauth(acc)),
-              Effect.tapError((err) =>
-                err instanceof GitHubAuthError
-                  ? handleAuthError(acc)
-                  : err instanceof GitHubRateLimitError
-                    ? Effect.sync(() => markRateLimited(acc, err))
-                    : Effect.sync(() => {
-                        if (opts?.errorLabel) {
-                          logError("PollScheduler", `${opts.errorLabel}:`, err);
-                        }
-                      }),
-              ),
+              Effect.tapError((err) => {
+                if (err instanceof GitHubAuthError) return handleAuthError(acc);
+                if (err instanceof GitHubRateLimitError) {
+                  return Effect.sync(() => {
+                    markRateLimited(acc, err);
+                  });
+                }
+                if (err instanceof GitHubAccessDeniedError) {
+                  return Effect.sync(() => {
+                    if (opts?.errorLabel) {
+                      debug("PollScheduler", `${opts.errorLabel}: ${err.message}`);
+                    }
+                  });
+                }
+                return Effect.sync(() => {
+                  if (opts?.errorLabel) {
+                    logError("PollScheduler", `${opts.errorLabel}:`, err);
+                  }
+                });
+              }),
               Effect.catchAll(() => Effect.succeed(null as A | null)),
             );
 

--- a/apps/server/src/services/PrContext.ts
+++ b/apps/server/src/services/PrContext.ts
@@ -88,6 +88,11 @@ export class PrContextService extends Context.Tag("PrContextService")<
       externalId: number,
       token: string,
     ) => Effect.Effect<PrFileMeta[], GitHubError, DbService | GitHubEtagCache | SettingsService>;
+    readonly prCommits: (
+      repoFullName: string,
+      externalId: number,
+      token: string,
+    ) => Effect.Effect<PrCommit[], GitHubError, SettingsService>;
     /**
      * Full PR fetch by number. Thin forward to the GitHub gateway. Used by
      * the recap backfill path to hydrate PRs that never landed in the local
@@ -244,6 +249,8 @@ export const PrContextServiceLive = Layer.effect(
       github.prs.meta(repoFullName, externalId, token);
     const prFiles = (repoFullName: string, externalId: number, token: string) =>
       github.prs.files(repoFullName, externalId, token);
+    const prCommits = (repoFullName: string, externalId: number, token: string) =>
+      github.prs.commits(repoFullName, externalId, token);
     const fetchPr = (repoFullName: string, externalId: number, token: string) =>
       github.prs.get(repoFullName, externalId, token);
     const searchClosedPrs = (
@@ -273,6 +280,7 @@ export const PrContextServiceLive = Layer.effect(
       resolveWithDiff,
       prMeta,
       prFiles,
+      prCommits,
       fetchPr,
       searchClosedPrs,
       resolveRepoToken,

--- a/apps/server/src/services/RepoClone.ts
+++ b/apps/server/src/services/RepoClone.ts
@@ -158,9 +158,9 @@ export class RepoCloneService extends Context.Tag("RepoCloneService")<
      * goes away when the PR row is deleted or the repo is removed.
      *
      * Lifecycle:
-     *   - **First acquire (no dir on disk):** fetch
-     *     `+refs/pull/N/head:refs/revv-pull/N` from GitHub, then
-     *     `git worktree add -B revv/pr-N` checks it out at the new branch.
+     *   - **First acquire (no dir on disk):** fetch the resolved head SHA
+     *     from GitHub, update `refs/revv-pull/N`, then `git worktree add -B
+     *     revv/pr-N` checks it out at the new branch.
      *     The fetch ref lives under `refs/revv-pull/` (not `refs/revv/pr-N`)
      *     so it can't shadow the bare branch name `revv/pr-N` — see the
      *     `prFetchRef` comment in the body.
@@ -185,6 +185,7 @@ export class RepoCloneService extends Context.Tag("RepoCloneService")<
       readonly prNumber: number;
       readonly prHeadSha: string;
       readonly githubToken: string;
+      readonly exactHead?: boolean;
     }) => Effect.Effect<
       { readonly worktreePath: string; readonly branchName: string },
       CloneError | CloneNotReadyError | WorktreeBlockedByUnpushedCommits
@@ -317,10 +318,12 @@ async function ensurePrCommitPresent(
 ): Promise<void> {
   if (await commitExists(cwd, prHeadSha)) return;
 
+  let directFetchError: unknown = null;
   try {
     await runGit(["fetch", "--no-tags", authedUrl, prHeadSha], cwd);
     if (await commitExists(cwd, prHeadSha)) return;
   } catch (err) {
+    directFetchError = err;
     debug(
       "pr-worktree",
       `direct SHA fetch failed for ${prHeadSha}, falling back to PR ref:`,
@@ -328,7 +331,19 @@ async function ensurePrCommitPresent(
     );
   }
 
-  await runGit(["fetch", "--no-tags", authedUrl, `refs/pull/${prNumber}/head`], cwd);
+  try {
+    await runGit(["fetch", "--no-tags", authedUrl, `refs/pull/${prNumber}/head`], cwd);
+  } catch (err) {
+    throw new Error(
+      [
+        `Unable to fetch PR #${prNumber} head commit ${prHeadSha}.`,
+        "GitHub did not provide the direct commit or refs/pull head ref.",
+        "The PR may have been force-pushed, deleted, moved, or the local PR metadata may be stale.",
+        `Direct SHA fetch: ${directFetchError instanceof Error ? directFetchError.message : String(directFetchError)}`,
+        `PR ref fetch: ${err instanceof Error ? err.message : String(err)}`,
+      ].join(" "),
+    );
+  }
 
   if (!(await commitExists(cwd, prHeadSha))) {
     throw new Error(
@@ -669,7 +684,7 @@ export const RepoCloneServiceLive = Layer.effect(
             }),
         }),
 
-      acquirePrWorktree: ({ repoId, prNumber, prHeadSha, githubToken }) =>
+      acquirePrWorktree: ({ repoId, prNumber, prHeadSha, githubToken, exactHead = false }) =>
         Effect.withSpan("RepoClone.acquirePrWorktree", {
           attributes: { repoId, prNumber, headSha: prHeadSha },
         })(
@@ -755,7 +770,7 @@ export const RepoCloneServiceLive = Layer.effect(
                         ["merge-base", "--is-ancestor", prHeadSha, currentSha],
                         worktreePath,
                       );
-                      if (isAncestor) {
+                      if (isAncestor && !exactHead) {
                         return { worktreePath, branchName };
                       }
                       await ensurePrCommitPresent(worktreePath, prHeadSha, prNumber, authedUrl);
@@ -814,12 +829,10 @@ export const RepoCloneServiceLive = Layer.effect(
                     await runGitBestEffort(["worktree", "prune"], clonePath, 15_000);
                   }
 
+                  await ensurePrCommitPresent(clonePath, prHeadSha, prNumber, authedUrl);
+                  await runGit(["update-ref", prFetchRef, prHeadSha], clonePath);
                   await runGit(
-                    ["fetch", "--no-tags", authedUrl, `+refs/pull/${prNumber}/head:${prFetchRef}`],
-                    clonePath,
-                  );
-                  await runGit(
-                    ["worktree", "add", "-B", branchName, worktreePath, prFetchRef],
+                    ["worktree", "add", "-B", branchName, worktreePath, prHeadSha],
                     clonePath,
                   );
                   const tipSha = (await runGitCapture(["rev-parse", "HEAD"], worktreePath)).trim();

--- a/apps/server/src/services/Walkthrough.test.ts
+++ b/apps/server/src/services/Walkthrough.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test";
+import { eq } from "drizzle-orm";
+import { Effect, Layer } from "effect";
+import { createDb, type Db } from "../db/index";
+import { reviewRounds, walkthroughs } from "../db/schema";
+import { DbService } from "./Db";
+import type { PrCommit } from "./GitHub";
+import { __walkthroughTest, WalkthroughService, WalkthroughServiceLive } from "./Walkthrough";
+
+function commit(sha: string, message: string): PrCommit {
+  return {
+    sha,
+    message,
+    authorLogin: null,
+    authorAvatarUrl: null,
+    date: null,
+  };
+}
+
+describe("commitsInRoundRange", () => {
+  const commits = [
+    commit("a", "feat: initial"),
+    commit("b", "fix: reviewed base"),
+    commit("c", "feat: add indexes"),
+    commit("d", "test: coverage"),
+    commit("e", "fix: tune range query"),
+  ];
+
+  it("returns commits after fromSha through toSha for a normal forward range", () => {
+    expect(__walkthroughTest.commitsInRoundRange(commits, "b", "d").map((c) => c.sha)).toEqual([
+      "c",
+      "d",
+    ]);
+  });
+
+  it("returns an empty range when fromSha equals toSha", () => {
+    expect(__walkthroughTest.commitsInRoundRange(commits, "c", "c")).toEqual([]);
+  });
+
+  it("returns commits after fromSha when toSha is missing from the snapshot", () => {
+    expect(
+      __walkthroughTest.commitsInRoundRange(commits, "b", "missing").map((c) => c.sha),
+    ).toEqual(["c", "d", "e"]);
+  });
+
+  it("returns all commits when neither boundary is available", () => {
+    expect(
+      __walkthroughTest
+        .commitsInRoundRange(commits, "missing-base", "missing-head")
+        .map((c) => c.sha),
+    ).toEqual(["a", "b", "c", "d", "e"]);
+  });
+});
+
+describe("deriveRoundFocusTitle", () => {
+  it("uses the newest non-low-signal commit in the selected round", () => {
+    const commits = [
+      commit("a", "feat: base"),
+      commit("b", "fix: previous review"),
+      commit("c", "feat(db): add range indexes"),
+      commit("d", "test: add query coverage"),
+    ];
+
+    expect(__walkthroughTest.deriveRoundFocusTitle(null, "b", "d", commits)).toBe(
+      "add range indexes",
+    );
+  });
+});
+
+function seedWalkthroughRound(db: Db): void {
+  const sqlite = (db as unknown as { session: { client: { run: (sql: string) => void } } }).session
+    .client;
+  sqlite.run("PRAGMA foreign_keys = OFF");
+  db.insert(walkthroughs)
+    .values({
+      id: "wt-1",
+      reviewSessionId: "session-1",
+      pullRequestId: "pr-1",
+      generatedAt: "2026-01-01T00:00:00Z",
+      modelUsed: "test-model",
+      prHeadSha: "head-1",
+    })
+    .run();
+  db.insert(reviewRounds)
+    .values({
+      id: "round-1",
+      pullRequestId: "pr-1",
+      reviewSessionId: "session-1",
+      walkthroughId: "wt-1",
+      roundNumber: 1,
+      toSha: "head-1",
+      createdAt: "2026-01-01T00:00:00Z",
+    })
+    .run();
+}
+
+describe("setStatus", () => {
+  it("updates walkthrough and review round status together with one completion timestamp", async () => {
+    const db = createDb(":memory:");
+    seedWalkthroughRound(db);
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* WalkthroughService;
+        yield* service.setStatus("wt-1", "complete");
+      }).pipe(
+        Effect.provide(WalkthroughServiceLive),
+        Effect.provide(Layer.succeed(DbService, { db })),
+      ),
+    );
+
+    const walkthrough = db
+      .select({ status: walkthroughs.status, completedAt: walkthroughs.completedAt })
+      .from(walkthroughs)
+      .where(eq(walkthroughs.id, "wt-1"))
+      .get();
+    const round = db
+      .select({ status: reviewRounds.status, completedAt: reviewRounds.completedAt })
+      .from(reviewRounds)
+      .where(eq(reviewRounds.id, "round-1"))
+      .get();
+
+    expect(walkthrough?.status).toBe("complete");
+    expect(round?.status).toBe("complete");
+    expect(walkthrough?.completedAt).toBeTruthy();
+    expect(round?.completedAt).toBe(walkthrough?.completedAt);
+  });
+});

--- a/apps/server/src/services/Walkthrough.ts
+++ b/apps/server/src/services/Walkthrough.ts
@@ -583,7 +583,10 @@ export class WalkthroughService extends Context.Tag("WalkthroughService")<
      * Find the latest completed/superseded walkthrough that can seed an
      * incremental refresh for a new PR head.
      */
-    readonly findLatestReviewArtifact: (prId: string) => Effect.Effect<
+    readonly findLatestReviewArtifact: (
+      prId: string,
+      mode?: WalkthroughMode,
+    ) => Effect.Effect<
       {
         readonly id: string;
         readonly prHeadSha: string;
@@ -1145,9 +1148,41 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
       return Math.max(0, (row?.nextSeq ?? 1) - 1);
     }).pipe(Effect.catchAll(() => Effect.succeed(0))),
 
-  findLatestReviewArtifact: (prId) =>
+  findLatestReviewArtifact: (prId, mode = "reviewer") =>
     Effect.gen(function* () {
       const { db } = yield* DbService;
+      const roundRows = db
+        .select({
+          id: walkthroughs.id,
+          prHeadSha: walkthroughs.prHeadSha,
+          kind: reviewRounds.kind,
+          visibility: reviewRounds.visibility,
+          fromSha: reviewRounds.fromSha,
+          toSha: reviewRounds.toSha,
+        })
+        .from(reviewRounds)
+        .innerJoin(walkthroughs, eq(walkthroughs.id, reviewRounds.walkthroughId))
+        .where(
+          and(
+            eq(reviewRounds.pullRequestId, prId),
+            eq(walkthroughs.mode, mode),
+            inArray(walkthroughs.status, ["complete", "superseded"]),
+          ),
+        )
+        .orderBy(desc(reviewRounds.roundNumber))
+        .all();
+
+      const visibleRound = roundRows.find(
+        (row) =>
+          row.visibility !== "hidden" && !(row.kind === "incremental" && row.fromSha === row.toSha),
+      );
+      if (visibleRound) {
+        return {
+          id: visibleRound.id,
+          prHeadSha: visibleRound.prHeadSha,
+        };
+      }
+
       const row = db
         .select({
           id: walkthroughs.id,
@@ -1157,6 +1192,7 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
         .where(
           and(
             eq(walkthroughs.pullRequestId, prId),
+            eq(walkthroughs.mode, mode),
             inArray(walkthroughs.status, ["complete", "superseded"]),
           ),
         )

--- a/apps/server/src/services/Walkthrough.ts
+++ b/apps/server/src/services/Walkthrough.ts
@@ -565,6 +565,7 @@ export class WalkthroughService extends Context.Tag("WalkthroughService")<
         readonly prId: string;
         readonly walkthroughId: string;
         readonly prHeadSha: string;
+        readonly mode: WalkthroughMode;
         readonly seqAt: number;
       }>,
       never,
@@ -1122,6 +1123,7 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
           walkthroughId: walkthroughs.id,
           prId: walkthroughs.pullRequestId,
           prHeadSha: walkthroughs.prHeadSha,
+          mode: walkthroughs.mode,
           nextSeq: walkthroughs.nextSeq,
         })
         .from(walkthroughs)
@@ -1133,6 +1135,7 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
         prId: r.prId,
         walkthroughId: r.walkthroughId,
         prHeadSha: r.prHeadSha,
+        mode: r.mode,
         seqAt: Math.max(0, r.nextSeq - 1),
       }));
     }).pipe(Effect.catchAll(() => Effect.succeed([]))),

--- a/apps/server/src/services/Walkthrough.ts
+++ b/apps/server/src/services/Walkthrough.ts
@@ -30,10 +30,13 @@ import type {
   Verdict,
   Walkthrough,
   WalkthroughBlock,
+  WalkthroughGenerationMode,
   WalkthroughIssue,
   WalkthroughMode,
   WalkthroughPipelinePhase,
   WalkthroughRating,
+  WalkthroughReviewRound,
+  WalkthroughReviewRoundsResponse,
   WalkthroughSemanticStep,
   WalkthroughStatus,
   WalkthroughTokenUsage,
@@ -44,6 +47,7 @@ import { commentThreads } from "../db/schema/comment-threads";
 import { pullRequests } from "../db/schema/pull-requests";
 import { remoteUsers } from "../db/schema/remote-users";
 import { repositories } from "../db/schema/repositories";
+import { reviewRounds } from "../db/schema/review-rounds";
 import { walkthroughBlocks } from "../db/schema/walkthrough-blocks";
 import { walkthroughIssues } from "../db/schema/walkthrough-issues";
 import { walkthroughRatings } from "../db/schema/walkthrough-ratings";
@@ -188,9 +192,108 @@ function rowToWalkthrough(
     modelUsed: row.modelUsed,
     tokenUsage: JSON.parse(row.tokenUsage) as WalkthroughTokenUsage,
     prHeadSha: row.prHeadSha,
+    generationMode: row.generationMode as WalkthroughGenerationMode,
+    parentWalkthroughId: row.parentWalkthroughId ?? null,
+    baseHeadSha: row.baseHeadSha ?? null,
     generatedBy,
     providerConfig,
   };
+}
+
+function isPrCommit(v: unknown): v is PrCommit {
+  if (v === null || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.sha === "string" &&
+    typeof o.message === "string" &&
+    (o.authorLogin === null || typeof o.authorLogin === "string") &&
+    (o.authorAvatarUrl === null || typeof o.authorAvatarUrl === "string") &&
+    (o.date === null || typeof o.date === "string")
+  );
+}
+
+function parsePrCommits(raw: string | null): PrCommit[] {
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(isPrCommit) : [];
+  } catch {
+    return [];
+  }
+}
+
+function commitsInRoundRange(
+  commits: readonly PrCommit[],
+  fromSha: string | null,
+  toSha: string,
+): readonly PrCommit[] {
+  const toIndex = commits.findIndex((commit) => commit.sha === toSha);
+  const fromIndex = fromSha ? commits.findIndex((commit) => commit.sha === fromSha) : -1;
+  if (fromSha !== null && fromSha === toSha) return [];
+
+  if (toIndex !== -1 && fromIndex !== -1) {
+    if (fromIndex < toIndex) {
+      return commits.slice(fromIndex + 1, toIndex + 1);
+    }
+    return commits.slice(toIndex, fromIndex).reverse();
+  }
+
+  if (toIndex !== -1) {
+    const prefix = commits.slice(0, toIndex + 1);
+    return prefix.length > 1 && commits[0]?.sha === toSha ? prefix.reverse() : prefix;
+  }
+
+  if (fromIndex !== -1) {
+    const afterFrom = commits.slice(0, fromIndex);
+    return afterFrom.reverse();
+  }
+
+  return commits;
+}
+
+function subjectFromCommitMessage(message: string): string {
+  return message.split("\n", 1)[0]?.trim() ?? "";
+}
+
+function cleanCommitSubject(subject: string): string {
+  return subject
+    .replace(/^revert\s+"?(.+?)"?$/i, "$1")
+    .replace(/^\w+(?:\([^)]+\))?!?:\s+/i, "")
+    .replace(/\b(?:[A-Z][A-Z0-9]+-\d+|#\d+)\b/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function isLowSignalSubject(subject: string): boolean {
+  return /^(?:merge|revert|chore|style|format|lint|test|tests|wip|fixup)\b/i.test(subject);
+}
+
+function toFiveWordTitle(text: string): string | null {
+  const words = text
+    .replace(/[`*_#()[\]{}]/g, "")
+    .split(/\s+/)
+    .map((word) => word.replace(/^[^\w]+|[^\w]+$/g, ""))
+    .filter((word) => word.length > 0);
+  if (words.length === 0) return null;
+  return words.slice(0, 5).join(" ");
+}
+
+function deriveRoundFocusTitle(
+  rawCommits: string | null,
+  fromSha: string | null,
+  toSha: string,
+  fallbackCommits: readonly PrCommit[] = [],
+): string | null {
+  const persistedCommits = parsePrCommits(rawCommits);
+  const sourceCommits = persistedCommits.length > 0 ? persistedCommits : fallbackCommits;
+  const commits = commitsInRoundRange(sourceCommits, fromSha, toSha);
+  const subjects = commits
+    .map((commit) => subjectFromCommitMessage(commit.message))
+    .filter((subject) => subject.length > 0);
+  if (subjects.length === 0) return null;
+
+  const preferred = [...subjects].reverse().find((subject) => !isLowSignalSubject(subject));
+  return toFiveWordTitle(cleanCommitSubject(preferred ?? subjects.at(-1) ?? ""));
 }
 
 // ── Service definition ──────────────────────────────────────────────────────
@@ -206,21 +309,14 @@ export class WalkthroughService extends Context.Tag("WalkthroughService")<
      *   • row in 'generating' → return the existing id (the in-flight job
      *                            owns this row; concurrent startJob is
      *                            idempotent).
-     *   • row in 'complete'   → return the existing id (caller is expected
-     *                            to have hit the cache path first; defensive
-     *                            no-op so we never clobber a finished
-     *                            walkthrough).
-     *   • row in 'superseded' → RECYCLE: delete the stale row (cascades
-     *                            blocks/issues/ratings + AI-authored
-     *                            comment_threads via the issue FK) and
-     *                            insert a fresh row with a new id. This is
-     *                            the regenerate path — the user explicitly
-     *                            asked for a do-over at the same head SHA,
-     *                            so the failed/cancelled prior attempt's
-     *                            content is intentionally cleared.
-     *   • row in 'error'      → RECYCLE: same as superseded. The row is
-     *                            terminal and has no live fiber, so a fresh
-     *                            run replaces it cleanly.
+     *   • row in 'complete'   → return the existing id unless the caller
+     *                            explicitly requested a fresh round. Fresh
+     *                            rounds keep the old row as superseded audit
+     *                            history and insert a new row at the same SHA.
+     *   • row in 'superseded' → left in place as historical data. The active
+     *                            uniqueness index excludes superseded rows.
+     *   • row in 'error'      → mark historical and insert a fresh row. The
+     *                            row is terminal and has no live fiber.
      *
      * All-in-one transaction so the lookup + delete + insert can't race a
      * concurrent startJob for the same (prId, prHeadSha).
@@ -261,6 +357,10 @@ export class WalkthroughService extends Context.Tag("WalkthroughService")<
        * column survives a mid-job settings change.
        */
       providerConfig?: GenerationProviderConfig;
+      generationMode?: WalkthroughGenerationMode;
+      parentWalkthroughId?: string | null;
+      baseHeadSha?: string | null;
+      forceNew?: boolean;
     }) => Effect.Effect<string, ReviewError, DbService>;
 
     /**
@@ -478,6 +578,52 @@ export class WalkthroughService extends Context.Tag("WalkthroughService")<
      * envelopes already covered by the REST snapshot.
      */
     readonly getSeqAt: (walkthroughId: string) => Effect.Effect<number, never, DbService>;
+
+    /**
+     * Find the latest completed/superseded walkthrough that can seed an
+     * incremental refresh for a new PR head.
+     */
+    readonly findLatestReviewArtifact: (prId: string) => Effect.Effect<
+      {
+        readonly id: string;
+        readonly prHeadSha: string;
+      } | null,
+      never,
+      DbService
+    >;
+
+    /**
+     * Return the latest completed historical walkthrough for display when the
+     * current PR head has no generated row yet. Unlike `getCached`, this can
+     * return `superseded` rows because the reader wants to show the last
+     * reviewed artifact while the user decides whether to review new commits.
+     */
+    readonly getLatestDisplayable: (
+      prId: string,
+      mode?: WalkthroughMode,
+    ) => Effect.Effect<Walkthrough | null, never, DbService>;
+
+    /**
+     * Return a specific walkthrough for a PR/mode. This is a read-only
+     * historical report view: callers use it to display an older report, not
+     * to resume or mutate the row.
+     */
+    readonly getReport: (
+      prId: string,
+      walkthroughId: string,
+      mode?: WalkthroughMode,
+    ) => Effect.Effect<
+      { readonly walkthrough: Walkthrough; readonly status: WalkthroughStatus } | null,
+      never,
+      DbService
+    >;
+
+    readonly listReviewRounds: (
+      prId: string,
+      currentHeadSha: string | null,
+      fallbackCommits?: readonly PrCommit[],
+      mode?: WalkthroughMode,
+    ) => Effect.Effect<WalkthroughReviewRoundsResponse, never, DbService>;
   }
 >() {}
 
@@ -490,25 +636,17 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
       const newId = params.id ?? crypto.randomUUID();
       const generatedAt = new Date().toISOString();
       const mode = params.mode ?? "reviewer";
+      const generationMode = params.generationMode ?? "full";
 
-      // Atomically: look at any existing row at (prId, prHeadSha), recycle
-      // it if it's terminal (superseded/error), otherwise reuse it. The
-      // transaction ensures concurrent startJob calls for the same
-      // (prId, prHeadSha, mode) can't race the delete-then-insert and produce
+      // Atomically: look at any existing row at (prId, prHeadSha), mark
+      // terminal rows historical when a fresh row is needed, otherwise
+      // reuse active rows. The transaction ensures concurrent startJob
+      // calls for the same (prId, prHeadSha, mode, generationMode) can't race and produce
       // duplicate rows or zero rows.
-      //
-      // Cascade chain on DELETE walkthroughs:
-      //   walkthrough_blocks   (FK onDelete: cascade)
-      //   walkthrough_issues   (FK onDelete: cascade)
-      //     └─ comment_threads.walkthrough_issue_id (FK onDelete: cascade)
-      //        — drops AI-authored inline comments tied to the failed run
-      //   walkthrough_ratings  (FK onDelete: cascade)
-      // Other walkthroughs that referenced this row via supersededBy get
-      // their pointer NULLed (FK onDelete: set null), which is fine — the
-      // audit chain just truncates at the recycled row.
       const result = yield* Effect.try({
         try: () =>
           db.transaction((tx): { id: string } => {
+            let supersededExistingId: string | null = null;
             const existing = tx
               .select({
                 id: walkthroughs.id,
@@ -520,21 +658,35 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
                   eq(walkthroughs.pullRequestId, params.prId),
                   eq(walkthroughs.prHeadSha, params.prHeadSha),
                   eq(walkthroughs.mode, mode),
+                  eq(walkthroughs.generationMode, generationMode),
+                  ne(walkthroughs.status, "superseded"),
                 ),
               )
               .get();
 
             if (existing) {
-              if (existing.status === "generating" || existing.status === "complete") {
-                // In-flight or finished — keep the row. The
-                // orchestrator's idempotent-startJob and cache
-                // paths upstream of this call already handle
-                // these cases; we only reach here on a race.
+              if (existing.status === "generating") {
+                // In-flight — keep the row. The orchestrator's
+                // idempotent-startJob path upstream of this call already
+                // handles this case; we only reach here on a race.
                 return { id: existing.id };
               }
-              // 'superseded' or 'error' — drop the row. Cascades
-              // clean every child row tied to the prior attempt.
-              tx.delete(walkthroughs).where(eq(walkthroughs.id, existing.id)).run();
+              if (existing.status === "complete" && !params.forceNew) {
+                return { id: existing.id };
+              }
+              if (existing.status === "error" || existing.status === "complete") {
+                tx.update(walkthroughs)
+                  .set({ status: "superseded" })
+                  .where(eq(walkthroughs.id, existing.id))
+                  .run();
+                supersededExistingId = existing.id;
+                tx.update(reviewRounds)
+                  .set({ status: "superseded" })
+                  .where(eq(reviewRounds.walkthroughId, existing.id))
+                  .run();
+              }
+              // 'superseded' rows stay in place now that uniqueness only
+              // applies to active rows.
             }
 
             tx.insert(walkthroughs)
@@ -552,6 +704,9 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
                 modelUsed: params.modelUsed,
                 tokenUsage: "{}",
                 prHeadSha: params.prHeadSha,
+                generationMode,
+                parentWalkthroughId: params.parentWalkthroughId ?? null,
+                baseHeadSha: params.baseHeadSha ?? null,
                 resumeAttempts: 0,
                 prCommits: params.prCommits ? JSON.stringify(params.prCommits) : null,
                 generatedByGithubUserId: params.generatedBy?.githubUserId ?? null,
@@ -561,6 +716,34 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
                 providerConfig: params.providerConfig
                   ? JSON.stringify(params.providerConfig)
                   : null,
+              })
+              .run();
+            if (supersededExistingId) {
+              tx.update(walkthroughs)
+                .set({ supersededBy: newId })
+                .where(eq(walkthroughs.id, supersededExistingId))
+                .run();
+            }
+            const latestRound = tx
+              .select({ roundNumber: reviewRounds.roundNumber })
+              .from(reviewRounds)
+              .where(eq(reviewRounds.pullRequestId, params.prId))
+              .orderBy(desc(reviewRounds.roundNumber))
+              .get();
+            tx.insert(reviewRounds)
+              .values({
+                id: crypto.randomUUID(),
+                pullRequestId: params.prId,
+                reviewSessionId: params.reviewSessionId,
+                walkthroughId: newId,
+                previousWalkthroughId: params.parentWalkthroughId ?? null,
+                roundNumber: (latestRound?.roundNumber ?? 0) + 1,
+                kind: generationMode,
+                visibility: "visible",
+                status: "generating",
+                fromSha: params.baseHeadSha ?? null,
+                toSha: params.prHeadSha,
+                createdAt: generatedAt,
               })
               .run();
             return { id: newId };
@@ -594,6 +777,13 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
         })
         .where(eq(walkthroughs.id, walkthroughId))
         .run();
+      db.update(reviewRounds)
+        .set({
+          status,
+          ...(status === "complete" ? { completedAt: new Date().toISOString() } : {}),
+        })
+        .where(eq(reviewRounds.walkthroughId, walkthroughId))
+        .run();
     }).pipe(Effect.catchAll(() => Effect.void)),
 
   supersede: (oldId, newId) =>
@@ -618,6 +808,10 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
         db.update(walkthroughs)
           .set({ status: "superseded", supersededBy: newId })
           .where(eq(walkthroughs.id, oldId))
+          .run();
+        db.update(reviewRounds)
+          .set({ status: "superseded" })
+          .where(eq(reviewRounds.walkthroughId, oldId))
           .run();
       });
     }).pipe(Effect.catchAll(() => Effect.void)),
@@ -664,6 +858,10 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
         }
 
         db.update(walkthroughs).set({ status: "superseded" }).where(condition).run();
+        db.update(reviewRounds)
+          .set({ status: "superseded" })
+          .where(inArray(reviewRounds.walkthroughId, activeIds))
+          .run();
       });
     }).pipe(Effect.catchAll(() => Effect.void)),
 
@@ -946,6 +1144,269 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
         .get();
       return Math.max(0, (row?.nextSeq ?? 1) - 1);
     }).pipe(Effect.catchAll(() => Effect.succeed(0))),
+
+  findLatestReviewArtifact: (prId) =>
+    Effect.gen(function* () {
+      const { db } = yield* DbService;
+      const row = db
+        .select({
+          id: walkthroughs.id,
+          prHeadSha: walkthroughs.prHeadSha,
+        })
+        .from(walkthroughs)
+        .where(
+          and(
+            eq(walkthroughs.pullRequestId, prId),
+            inArray(walkthroughs.status, ["complete", "superseded"]),
+          ),
+        )
+        .orderBy(desc(walkthroughs.generatedAt))
+        .get();
+      return row ?? null;
+    }).pipe(Effect.catchAll(() => Effect.succeed(null))),
+
+  getLatestDisplayable: (prId, mode = "reviewer") =>
+    Effect.gen(function* () {
+      const { db } = yield* DbService;
+      const result = db
+        .select({ wt: walkthroughs, avatarContent: remoteUsers.avatarContent })
+        .from(walkthroughs)
+        .leftJoin(
+          remoteUsers,
+          and(
+            eq(remoteUsers.provider, "github"),
+            eq(remoteUsers.login, walkthroughs.generatedByGithubLogin),
+          ),
+        )
+        .where(
+          and(
+            eq(walkthroughs.pullRequestId, prId),
+            eq(walkthroughs.mode, mode),
+            inArray(walkthroughs.status, ["complete", "superseded"]),
+          ),
+        )
+        .orderBy(desc(walkthroughs.generatedAt))
+        .get();
+
+      if (!result) return null;
+
+      const { wt: row, avatarContent } = result;
+
+      const semanticSteps = db
+        .select()
+        .from(walkthroughSemanticSteps)
+        .where(eq(walkthroughSemanticSteps.walkthroughId, row.id))
+        .orderBy(asc(walkthroughSemanticSteps.semanticStepIndex))
+        .all();
+
+      const blocks = db
+        .select()
+        .from(walkthroughBlocks)
+        .where(eq(walkthroughBlocks.walkthroughId, row.id))
+        .all();
+
+      const issues = db
+        .select()
+        .from(walkthroughIssues)
+        .where(eq(walkthroughIssues.walkthroughId, row.id))
+        .all();
+
+      const ratings = db
+        .select()
+        .from(walkthroughRatings)
+        .where(eq(walkthroughRatings.walkthroughId, row.id))
+        .all();
+
+      return rowToWalkthrough(row, semanticSteps, blocks, issues, ratings, avatarContent);
+    }).pipe(Effect.catchAll(() => Effect.succeed(null))),
+
+  getReport: (prId, walkthroughId, mode = "reviewer") =>
+    Effect.gen(function* () {
+      const { db } = yield* DbService;
+      const result = db
+        .select({ wt: walkthroughs, avatarContent: remoteUsers.avatarContent })
+        .from(walkthroughs)
+        .leftJoin(
+          remoteUsers,
+          and(
+            eq(remoteUsers.provider, "github"),
+            eq(remoteUsers.login, walkthroughs.generatedByGithubLogin),
+          ),
+        )
+        .where(
+          and(
+            eq(walkthroughs.id, walkthroughId),
+            eq(walkthroughs.pullRequestId, prId),
+            eq(walkthroughs.mode, mode),
+          ),
+        )
+        .get();
+
+      if (!result) return null;
+
+      const { wt: row, avatarContent } = result;
+
+      const semanticSteps = db
+        .select()
+        .from(walkthroughSemanticSteps)
+        .where(eq(walkthroughSemanticSteps.walkthroughId, row.id))
+        .orderBy(asc(walkthroughSemanticSteps.semanticStepIndex))
+        .all();
+
+      const blocks = db
+        .select()
+        .from(walkthroughBlocks)
+        .where(eq(walkthroughBlocks.walkthroughId, row.id))
+        .all();
+
+      const issues = db
+        .select()
+        .from(walkthroughIssues)
+        .where(eq(walkthroughIssues.walkthroughId, row.id))
+        .all();
+
+      const ratings = db
+        .select()
+        .from(walkthroughRatings)
+        .where(eq(walkthroughRatings.walkthroughId, row.id))
+        .all();
+
+      return {
+        walkthrough: rowToWalkthrough(row, semanticSteps, blocks, issues, ratings, avatarContent),
+        status: row.status as WalkthroughStatus,
+      };
+    }).pipe(Effect.catchAll(() => Effect.succeed(null))),
+
+  listReviewRounds: (prId, currentHeadSha, fallbackCommits = [], mode = "reviewer") =>
+    Effect.gen(function* () {
+      const { db } = yield* DbService;
+      const rows = db
+        .select({
+          id: reviewRounds.id,
+          walkthroughId: reviewRounds.walkthroughId,
+          previousWalkthroughId: reviewRounds.previousWalkthroughId,
+          roundNumber: reviewRounds.roundNumber,
+          kind: reviewRounds.kind,
+          visibility: reviewRounds.visibility,
+          status: reviewRounds.status,
+          fromSha: reviewRounds.fromSha,
+          toSha: reviewRounds.toSha,
+          createdAt: reviewRounds.createdAt,
+          completedAt: reviewRounds.completedAt,
+          summary: walkthroughs.summary,
+          prCommits: walkthroughs.prCommits,
+          prHeadSha: walkthroughs.prHeadSha,
+        })
+        .from(reviewRounds)
+        .innerJoin(walkthroughs, eq(walkthroughs.id, reviewRounds.walkthroughId))
+        .where(and(eq(reviewRounds.pullRequestId, prId), eq(walkthroughs.mode, mode)))
+        .orderBy(asc(reviewRounds.roundNumber))
+        .all();
+
+      let rounds: WalkthroughReviewRound[] = rows.map((row) => ({
+        id: row.id,
+        walkthroughId: row.walkthroughId,
+        previousWalkthroughId: row.previousWalkthroughId ?? null,
+        roundNumber: row.roundNumber,
+        kind: row.kind === "incremental" ? "incremental" : "full",
+        visibility:
+          row.visibility === "hidden" || (row.kind === "incremental" && row.fromSha === row.toSha)
+            ? "hidden"
+            : "visible",
+        status: row.status as WalkthroughStatus,
+        fromSha: row.fromSha ?? null,
+        toSha: row.toSha,
+        createdAt: row.createdAt,
+        completedAt: row.completedAt ?? null,
+        summary: row.summary.trim() ? row.summary : null,
+        focusTitle: deriveRoundFocusTitle(
+          row.prCommits,
+          row.fromSha ?? null,
+          row.toSha,
+          fallbackCommits,
+        ),
+        prHeadSha: row.prHeadSha,
+      }));
+
+      if (rounds.length === 0) {
+        const legacyRows = db
+          .select({
+            id: walkthroughs.id,
+            previousWalkthroughId: walkthroughs.parentWalkthroughId,
+            status: walkthroughs.status,
+            generatedAt: walkthroughs.generatedAt,
+            completedAt: walkthroughs.completedAt,
+            summary: walkthroughs.summary,
+            prCommits: walkthroughs.prCommits,
+            prHeadSha: walkthroughs.prHeadSha,
+            generationMode: walkthroughs.generationMode,
+            baseHeadSha: walkthroughs.baseHeadSha,
+          })
+          .from(walkthroughs)
+          .where(and(eq(walkthroughs.pullRequestId, prId), eq(walkthroughs.mode, mode)))
+          .orderBy(asc(walkthroughs.generatedAt))
+          .all();
+
+        rounds = legacyRows.map((row, index) => ({
+          id: `legacy-${row.id}`,
+          walkthroughId: row.id,
+          previousWalkthroughId: row.previousWalkthroughId ?? null,
+          roundNumber: index + 1,
+          kind: row.generationMode === "incremental" ? "incremental" : "full",
+          visibility:
+            row.generationMode === "incremental" && row.baseHeadSha === row.prHeadSha
+              ? "hidden"
+              : "visible",
+          status: row.status as WalkthroughStatus,
+          fromSha: row.baseHeadSha ?? null,
+          toSha: row.prHeadSha,
+          createdAt: row.generatedAt,
+          completedAt: row.completedAt ?? null,
+          summary: row.summary.trim() ? row.summary : null,
+          focusTitle: deriveRoundFocusTitle(
+            row.prCommits,
+            row.baseHeadSha ?? null,
+            row.prHeadSha,
+            fallbackCommits,
+          ),
+          prHeadSha: row.prHeadSha,
+        }));
+      }
+
+      const reportRounds = rounds.filter((round) => round.visibility !== "hidden");
+      const latestReviewed =
+        [...reportRounds].reverse().find((round) => round.completedAt !== null) ??
+        [...reportRounds]
+          .reverse()
+          .find((round) => round.status === "complete" || round.status === "superseded") ??
+        null;
+
+      const latestReviewedHeadSha = latestReviewed?.toSha ?? null;
+      const hasNewCommits =
+        currentHeadSha !== null &&
+        latestReviewedHeadSha !== null &&
+        latestReviewedHeadSha !== currentHeadSha;
+
+      return {
+        prId,
+        currentHeadSha,
+        latestReviewedHeadSha,
+        hasNewCommits,
+        nextBaseHeadSha: hasNewCommits ? latestReviewedHeadSha : null,
+        rounds,
+      };
+    }).pipe(
+      Effect.catchAll(() =>
+        Effect.succeed({
+          prId,
+          currentHeadSha,
+          latestReviewedHeadSha: null,
+          hasNewCommits: false,
+          nextBaseHeadSha: null,
+          rounds: [],
+        }),
+      ),
+    ),
 
   getChildRowsSince: (walkthroughId, since) =>
     Effect.gen(function* () {

--- a/apps/server/src/services/Walkthrough.ts
+++ b/apps/server/src/services/Walkthrough.ts
@@ -244,8 +244,7 @@ function commitsInRoundRange(
   }
 
   if (fromIndex !== -1) {
-    const afterFrom = commits.slice(0, fromIndex);
-    return afterFrom.reverse();
+    return commits.slice(fromIndex + 1);
   }
 
   return commits;
@@ -771,23 +770,24 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
       // in period N+1 lands in N+1's recap. We deliberately do NOT clear
       // it on any other transition: a row that briefly hit 'complete'
       // then got 'superseded' retains its completedAt for audit.
-      const completedAtPatch =
-        status === "complete" ? { completedAt: new Date().toISOString() } : {};
-      db.update(walkthroughs)
-        .set({
-          status,
-          ...completedAtPatch,
-          ...(options?.tokenUsage ? { tokenUsage: JSON.stringify(options.tokenUsage) } : {}),
-        })
-        .where(eq(walkthroughs.id, walkthroughId))
-        .run();
-      db.update(reviewRounds)
-        .set({
-          status,
-          ...(status === "complete" ? { completedAt: new Date().toISOString() } : {}),
-        })
-        .where(eq(reviewRounds.walkthroughId, walkthroughId))
-        .run();
+      const completedAt = status === "complete" ? new Date().toISOString() : null;
+      db.transaction(() => {
+        db.update(walkthroughs)
+          .set({
+            status,
+            ...(completedAt ? { completedAt } : {}),
+            ...(options?.tokenUsage ? { tokenUsage: JSON.stringify(options.tokenUsage) } : {}),
+          })
+          .where(eq(walkthroughs.id, walkthroughId))
+          .run();
+        db.update(reviewRounds)
+          .set({
+            status,
+            ...(completedAt ? { completedAt } : {}),
+          })
+          .where(eq(reviewRounds.walkthroughId, walkthroughId))
+          .run();
+      });
     }).pipe(Effect.catchAll(() => Effect.void)),
 
   supersede: (oldId, newId) =>
@@ -1542,3 +1542,8 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
       ),
     ),
 });
+
+export const __walkthroughTest = {
+  commitsInRoundRange,
+  deriveRoundFocusTitle,
+};

--- a/apps/server/src/services/WalkthroughJobs.ts
+++ b/apps/server/src/services/WalkthroughJobs.ts
@@ -1428,15 +1428,8 @@ export const WalkthroughJobsLive = Layer.effect(
         // the row already has them from the original insert.
         const priorArtifact =
           partial === null && requestedGenerationMode === "incremental"
-            ? yield* provideDb(walkthroughService.findLatestReviewArtifact(pr.id))
+            ? yield* provideDb(walkthroughService.findLatestReviewArtifact(pr.id, mode))
             : null;
-        if (partial === null && priorArtifact?.prHeadSha === meta.headSha) {
-          debug(
-            "walkthrough-jobs",
-            `incremental start requested at unchanged head sha=${meta.headSha}; reusing wt=${priorArtifact.id}`,
-          );
-          return { walkthroughId: priorArtifact.id };
-        }
         const parentWalkthroughId = partial?.parentWalkthroughId ?? priorArtifact?.id ?? null;
         const baseHeadSha = partial?.baseHeadSha ?? priorArtifact?.prHeadSha ?? null;
         const generationMode: WalkthroughGenerationMode =

--- a/apps/server/src/services/WalkthroughJobs.ts
+++ b/apps/server/src/services/WalkthroughJobs.ts
@@ -30,6 +30,7 @@
 import type {
   GenerationProviderConfig,
   Walkthrough,
+  WalkthroughGenerationMode,
   WalkthroughMode,
   WalkthroughStatus,
   WalkthroughStreamEvent,
@@ -69,6 +70,7 @@ import { AiService, type ContinuationContext } from "./Ai";
 import { Broadcaster } from "./Broadcaster";
 import { DbService } from "./Db";
 import { GitHubEtagCache } from "./GitHubEtagCache";
+import { commitExists, diffNameStatusZ, diffPatchForPath, fetchCommit } from "./GitOps";
 import { analyzeJobFailure } from "./job-failure";
 import { makeStartJobMutex } from "./job-mutex";
 import { makeSubscriberRegistry, type SubscriberHandle } from "./job-subscribers";
@@ -180,6 +182,7 @@ export class WalkthroughJobs extends Context.Tag("WalkthroughJobs")<
       readonly trigger: StartJobTrigger;
       readonly walkthroughId?: string;
       readonly mode?: WalkthroughMode;
+      readonly generationMode?: WalkthroughGenerationMode;
     }) => Effect.Effect<{ readonly walkthroughId: string }, StartJobError>;
 
     /**
@@ -465,6 +468,8 @@ export const WalkthroughJobsLive = Layer.effect(
       readonly repoId: string;
       readonly token: string;
       readonly prHeadSha: string;
+      readonly repoFullName: string;
+      readonly githubHost: string;
       readonly files: ReadonlyArray<{
         readonly filename: string;
         readonly previousFilename: string | null;
@@ -477,6 +482,145 @@ export const WalkthroughJobsLive = Layer.effect(
       readonly reviewSessionId: string;
       readonly modelUsed: string;
       readonly mode: WalkthroughMode;
+      readonly generationMode: WalkthroughGenerationMode;
+      readonly parentWalkthroughId: string | null;
+      readonly baseHeadSha: string | null;
+    };
+
+    type PromptFile = ResolvedContext["files"][number];
+    type PromptFilesResult = {
+      readonly files: ReadonlyArray<PromptFile>;
+      readonly diffSource: "full_pr" | "incremental_range" | "full_pr_fallback";
+    };
+
+    const normalizeGitStatus = (raw: string): PromptFile["status"] => {
+      const prefix = raw[0] ?? "M";
+      switch (prefix) {
+        case "A":
+          return "added";
+        case "D":
+          return "removed";
+        case "R":
+          return "renamed";
+        case "C":
+          return "copied";
+        case "T":
+          return "changed";
+        default:
+          return "modified";
+      }
+    };
+
+    const parseNameStatusZ = (
+      raw: string,
+    ): ReadonlyArray<{
+      readonly status: string;
+      readonly filename: string;
+      readonly previousFilename: string | null;
+    }> => {
+      const tokens = raw.split("\0").filter((token) => token.length > 0);
+      const files: Array<{
+        readonly status: string;
+        readonly filename: string;
+        readonly previousFilename: string | null;
+      }> = [];
+      for (let i = 0; i < tokens.length; ) {
+        const status = tokens[i++];
+        if (!status) break;
+        if (status.startsWith("R") || status.startsWith("C")) {
+          const previousFilename = tokens[i++];
+          const filename = tokens[i++];
+          if (previousFilename && filename) {
+            files.push({ status, filename, previousFilename });
+          }
+          continue;
+        }
+        const filename = tokens[i++];
+        if (filename) {
+          files.push({ status, filename, previousFilename: null });
+        }
+      }
+      return files;
+    };
+
+    const countPatchLines = (
+      patch: string,
+    ): { readonly additions: number; readonly deletions: number } => {
+      let additions = 0;
+      let deletions = 0;
+      for (const line of patch.split("\n")) {
+        if (line.startsWith("+++") || line.startsWith("---")) continue;
+        if (line.startsWith("+")) additions += 1;
+        else if (line.startsWith("-")) deletions += 1;
+      }
+      return { additions, deletions };
+    };
+
+    const buildAuthedRepoUrl = (ctx: ResolvedContext): string =>
+      `https://x-access-token:${ctx.token}@${ctx.githubHost}/${ctx.repoFullName}.git`;
+
+    const redactGitAuth = (message: string): string =>
+      message.replace(/x-access-token:[^@\s]+@/g, "x-access-token:<redacted>@");
+
+    const resolveIncrementalPromptFiles = (
+      ctx: ResolvedContext,
+      worktreePath: string,
+    ): Effect.Effect<PromptFilesResult> => {
+      if (ctx.generationMode !== "incremental" || !ctx.baseHeadSha) {
+        return Effect.succeed({ files: ctx.files, diffSource: "full_pr" });
+      }
+      const baseHeadSha = ctx.baseHeadSha;
+
+      return Effect.tryPromise({
+        try: async () => {
+          if (!(await commitExists(worktreePath, baseHeadSha))) {
+            await fetchCommit(worktreePath, buildAuthedRepoUrl(ctx), baseHeadSha);
+          }
+          if (!(await commitExists(worktreePath, baseHeadSha))) {
+            throw new Error(`base commit ${baseHeadSha} is not available locally`);
+          }
+
+          const nameStatus = parseNameStatusZ(
+            await diffNameStatusZ(worktreePath, baseHeadSha, ctx.prHeadSha),
+          );
+          const files: PromptFile[] = [];
+          for (const file of nameStatus) {
+            let patch: string | null = null;
+            try {
+              const rawPatch = await diffPatchForPath(
+                worktreePath,
+                baseHeadSha,
+                ctx.prHeadSha,
+                file.filename,
+              );
+              patch = rawPatch.trim().length > 0 ? rawPatch : null;
+            } catch {
+              patch = null;
+            }
+            const counts = patch ? countPatchLines(patch) : { additions: 0, deletions: 0 };
+            files.push({
+              filename: file.filename,
+              previousFilename: file.previousFilename,
+              status: normalizeGitStatus(file.status),
+              additions: counts.additions,
+              deletions: counts.deletions,
+              patch,
+            });
+          }
+          return { files, diffSource: "incremental_range" as const };
+        },
+        catch: (cause) => cause,
+      }).pipe(
+        Effect.catchAll((cause) => {
+          logError(
+            "walkthrough-jobs",
+            `incremental diff build failed pr=${ctx.pr.id} base=${ctx.baseHeadSha} head=${ctx.prHeadSha}; falling back to full PR diff: ${redactGitAuth(
+              cause instanceof Error ? cause.message : String(cause),
+            )}`,
+          );
+          return Effect.succeed({ files: ctx.files, diffSource: "full_pr_fallback" as const });
+        }),
+      );
     };
 
     interface LoopState {
@@ -520,6 +664,7 @@ export const WalkthroughJobsLive = Layer.effect(
             prNumber: ctx.pr.externalId,
             prHeadSha: ctx.prHeadSha,
             githubToken: ctx.token,
+            exactHead: true,
           })
           .pipe(
             Effect.mapError((e) => {
@@ -541,6 +686,7 @@ export const WalkthroughJobsLive = Layer.effect(
         const partial = ctx.partial;
         let generator: AsyncGenerator<WalkthroughStreamEvent>;
         let capturedOpencodeSessionId: string | undefined;
+        const promptInput = yield* resolveIncrementalPromptFiles(ctx, worktreePath);
 
         const buildStreamParams = (overrideContinuation?: ContinuationContext) => ({
           pr: {
@@ -550,11 +696,18 @@ export const WalkthroughJobsLive = Layer.effect(
             targetBranch: ctx.pr.targetBranch,
             url: ctx.pr.url,
           },
-          files: ctx.files as never,
+          files: promptInput.files as never,
           mode: ctx.mode,
           worktreePath,
           walkthroughId: job.walkthroughId,
           accountId: job.accountId,
+          reviewMode: {
+            mode: ctx.generationMode,
+            parentWalkthroughId: ctx.parentWalkthroughId,
+            baseHeadSha: ctx.baseHeadSha,
+            headSha: ctx.prHeadSha,
+            diffSource: promptInput.diffSource,
+          },
           ...(overrideContinuation ? { continuation: overrideContinuation } : {}),
           onSessionId: (id: string) => {
             capturedOpencodeSessionId = id;
@@ -1083,6 +1236,7 @@ export const WalkthroughJobsLive = Layer.effect(
       readonly trigger: StartJobTrigger;
       readonly walkthroughId?: string;
       readonly mode?: WalkthroughMode;
+      readonly generationMode?: WalkthroughGenerationMode;
     }): Effect.Effect<{ readonly walkthroughId: string }, StartJobError> =>
       Effect.gen(function* () {
         const mode = params.mode ?? "reviewer";
@@ -1114,6 +1268,7 @@ export const WalkthroughJobsLive = Layer.effect(
       readonly trigger: StartJobTrigger;
       readonly walkthroughId?: string;
       readonly mode?: WalkthroughMode;
+      readonly generationMode?: WalkthroughGenerationMode;
     }): Effect.Effect<{ readonly walkthroughId: string }, StartJobError> =>
       Effect.gen(function* () {
         const mode = params.mode ?? "reviewer";
@@ -1186,6 +1341,7 @@ export const WalkthroughJobsLive = Layer.effect(
 
         const reviewSession = yield* provideDb(reviewService.getOrCreateActiveSession(pr.id, mode));
         const reviewSessionId = partial?.reviewSessionId ?? reviewSession.id;
+        const requestedGenerationMode = params.generationMode ?? "full";
 
         const settings = yield* provideDb(settingsService.getSettings());
         const agent = yield* provideDb(settingsService.resolveAgent());
@@ -1270,6 +1426,24 @@ export const WalkthroughJobsLive = Layer.effect(
         // the journey chapter (chapter 0). On the "keep existing row"
         // path inside createPartial, the commits are not overwritten —
         // the row already has them from the original insert.
+        const priorArtifact =
+          partial === null && requestedGenerationMode === "incremental"
+            ? yield* provideDb(walkthroughService.findLatestReviewArtifact(pr.id))
+            : null;
+        if (partial === null && priorArtifact?.prHeadSha === meta.headSha) {
+          debug(
+            "walkthrough-jobs",
+            `incremental start requested at unchanged head sha=${meta.headSha}; reusing wt=${priorArtifact.id}`,
+          );
+          return { walkthroughId: priorArtifact.id };
+        }
+        const parentWalkthroughId = partial?.parentWalkthroughId ?? priorArtifact?.id ?? null;
+        const baseHeadSha = partial?.baseHeadSha ?? priorArtifact?.prHeadSha ?? null;
+        const generationMode: WalkthroughGenerationMode =
+          requestedGenerationMode === "incremental" && parentWalkthroughId && baseHeadSha
+            ? "incremental"
+            : "full";
+
         const idCandidate = partial?.id ?? params.walkthroughId;
         const walkthroughId = yield* provideDb(
           walkthroughService.createPartial({
@@ -1279,6 +1453,10 @@ export const WalkthroughJobsLive = Layer.effect(
             modelUsed,
             prHeadSha: meta.headSha,
             mode,
+            generationMode,
+            parentWalkthroughId,
+            baseHeadSha,
+            forceNew: params.trigger === "user" && generationMode === "full",
             prCommits: commits,
             ...(generatedBy ? { generatedBy } : {}),
             providerConfig: providerConfigForJob,
@@ -1316,7 +1494,7 @@ export const WalkthroughJobsLive = Layer.effect(
               }),
             ).pipe(Effect.either);
             if (importResult._tag === "Right") {
-              yield* setStatus(walkthroughId, "complete");
+              yield* setStatus(walkthroughId, "complete", { tokenUsage: ZERO_TOKEN_USAGE });
               // New clients see the cache-hit marker + lifecycle:complete on
               // the global SSE bus and re-hydrate via REST `/current` to get
               // the imported content. (A future iteration can replay the
@@ -1382,6 +1560,8 @@ export const WalkthroughJobsLive = Layer.effect(
               externalId: pr.externalId,
             },
             repoId: repo.id,
+            repoFullName: repo.fullName,
+            githubHost: repo.githubHost,
             token,
             prHeadSha: meta.headSha,
             files,
@@ -1389,6 +1569,9 @@ export const WalkthroughJobsLive = Layer.effect(
             reviewSessionId,
             modelUsed,
             mode,
+            generationMode,
+            parentWalkthroughId,
+            baseHeadSha,
           },
           params.trigger,
         );
@@ -1738,7 +1921,7 @@ export const WalkthroughJobsLive = Layer.effect(
           return false;
         }
 
-        yield* setStatus(walkthroughId, "complete");
+        yield* setStatus(walkthroughId, "complete", { tokenUsage: ZERO_TOKEN_USAGE });
         // New SSE bus only. Clients re-hydrate via `/current` to fetch the
         // imported content; replay-as-events is a follow-up improvement.
         yield* emitEvent(walkthroughId, {

--- a/apps/server/src/services/WalkthroughJobs.ts
+++ b/apps/server/src/services/WalkthroughJobs.ts
@@ -1338,6 +1338,9 @@ export const WalkthroughJobsLive = Layer.effect(
         ) {
           partial = null;
         }
+        if (params.trigger === "user" && partial?.status === "error") {
+          partial = null;
+        }
 
         const reviewSession = yield* provideDb(reviewService.getOrCreateActiveSession(pr.id, mode));
         const reviewSessionId = partial?.reviewSessionId ?? reviewSession.id;

--- a/apps/server/src/services/WalkthroughJobs.ts
+++ b/apps/server/src/services/WalkthroughJobs.ts
@@ -772,6 +772,19 @@ export const WalkthroughJobsLive = Layer.effect(
         //     progress) for auto-continuation + completion.
         //   - Reacts to the terminal `done` / `error` events.
 
+        const closeGeneratorBestEffort = (
+          generator: AsyncGenerator<WalkthroughStreamEvent>,
+        ): Effect.Effect<void> =>
+          Effect.sync(() => {
+            void generator.return?.(undefined).catch((err) => {
+              debug(
+                "walkthrough-jobs",
+                "generator cleanup failed:",
+                err instanceof Error ? err.message : String(err),
+              );
+            });
+          });
+
         const processEvent = (
           state: LoopState,
           event: WalkthroughStreamEvent,
@@ -952,6 +965,7 @@ export const WalkthroughJobsLive = Layer.effect(
             if (result._tag === "continue") {
               return yield* consumeGenerator(state);
             }
+            yield* closeGeneratorBestEffort(state.currentGenerator);
             return result;
           });
 

--- a/apps/server/src/services/github-rest.ts
+++ b/apps/server/src/services/github-rest.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { Effect, Schedule } from "effect";
 import {
+  GitHubAccessDeniedError,
   GitHubAuthError,
   type GitHubError,
   GitHubNetworkError,
@@ -11,6 +12,7 @@ import type { DbService } from "./Db";
 import { buildCacheKey, GitHubEtagCache } from "./GitHubEtagCache";
 
 const retrySchedule = Schedule.intersect(Schedule.exponential("2 seconds"), Schedule.recurs(3));
+const GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
 const isTransientGitHubError = (e: GitHubError): boolean => e instanceof GitHubNetworkError;
 
@@ -29,6 +31,7 @@ function cacheKeyForRequest(apiBase: string, path: string, token: string): strin
 export function toGitHubError(e: unknown): GitHubError {
   if (
     e instanceof GitHubAuthError ||
+    e instanceof GitHubAccessDeniedError ||
     e instanceof GitHubRateLimitError ||
     e instanceof GitHubNotFoundError ||
     e instanceof GitHubNetworkError
@@ -45,6 +48,28 @@ export function githubHeaders(token: string): Record<string, string> {
     Accept: "application/vnd.github.v3+json",
     "X-GitHub-Api-Version": "2022-11-28",
   };
+}
+
+async function githubHttpFetch(url: string, init: RequestInit, path: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), GITHUB_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } catch (e) {
+    const name = typeof e === "object" && e !== null && "name" in e ? String(e.name) : "";
+    if (name === "AbortError") {
+      throw new GitHubNetworkError({
+        cause: `Request timed out after ${GITHUB_REQUEST_TIMEOUT_MS}ms for ${path}`,
+      });
+    }
+    const detail = e instanceof Error && e.message ? `${e.name}: ${e.message}` : String(e);
+    throw new GitHubNetworkError({ cause: `${detail} for ${path}` });
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /** Assert a fetch response is successful, throwing the appropriate domain error on failure. */
@@ -83,8 +108,9 @@ export function assertGitHubOk(res: Response, path: string): void {
       });
     }
 
-    throw new GitHubNetworkError({
-      cause: `HTTP 403 - access denied for ${path} (check GitHub org OAuth app policies)`,
+    throw new GitHubAccessDeniedError({
+      resource: path,
+      message: `Access denied for ${path} (check GitHub org OAuth app policies)`,
     });
   }
   if (res.status === 404) {
@@ -116,9 +142,13 @@ export function githubFetch(
   })(
     Effect.tryPromise({
       try: async () => {
-        const res = await fetch(`${apiBase}${path}`, {
-          headers: githubHeaders(token),
-        });
+        const res = await githubHttpFetch(
+          `${apiBase}${path}`,
+          {
+            headers: githubHeaders(token),
+          },
+          path,
+        );
         assertGitHubOk(res, path);
         return res.json();
       },
@@ -143,7 +173,7 @@ export function conditionalFetch(
         if (cached) {
           headers["If-None-Match"] = cached.etag;
         }
-        const res = await fetch(`${apiBase}${path}`, { headers });
+        const res = await githubHttpFetch(`${apiBase}${path}`, { headers }, path);
 
         if (res.status === 304 && cached) {
           return { kind: "hit" as const, body: cached.body, bytes: 0 };
@@ -204,7 +234,7 @@ export function conditionalFetchPaginated(
           }
 
           const firstUrl = `${apiBase}${path}`;
-          let firstResponse = await fetch(firstUrl, { headers });
+          let firstResponse = await githubHttpFetch(firstUrl, { headers }, path);
 
           if (firstResponse.status === 304 && cached) {
             if (Array.isArray(cached.body)) {
@@ -214,7 +244,11 @@ export function conditionalFetchPaginated(
               }
             }
 
-            firstResponse = await fetch(firstUrl, { headers: githubHeaders(token) });
+            firstResponse = await githubHttpFetch(
+              firstUrl,
+              { headers: githubHeaders(token) },
+              path,
+            );
           }
 
           const results: unknown[] = [];
@@ -225,7 +259,9 @@ export function conditionalFetchPaginated(
 
           for (let page = 0; page < maxPages && url; page++) {
             const res =
-              page === 0 ? firstResponse : await fetch(url, { headers: githubHeaders(token) });
+              page === 0
+                ? firstResponse
+                : await githubHttpFetch(url, { headers: githubHeaders(token) }, path);
             assertGitHubOk(res, path);
 
             if (page === 0) {
@@ -292,11 +328,15 @@ export function githubPost(
   })(
     Effect.tryPromise({
       try: async () => {
-        const res = await fetch(`${apiBase}${path}`, {
-          method: "POST",
-          headers: { ...githubHeaders(token), "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        });
+        const res = await githubHttpFetch(
+          `${apiBase}${path}`,
+          {
+            method: "POST",
+            headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          },
+          path,
+        );
         if (res.status === 422) {
           const text = await res.text().catch(() => "");
           throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
@@ -317,11 +357,15 @@ export function githubPatch(
 ): Effect.Effect<unknown, GitHubError> {
   return Effect.tryPromise({
     try: async () => {
-      const res = await fetch(`${apiBase}${path}`, {
-        method: "PATCH",
-        headers: { ...githubHeaders(token), "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
+      const res = await githubHttpFetch(
+        `${apiBase}${path}`,
+        {
+          method: "PATCH",
+          headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        path,
+      );
       if (res.status === 422) {
         const text = await res.text().catch(() => "");
         throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
@@ -341,11 +385,15 @@ export function githubPut(
 ): Effect.Effect<unknown, GitHubError> {
   return Effect.tryPromise({
     try: async () => {
-      const res = await fetch(`${apiBase}${path}`, {
-        method: "PUT",
-        headers: { ...githubHeaders(token), "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
+      const res = await githubHttpFetch(
+        `${apiBase}${path}`,
+        {
+          method: "PUT",
+          headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        path,
+      );
       if (res.status === 405) {
         const text = await res.text().catch(() => "");
         throw new GitHubNetworkError({ cause: `HTTP 405 Method Not Allowed: ${text}` });
@@ -373,11 +421,15 @@ export function githubGraphql<T = unknown>(
   })(
     Effect.tryPromise({
       try: async () => {
-        const res = await fetch(`${apiBase}/graphql`, {
-          method: "POST",
-          headers: { ...githubHeaders(token), "Content-Type": "application/json" },
-          body: JSON.stringify({ query, variables }),
-        });
+        const res = await githubHttpFetch(
+          `${apiBase}/graphql`,
+          {
+            method: "POST",
+            headers: { ...githubHeaders(token), "Content-Type": "application/json" },
+            body: JSON.stringify({ query, variables }),
+          },
+          "/graphql",
+        );
         assertGitHubOk(res, "/graphql");
         const payload = (await res.json()) as { data?: T; errors?: Array<{ message: string }> };
         if (payload.errors && payload.errors.length > 0) {
@@ -416,9 +468,13 @@ export function githubFetchPaginated(
         let url: string | null = `${apiBase}${path}`;
 
         for (let page = 0; page < maxPages && url; page++) {
-          const res = await fetch(url, {
-            headers: githubHeaders(token),
-          });
+          const res = await githubHttpFetch(
+            url,
+            {
+              headers: githubHeaders(token),
+            },
+            path,
+          );
           assertGitHubOk(res, path);
 
           const data = await res.json();

--- a/apps/server/src/services/github-rest.ts
+++ b/apps/server/src/services/github-rest.ts
@@ -409,6 +409,29 @@ export function githubPut(
   });
 }
 
+export function githubDelete(
+  path: string,
+  token: string,
+  apiBase: string,
+): Effect.Effect<unknown, GitHubError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const res = await githubHttpFetch(
+        `${apiBase}${path}`,
+        {
+          method: "DELETE",
+          headers: githubHeaders(token),
+        },
+        path,
+      );
+      assertGitHubOk(res, path);
+      const text = await res.text();
+      return text ? JSON.parse(text) : null;
+    },
+    catch: toGitHubError,
+  });
+}
+
 export function githubGraphql<T = unknown>(
   query: string,
   variables: Record<string, unknown>,

--- a/apps/web/src/lib/components/layout/AppShell.svelte
+++ b/apps/web/src/lib/components/layout/AppShell.svelte
@@ -31,7 +31,7 @@ import {
   toggleRightPanel,
   toggleSidebar,
 } from "$lib/stores/sidebar.svelte";
-import { getPrWalkthroughStatus } from "$lib/stores/walkthrough.svelte";
+import { getPrWalkthroughStatus, markWalkthroughStale } from "$lib/stores/walkthrough.svelte";
 import BottomBar from "./BottomBar.svelte";
 import CommandPalette from "./CommandPalette.svelte";
 import FloatingTabs from "./FloatingTabs.svelte";
@@ -71,6 +71,11 @@ const hasNewCommit = $derived.by(() => {
   return loaded !== null && loaded !== pr.headSha;
 });
 const isPulling = $derived(pr ? getIsPullingCommit(pr.id) : false);
+
+$effect(() => {
+  if (pr && hasNewCommit) markWalkthroughStale(pr.id);
+});
+
 function onPullCommit(): void {
   if (pr) void pullLatestCommit(pr.id);
 }

--- a/apps/web/src/lib/components/layout/GenActionBar.svelte
+++ b/apps/web/src/lib/components/layout/GenActionBar.svelte
@@ -28,10 +28,19 @@ interface Props {
   onResume?: () => void;
   onGenerate?: () => void;
   onRegenerate: () => void;
+  onRegenerateFromScratch?: () => void;
 }
 
-let { uiState, pendingAction, disabledTitle, onStop, onResume, onGenerate, onRegenerate }: Props =
-  $props();
+let {
+  uiState,
+  pendingAction,
+  disabledTitle,
+  onStop,
+  onResume,
+  onGenerate,
+  onRegenerate,
+  onRegenerateFromScratch,
+}: Props = $props();
 
 const destructiveDisabled = $derived(pendingAction !== null);
 const destructiveTitle = $derived(
@@ -123,20 +132,36 @@ const destructiveTitle = $derived(
     {:else if uiState.kind === "complete"}
       <GlassPill
         disabled={destructiveDisabled}
-        title={destructiveTitle ?? "Generate a fresh version"}
+        title={destructiveTitle ?? "Refresh this report using the current review as context"}
         onclick={onRegenerate}
       >
         <RefreshCw size={16} weight="fill" />
         Regenerate
       </GlassPill>
+      <GlassPill
+        disabled={destructiveDisabled}
+        title={destructiveTitle ?? "Generate a fresh review without using the prior report"}
+        onclick={onRegenerateFromScratch ?? onRegenerate}
+      >
+        <RotateCcw size={16} weight="fill" />
+        From scratch
+      </GlassPill>
     {:else if uiState.kind === "stale"}
       <GlassPill
         disabled={destructiveDisabled}
-        title={destructiveTitle ?? "Regenerate for the latest version"}
+        title={destructiveTitle ?? "Review only what changed since the last reviewed commit"}
         onclick={onRegenerate}
       >
         <RefreshCw size={16} weight="fill" />
-        {uiState.label ?? "Regenerate for latest"}
+        {uiState.label ?? "Review new commits"}
+      </GlassPill>
+      <GlassPill
+        disabled={destructiveDisabled}
+        title={destructiveTitle ?? "Generate a fresh review for the latest commit"}
+        onclick={onRegenerateFromScratch ?? onRegenerate}
+      >
+        <RotateCcw size={16} weight="fill" />
+        From scratch
       </GlassPill>
     {/if}
     </span>

--- a/apps/web/src/lib/components/layout/WalkthroughActionBar.svelte
+++ b/apps/web/src/lib/components/layout/WalkthroughActionBar.svelte
@@ -10,10 +10,13 @@ import { getReviewMode } from "$lib/stores/review.svelte";
 import {
   abort as abortWalkthrough,
   generateWalkthrough,
+  getHasUnreviewedCommits,
   getPendingAction as getWalkthroughPendingAction,
   getRatings as getWalkthroughRatings,
   getWalkthroughUiState,
+  loadReviewRounds,
   regenerate as regenerateWalkthrough,
+  regenerateFromScratch as regenerateWalkthroughFromScratch,
   resume as resumeWalkthrough,
 } from "$lib/stores/walkthrough.svelte";
 import {
@@ -35,12 +38,21 @@ const walkthroughHasRatings = $derived(getWalkthroughRatings().length > 0);
 const walkthroughHasNewContentBelow = $derived(getWalkthroughHasNewContentBelow());
 const chatStreaming = $derived(isChatStreaming(prId));
 const selectedMode = $derived(getReviewMode(prId));
+const hasUnreviewedCommits = $derived(getHasUnreviewedCommits(prId, selectedMode));
+const reviewNewCommitsLabel = "Review new commits";
+
+$effect(() => {
+  void loadReviewRounds(prId, selectedMode);
+});
 
 /** Map walkthrough-specific state to the normalised GenActionState. */
 const genActionState = $derived.by((): GenActionState | null => {
   switch (walkthroughUiState.kind) {
     case "absent":
     case "idle":
+      if (hasUnreviewedCommits) {
+        return { kind: "stale", label: reviewNewCommitsLabel };
+      }
       return { kind: "empty", label: "Generate walkthrough" };
     case "streaming":
       return { kind: "streaming" };
@@ -50,9 +62,12 @@ const genActionState = $derived.by((): GenActionState | null => {
     case "error-empty":
       return { kind: "error" };
     case "complete":
+      if (hasUnreviewedCommits) {
+        return { kind: "stale", label: reviewNewCommitsLabel };
+      }
       return { kind: "complete" };
     case "complete-stale":
-      return { kind: "stale", label: "Regenerate for latest commit" };
+      return { kind: "stale", label: reviewNewCommitsLabel };
     default:
       return null;
   }
@@ -89,6 +104,7 @@ const combinedDisabledTitle = $derived(
         onResume={() => resumeWalkthrough(prId, selectedMode)}
         onGenerate={() => generateWalkthrough(prId, selectedMode)}
         onRegenerate={() => regenerateWalkthrough(prId, selectedMode)}
+        onRegenerateFromScratch={() => regenerateWalkthroughFromScratch(prId)}
       />
 
       {#if walkthroughUiState.kind === "streaming" && walkthroughHasNewContentBelow}

--- a/apps/web/src/lib/components/onboarding/StepHost.svelte
+++ b/apps/web/src/lib/components/onboarding/StepHost.svelte
@@ -44,11 +44,24 @@ function normalizeHost(raw: string): string {
 
 const resolvedHost = $derived(selected === CUSTOM ? normalizeHost(customHost) : selected);
 const resolvedClientId = $derived(selected === CUSTOM ? customClientId.trim() : "");
+const clientIdIsPlaceholder = $derived(
+  (() => {
+    const normalized = resolvedClientId.toLowerCase();
+    return (
+      normalized === "github_client_id" ||
+      normalized === "client_id" ||
+      normalized === "your_client_id" ||
+      normalized === "your-github-client-id" ||
+      normalized.includes("xxxxxxxx")
+    );
+  })(),
+);
 // Example URL for the "create a GitHub App" instructions — uses the host the
 // user typed once it's present, otherwise a placeholder.
 const appCreateUrl = $derived(`https://${resolvedHost || "your-ghe-host.com"}/settings/apps/new`);
 const canContinue = $derived(
-  selected !== CUSTOM || (resolvedHost.length > 0 && resolvedClientId.length > 0),
+  selected !== CUSTOM ||
+    (resolvedHost.length > 0 && resolvedClientId.length > 0 && !clientIdIsPlaceholder),
 );
 
 async function handleContinue() {
@@ -147,6 +160,9 @@ async function handleContinue() {
 					Revv has no app registered on your instance — you create one and paste its
 					public client ID here. It's safe to store (it isn't a secret).
 				</p>
+				{#if clientIdIsPlaceholder}
+					<p class="field-error">Paste the real client ID from your GitHub App or OAuth App.</p>
+				{/if}
 			</div>
 
 			<div class="guide" data-open={showInstructions}>
@@ -551,6 +567,14 @@ async function handleContinue() {
 		font-size: 13.5px;
 		line-height: 1.55;
 		color: var(--ob-text-muted);
+	}
+
+	.field-error {
+		margin: 0;
+		font-family: 'Newsreader', Georgia, serif;
+		font-size: 13.5px;
+		line-height: 1.45;
+		color: var(--danger, #f87171);
 	}
 
 	.guide {

--- a/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
+++ b/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
@@ -235,7 +235,13 @@ $effect(() => {
     visibleReportRounds.find((round) => round.status !== "generating") ??
     visibleReportRounds[0] ??
     null;
-  if (!candidate || displayedReportIsVisible || isStreaming || reportLoadingId !== null) {
+  if (
+    !candidate ||
+    selectedReportId !== null ||
+    displayedReportIsVisible ||
+    isStreaming ||
+    reportLoadingId !== null
+  ) {
     return;
   }
 

--- a/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
+++ b/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
@@ -3,8 +3,16 @@ import { onDestroy, onMount, untrack } from "svelte";
 
 const TOOL_CALL_ROW_H = 14; // px — 10px font × 1.4 line-height
 
-import type { WalkthroughBlock, WalkthroughMode, WalkthroughSemanticStep } from "@revv/shared";
+import type {
+  WalkthroughBlock,
+  WalkthroughMode,
+  WalkthroughReviewRound,
+  WalkthroughSemanticStep,
+} from "@revv/shared";
 import RefreshCw from "phosphor-svelte/lib/ArrowsClockwise";
+import CaretDown from "phosphor-svelte/lib/CaretDown";
+import Check from "phosphor-svelte/lib/Check";
+import Clock from "phosphor-svelte/lib/Clock";
 import AlertTriangle from "phosphor-svelte/lib/Warning";
 import { toast } from "svelte-sonner";
 import { mermaidDiagrams } from "$lib/actions/mermaid.svelte";
@@ -15,6 +23,7 @@ import { ToolActivityGroup } from "$lib/components/ai/tool";
 import { Button } from "$lib/components/ui/button";
 import { Dotmatrix } from "$lib/components/ui/dotmatrix/index.js";
 import FileBadge from "$lib/components/ui/FileBadge.svelte";
+import * as Popover from "$lib/components/ui/popover";
 import { Progress } from "$lib/components/ui/progress";
 import { Separator } from "$lib/components/ui/separator";
 import { gsapFadeY, tokens } from "$lib/motion";
@@ -30,6 +39,7 @@ import {
   getBlocks,
   getCloneInProgress,
   getCloneRepoId,
+  getDisplayedWalkthroughId,
   getExplorationInputs,
   getExplorationResults,
   getExplorationSteps,
@@ -43,7 +53,9 @@ import {
   getPhase,
   getProviderConfig,
   getRatings,
+  getReviewRounds,
   getRiskLevel,
+  getSelectedReportId,
   getSemanticSteps,
   getSentiment,
   getSource,
@@ -55,17 +67,20 @@ import {
   hasContainerAnimated,
   hasIssueAnimated,
   hydrateFromCache,
+  loadReviewRounds,
   markBlockAnimated,
   markContainerAnimated,
   markIssueAnimated,
   pollCloneUntilResolved,
   prepareEntry,
   regenerate,
+  selectWalkthroughReport,
   startWalkthrough,
   stopClonePoll,
 } from "$lib/stores/walkthrough.svelte";
 import { type GroupableActivity, isExplorationActivity } from "$lib/utils/activity-groups";
 import { initHighlighter } from "$lib/utils/code-highlight.svelte";
+import { formatRelativeTime } from "$lib/utils/format-relative-time";
 import { renderMarkdown } from "$lib/utils/markdown";
 import { authHeaders } from "$lib/utils/session-token";
 import { groupIssuesBySeverityWithIndex } from "$lib/utils/walkthrough-issues";
@@ -78,6 +93,8 @@ interface Props {
   scrollRoot?: HTMLElement | undefined;
   isActive?: boolean;
 }
+
+type DisplayReportRound = WalkthroughReviewRound & { displayRoundNumber: number };
 
 let { prId, scrollRoot, isActive = true }: Props = $props();
 
@@ -119,6 +136,114 @@ const superseded = $derived(getIsSuperseded());
 const generatedBy = $derived(getGeneratedBy());
 const providerConfig = $derived(getProviderConfig());
 const walkthroughSource = $derived(getSource());
+const reviewRounds = $derived(getReviewRounds(prId, selectedMode));
+const displayedWalkthroughId = $derived(getDisplayedWalkthroughId(prId));
+const selectedReportId = $derived(getSelectedReportId(prId));
+const reportRounds = $derived(reviewRounds?.rounds ?? []);
+const currentReportHeadSha = $derived(reviewRounds?.currentHeadSha ?? null);
+const visibleReportRounds = $derived.by((): DisplayReportRound[] => {
+  const numbered = [...reportRounds]
+    .filter((round) => round.visibility !== "hidden")
+    .sort((a, b) => a.roundNumber - b.roundNumber)
+    .map((round, index) => ({ ...round, displayRoundNumber: index + 1 }));
+
+  return numbered.sort((a, b) => {
+    const aCurrent = currentReportHeadSha !== null && a.toSha === currentReportHeadSha;
+    const bCurrent = currentReportHeadSha !== null && b.toSha === currentReportHeadSha;
+    if (aCurrent !== bCurrent) return aCurrent ? -1 : 1;
+
+    const aTime = Date.parse(a.completedAt ?? a.createdAt);
+    const bTime = Date.parse(b.completedAt ?? b.createdAt);
+    if (aTime !== bTime) return bTime - aTime;
+
+    return b.roundNumber - a.roundNumber;
+  });
+});
+const activeReportRound = $derived(
+  displayedWalkthroughId
+    ? (visibleReportRounds.find((round) => round.walkthroughId === displayedWalkthroughId) ?? null)
+    : null,
+);
+const displayedReportIsVisible = $derived(
+  displayedWalkthroughId !== null &&
+    visibleReportRounds.some((round) => round.walkthroughId === displayedWalkthroughId),
+);
+const reportSelectorVisible = $derived(visibleReportRounds.length > 1 || selectedReportId !== null);
+
+let reportPopoverOpen = $state(false);
+let reportLoadingId = $state<string | null>(null);
+let autoSelectedReportKey: string | null = null;
+
+function reportKindLabel(kind: WalkthroughReviewRound["kind"]): string {
+  return kind === "incremental" ? "New commits" : "Full PR";
+}
+
+function reportStatusLabel(status: WalkthroughReviewRound["status"]): string {
+  if (status === "superseded") return "Previous";
+  if (status === "generating") return "Generating";
+  if (status === "error") return "Stopped";
+  return "Complete";
+}
+
+function reportShortSha(sha: string | null): string {
+  return sha ? sha.slice(0, 7) : "start";
+}
+
+function reportCommitRange(round: WalkthroughReviewRound): string {
+  return `${reportShortSha(round.fromSha)} → ${reportShortSha(round.toSha)}`;
+}
+
+function reportTitle(round: WalkthroughReviewRound & { displayRoundNumber?: number }): string {
+  return `Report ${round.displayRoundNumber ?? round.roundNumber}: ${reportKindLabel(round.kind)}`;
+}
+
+function reportShortName(round: WalkthroughReviewRound): string {
+  if (round.focusTitle) return round.focusTitle;
+  if (currentReportHeadSha !== null && round.toSha === currentReportHeadSha) {
+    return round.kind === "full" ? "Current full review" : "Current changes";
+  }
+  return round.kind === "full" ? "Prior full review" : "Prior changes";
+}
+
+function reportHeadLabel(round: WalkthroughReviewRound): string {
+  return currentReportHeadSha !== null && round.toSha === currentReportHeadSha
+    ? "Current head"
+    : "Older head";
+}
+
+const reportTriggerLabel = $derived.by(() => {
+  if (activeReportRound) {
+    return `${reportTitle(activeReportRound)} · ${reportShortName(activeReportRound)}`;
+  }
+  if (selectedReportId !== null) return "Historical report";
+  return "Walkthrough reports";
+});
+
+async function chooseReport(walkthroughId: string | null): Promise<void> {
+  if (reportLoadingId !== null) return;
+  reportLoadingId = walkthroughId ?? "latest";
+  try {
+    await selectWalkthroughReport(prId, walkthroughId, selectedMode);
+    reportPopoverOpen = false;
+  } finally {
+    reportLoadingId = null;
+  }
+}
+
+$effect(() => {
+  const candidate =
+    visibleReportRounds.find((round) => round.status !== "generating") ??
+    visibleReportRounds[0] ??
+    null;
+  if (!candidate || displayedReportIsVisible || isStreaming || reportLoadingId !== null) {
+    return;
+  }
+
+  const key = `${prId}:${selectedMode}:${candidate.walkthroughId}`;
+  if (autoSelectedReportKey === key) return;
+  autoSelectedReportKey = key;
+  void chooseReport(candidate.walkthroughId);
+});
 
 const footerParts: string[] = $derived.by(() => {
   const parts: string[] = [];
@@ -146,6 +271,10 @@ let hydratedForMode: WalkthroughMode | null = $state(null);
 let lastStreamErrorToast: string | null = null;
 let lastCloneErrorToast: string | null = null;
 let lastSupersededToastPrId: string | null = null;
+
+$effect(() => {
+  void loadReviewRounds(prId, selectedMode);
+});
 
 $effect(() => {
   if (!isActive || !streamError) {
@@ -194,7 +323,7 @@ $effect(() => {
     id: `walkthrough-superseded-${prId}`,
     description: "The PR has new commits since this review was generated.",
     action: {
-      label: "Regenerate",
+      label: "Review new commits",
       onClick: () => handleRegenerate(),
     },
     duration: Number.POSITIVE_INFINITY,
@@ -924,6 +1053,57 @@ function handleRegenerate(): void {
 </script>
 
 <div class="walkthrough">
+	{#if reportSelectorVisible}
+		<div class="report-selector-row">
+			<Popover.Root bind:open={reportPopoverOpen}>
+				<Popover.Trigger
+					class="report-selector-trigger"
+					aria-label="Choose walkthrough report"
+					title="Choose walkthrough report"
+				>
+					<Clock size={13} weight="regular" aria-hidden="true" />
+					<span>{reportTriggerLabel}</span>
+					<CaretDown size={12} weight="bold" aria-hidden="true" />
+				</Popover.Trigger>
+
+				<Popover.Content align="start" sideOffset={6} class="report-selector-popover">
+					<div class="report-selector-header">
+						<span>Walkthrough reports</span>
+					</div>
+
+					<div class="report-option-list">
+						{#each visibleReportRounds as round (round.id)}
+							{@const active = displayedWalkthroughId === round.walkthroughId}
+							{@const disabled = reportLoadingId !== null || round.status === 'generating'}
+							<button
+								type="button"
+								class="report-option"
+								class:report-option--active={active}
+								disabled={disabled}
+								onclick={() => chooseReport(round.walkthroughId)}
+							>
+								<span class="report-check" aria-hidden="true">
+									{#if active}
+										<Check size={12} weight="bold" />
+									{/if}
+								</span>
+								<span class="report-option-main">
+									<span class="report-option-title">
+										<span>{reportTitle(round)}</span>
+										<span class="report-option-shortname">{reportShortName(round)}</span>
+									</span>
+									<span class="report-option-meta">
+										{reportStatusLabel(round.status)} · {reportHeadLabel(round)} · {reportCommitRange(round)} · {formatRelativeTime(round.completedAt ?? round.createdAt)}
+									</span>
+								</span>
+							</button>
+						{/each}
+					</div>
+				</Popover.Content>
+			</Popover.Root>
+		</div>
+	{/if}
+
 	{#if !streamError && stepperVisible}
 		<!-- Persistent chapters stepper. Replaces the old A→B→C→D dot indicator.
 		     Lives outside the if/else ladder so it stays mounted as the streaming
@@ -1439,6 +1619,150 @@ function handleRegenerate(): void {
 	   emit elements without the parent's Svelte scope hash. */
 	.walkthrough-loading > :global(*) {
 		grid-column: 3;
+	}
+
+	.report-selector-row {
+		display: grid;
+		grid-template-columns:
+			max(24px, min(calc(50% - 458px), calc(100% - 1312px)))
+			48px
+			minmax(0, 820px)
+			40px
+			380px
+			minmax(24px, 1fr);
+		padding: 18px 0 0;
+	}
+
+	.report-selector-row > :global(*) {
+		grid-column: 3;
+		justify-self: start;
+	}
+
+	:global(.report-selector-trigger) {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		max-width: min(100%, 340px);
+		height: 28px;
+		padding: 0 10px;
+		border: 1px solid var(--color-border);
+		border-radius: 999px;
+		background: var(--color-bg-elevated);
+		color: var(--color-text-secondary);
+		font-size: 0.75rem;
+		line-height: 1;
+	}
+
+	:global(.report-selector-trigger:hover),
+	:global(.report-selector-trigger[data-state="open"]) {
+		border-color: var(--color-border-strong);
+		color: var(--color-text-primary);
+	}
+
+	:global(.report-selector-trigger span) {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	:global(.report-selector-popover) {
+		width: min(420px, calc(100vw - 32px));
+		max-height: min(480px, calc(100vh - 120px));
+		overflow: auto;
+	}
+
+	.report-selector-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0 2px 4px;
+		font-size: 0.72rem;
+		font-weight: 650;
+		color: var(--color-text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.report-option-list {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.report-option {
+		display: grid;
+		grid-template-columns: 18px minmax(0, 1fr);
+		gap: 8px;
+		width: 100%;
+		padding: 8px;
+		border: 1px solid transparent;
+		border-radius: 8px;
+		background: transparent;
+		color: var(--color-text-primary);
+		text-align: left;
+	}
+
+	.report-option:hover:not(:disabled),
+	.report-option--active {
+		border-color: var(--color-border);
+		background: var(--color-bg-elevated);
+	}
+
+	.report-option:disabled {
+		opacity: 0.55;
+		cursor: default;
+	}
+
+	.report-check {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 18px;
+		height: 18px;
+		color: var(--color-accent);
+	}
+
+	.report-option-main {
+		display: flex;
+		min-width: 0;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.report-option-title {
+		display: flex;
+		min-width: 0;
+		align-items: baseline;
+		gap: 6px;
+		overflow: hidden;
+		font-size: 0.82rem;
+		font-weight: 650;
+		color: var(--color-text-primary);
+	}
+
+	.report-option-title > span:first-child,
+	.report-option-shortname,
+	.report-option-meta {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.report-option-title > span:first-child {
+		flex: 0 0 auto;
+	}
+
+	.report-option-shortname {
+		min-width: 0;
+		flex: 1 1 auto;
+		font-weight: 500;
+		color: var(--color-text-muted);
+	}
+
+	.report-option-meta {
+		font-size: 0.72rem;
+		color: var(--color-text-muted);
 	}
 
 	/* ── Persistent chapters stepper header ─────────────────────────────
@@ -2122,6 +2446,7 @@ function handleRegenerate(): void {
 		.block-annotation,
 		.issues-section,
 		.walkthrough-content,
+		.report-selector-row,
 		.walkthrough-stepper-header,
 		.dotmatrix-dot {
 			animation-duration: 0.01ms !important;
@@ -2230,6 +2555,7 @@ function handleRegenerate(): void {
 		   extra horizontal padding — that would shift them inward of the
 		   parent's content edges and break alignment with .blocks below. */
 		.walkthrough-loading,
+		.report-selector-row,
 		.walkthrough-stepper-header {
 			display: block;
 			width: 100%;
@@ -2251,6 +2577,7 @@ function handleRegenerate(): void {
 		}
 
 		.walkthrough-loading > :global(*),
+		.report-selector-row > :global(*),
 		.walkthrough-stepper-header > * {
 			grid-column: auto;
 		}

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -177,6 +177,27 @@ function parseSignInErrorCode(value: unknown): SignInErrorCode | null {
     : null;
 }
 
+async function signInHttpError(res: Response): Promise<Error> {
+  const body = await res.text().catch(() => "");
+  let detail = body.trim();
+  try {
+    const parsed = JSON.parse(body) as { error?: string; code?: unknown };
+    if (parsed?.error) detail = parsed.error;
+    signInErrorCode = parseSignInErrorCode(parsed?.code);
+  } catch {
+    // Plain-text body — use it as-is.
+  }
+  return new Error(`Sign-in request failed (${res.status})${detail ? `: ${detail}` : ""}`);
+}
+
+function signInErrorMessage(e: unknown): string {
+  if (e instanceof TypeError) {
+    return `Failed to reach the local Revv server at ${API_BASE_URL}: ${e.message}`;
+  }
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
 export async function signIn(host?: string): Promise<boolean> {
   error = null;
   signInErrorCode = null;
@@ -188,21 +209,7 @@ export async function signIn(host?: string): Promise<boolean> {
         ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify({ host }) }
         : {}),
     });
-    if (!res.ok) {
-      // Surface the server's actual reason (e.g. "Signing in to <host> requires
-      // a GitHub App or OAuth App client ID") instead of a generic message.
-      // `device/init` returns either a JSON `{ error }` or a plain-text reason.
-      const body = await res.text().catch(() => "");
-      let detail = body.trim();
-      try {
-        const parsed = JSON.parse(body) as { error?: string; code?: unknown };
-        if (parsed?.error) detail = parsed.error;
-        signInErrorCode = parseSignInErrorCode(parsed?.code);
-      } catch {
-        /* plain-text body — use as-is */
-      }
-      throw new Error(detail || `Failed to initiate sign-in (HTTP ${res.status})`);
-    }
+    if (!res.ok) throw await signInHttpError(res);
     const data = (await res.json()) as {
       device_code: string;
       user_code: string;
@@ -232,7 +239,7 @@ export async function signIn(host?: string): Promise<boolean> {
     startPolling();
     return true;
   } catch (e) {
-    error = `Failed to start sign-in: ${e instanceof Error ? e.message : String(e)}`;
+    error = `Failed to start sign-in: ${signInErrorMessage(e)}`;
     return false;
   } finally {
     isLoading = false;

--- a/apps/web/src/lib/stores/events.svelte.ts
+++ b/apps/web/src/lib/stores/events.svelte.ts
@@ -46,6 +46,7 @@ import {
   hydrateActiveWalkthroughs,
   hydrateFromCache,
   onWalkthroughEvent,
+  refreshReviewRoundsForPrs,
 } from "./walkthrough.svelte";
 
 let source: EventSource | null = null;
@@ -188,6 +189,7 @@ function dispatch(msg: ServerEventMessage): void {
       break;
     case "prs:updated":
       replacePullRequests(msg.data);
+      refreshReviewRoundsForPrs(msg.data.map((pr) => pr.id));
       break;
     case "pr:archived":
       onPrArchived(msg.data);

--- a/apps/web/src/lib/stores/review.svelte.ts
+++ b/apps/web/src/lib/stores/review.svelte.ts
@@ -114,6 +114,13 @@ export function getIsPullingCommit(prId: string): boolean {
   return isPullingCommit.has(prId);
 }
 
+function apiErrorMessage(error: { status: number; value?: unknown }, fallback: string): string {
+  const value = error.value as { error?: unknown; message?: unknown } | null | undefined;
+  if (typeof value?.error === "string") return value.error;
+  if (typeof value?.message === "string") return value.message;
+  return `${fallback} (HTTP ${error.status})`;
+}
+
 /**
  * Refetch the PR's diff files against the current `pr.headSha`, restamp
  * the loaded SHA, and regenerate the walkthrough against the new content.
@@ -136,7 +143,9 @@ export async function pullLatestCommit(prId: string): Promise<void> {
       query: activePath === null ? { mode } : { active: activePath, mode },
     });
     if (error || !Array.isArray(data)) {
-      throw new Error("Failed to refetch files");
+      throw new Error(
+        error ? apiErrorMessage(error, "Failed to refetch files") : "Failed to refetch files",
+      );
     }
 
     const mapped: ReviewFile[] = data.map((f) => ({

--- a/apps/web/src/lib/stores/walkthrough.svelte.ts
+++ b/apps/web/src/lib/stores/walkthrough.svelte.ts
@@ -1130,6 +1130,7 @@ async function doHydrateFromCache(
     const { status } = body;
     const isGenerating = status === "generating";
     const isError = status === "error";
+    const isHistorical = body.historical === true && !isGenerating;
     wtTrace(
       "lifecycle",
       `hydrateFromCache prId=${prId} status=${status} blocks=${wt.blocks.length} issues=${wt.issues.length} ratings=${wt.ratings.length} semanticSteps=${wt.semanticSteps?.length ?? 0} hasSentiment=${wt.sentiment !== null && wt.sentiment !== undefined}`,
@@ -1188,12 +1189,12 @@ async function doHydrateFromCache(
     entry.isStreaming = isGenerating;
     entry.tokenUsage = coerceTokenUsage(wt.tokenUsage);
     entry.streamError = isError
-      ? body.historical === true
+      ? isHistorical
         ? null
         : "Walkthrough generation failed. Resume or regenerate to retry."
       : null;
     entry.superseded = body.stale === true;
-    entry.historical = body.historical === true;
+    entry.historical = isHistorical;
     entry.phase = isGenerating ? "writing" : "finishing";
     entry.phaseMessage = isGenerating ? "Resuming walkthrough…" : "Complete";
     entry.liveGeneration = isGenerating;
@@ -1202,7 +1203,7 @@ async function doHydrateFromCache(
     if (previous?.source === "remote") entry.source = "remote";
     if (isGenerating) entry.streamStartedAt = Date.now();
     setEntry(prId, entry);
-    store.selectedReportIds.set(prId, body.historical === true ? wt.id : null);
+    store.selectedReportIds.set(prId, isHistorical ? wt.id : null);
 
     // Math.max so SSE can't regress the cursor below what it already advanced
     // past during the fetch window.
@@ -1445,7 +1446,30 @@ export async function regenerate(
     // entry, so dropping it here would only cause `_active` to flip to
     // undefined and flash the "Generate walkthrough" pill between the
     // regenerate and start round-trips.
-    await startWalkthrough(prId, mode, generationMode);
+    const res = await startWalkthrough(prId, mode, generationMode);
+    if (!res) {
+      updateEntry(prId, (e) => {
+        e.isStreaming = false;
+        e.streamError = "Failed to start walkthrough";
+      });
+      return;
+    }
+    if (!res.ok) {
+      updateEntry(prId, (e) => {
+        e.isStreaming = false;
+        e.streamError = `Failed to start walkthrough (HTTP ${res.status}).`;
+      });
+      return;
+    }
+
+    const started = (await res.json().catch(() => null)) as { walkthroughId?: string } | null;
+    if (started?.walkthroughId) {
+      await hydrateFromCache(prId, {
+        mode,
+        reportId: started.walkthroughId,
+        replace: true,
+      });
+    }
   } finally {
     clearPending(prId);
   }

--- a/apps/web/src/lib/stores/walkthrough.svelte.ts
+++ b/apps/web/src/lib/stores/walkthrough.svelte.ts
@@ -891,9 +891,10 @@ export function onWalkthroughEvent(
 
 /**
  * On SSE (re)connect: seed entries for any in-flight walkthroughs owned
- * by the user's account. Drives the sidebar spinner and primes
- * `lastSeenSeq` so subsequent SSE envelopes apply via the same cursor
- * the snapshot already covered.
+ * by the user's account. Each cursor returned by `/active` is only safe
+ * after the matching REST snapshot has been merged into the store; otherwise
+ * the UI would drop already-written events without ever rendering the content
+ * they represent.
  */
 export async function hydrateActiveWalkthroughs(): Promise<void> {
   try {
@@ -907,22 +908,36 @@ export async function hydrateActiveWalkthroughs(): Promise<void> {
         prId: string;
         walkthroughId: string;
         prHeadSha: string;
+        mode?: WalkthroughMode;
         seqAt: number;
       }>;
     };
     for (const row of body.walkthroughs) {
+      const mode = row.mode ?? getSelectedMode(row.prId);
+      const selectedReportId = store.selectedReportIds.get(row.prId) ?? null;
+      if (selectedReportId !== null && selectedReportId !== row.walkthroughId) {
+        continue;
+      }
+
       const existing = store.entries.get(row.prId);
       if (!existing) {
         const stub = freshEntry();
         stub.walkthroughId = row.walkthroughId;
+        stub.mode = mode;
         stub.isStreaming = true;
         stub.liveGeneration = true;
         stub.phase = "writing";
         stub.phaseMessage = "Generating walkthrough…";
         setEntry(row.prId, stub);
       }
-      const existingSeq = store.lastSeenSeq.get(row.walkthroughId) ?? -1;
-      store.lastSeenSeq.set(row.walkthroughId, Math.max(existingSeq, row.seqAt));
+      const hydrated = await hydrateFromCache(row.prId, {
+        activate: store.activePrId === row.prId,
+        mode,
+      });
+      if (hydrated) {
+        const existingSeq = store.lastSeenSeq.get(row.walkthroughId) ?? -1;
+        store.lastSeenSeq.set(row.walkthroughId, Math.max(existingSeq, row.seqAt));
+      }
     }
   } catch (e) {
     wtTrace(

--- a/apps/web/src/lib/stores/walkthrough.svelte.ts
+++ b/apps/web/src/lib/stores/walkthrough.svelte.ts
@@ -29,6 +29,7 @@ import type {
   WalkthroughMode,
   WalkthroughPipelinePhase,
   WalkthroughRating,
+  WalkthroughReviewRoundsResponse,
   WalkthroughSemanticStep,
   WalkthroughStreamEvent,
   WalkthroughTokenUsage,
@@ -67,6 +68,7 @@ export interface WalkthroughEntry {
   walkthroughId: string | null;
   doneReceived: boolean;
   superseded: boolean;
+  historical: boolean;
   explorationSteps: Activity[];
   /**
    * Captured tool outputs keyed by provider `callId`, merged into each
@@ -171,6 +173,7 @@ export function freshEntry(): WalkthroughEntry {
     walkthroughId: null,
     doneReceived: false,
     superseded: false,
+    historical: false,
     explorationSteps: [],
     explorationResults: {},
     explorationInputs: {},
@@ -207,6 +210,12 @@ export const store = $state({
    * by a more recent REST snapshot.
    */
   lastSeenSeq: new SvelteMap<string, number>(),
+  /**
+   * Null means "follow the current/latest walkthrough for this PR".
+   * A walkthrough id means the user intentionally selected a historical
+   * report, so unrelated live events must not mutate the displayed content.
+   */
+  selectedReportIds: new SvelteMap<string, string | null>(),
 });
 
 const PHASE_RANK: Record<WalkthroughPipelinePhase, number> = {
@@ -237,6 +246,16 @@ export function setEntry(prId: string, entry: WalkthroughEntry): void {
 export function deleteEntry(prId: string): void {
   store.entries.delete(prId);
   lastEventAtByPr.delete(prId);
+}
+
+export function getSelectedReportId(prId: string): string | null {
+  return store.selectedReportIds.get(prId) ?? null;
+}
+
+export function getDisplayedWalkthroughId(prId?: string): string | null {
+  const id = prId ?? store.activePrId;
+  if (!id) return null;
+  return store.entries.get(id)?.walkthroughId ?? null;
 }
 
 // ── Stream-liveness tracking ──────────────────────────────────────────────
@@ -337,6 +356,16 @@ export function getLastCompletedPhase(): WalkthroughPipelinePhase {
 export function getIsSuperseded(): boolean {
   return _active?.superseded ?? false;
 }
+
+export function markWalkthroughStale(prId: string): void {
+  updateEntry(prId, (entry) => {
+    if (!entry.doneReceived || entry.superseded) return;
+    entry.superseded = true;
+    entry.isStreaming = false;
+    entry.liveGeneration = false;
+    entry.streamError = null;
+  });
+}
 export function getSource(): "local" | "remote" {
   return _active?.source ?? "local";
 }
@@ -386,10 +415,17 @@ const _uiState: WalkthroughUiState = $derived.by((): WalkthroughUiState => {
 
   const hasPartial = e.summary !== null || e.blocks.length > 0;
 
+  if (e.superseded) {
+    return { kind: "complete-stale" };
+  }
+
   if (e.streamError) {
     return hasPartial
       ? { kind: "error-partial", message: e.streamError, lastPhase: e.lastCompletedPhase }
       : { kind: "error-empty", message: e.streamError };
+  }
+  if (e.historical) {
+    return e.superseded ? { kind: "complete-stale" } : { kind: "complete" };
   }
   if (e.doneReceived && e.lastCompletedPhase === "D") {
     return e.superseded ? { kind: "complete-stale" } : { kind: "complete" };
@@ -415,6 +451,110 @@ export type PendingAction = "regenerate" | "resume" | "start";
 const pendingActions = $state({
   map: new SvelteMap<string, PendingAction>(),
 });
+
+type ReviewRoundsEntry =
+  | { status: "idle" | "loading" }
+  | { status: "error"; error: string }
+  | { status: "ready"; data: WalkthroughReviewRoundsResponse };
+
+const reviewRounds = $state({
+  entries: new SvelteMap<string, ReviewRoundsEntry>(),
+});
+
+const pendingReviewRoundLoads = new Map<string, Promise<WalkthroughReviewRoundsResponse | null>>();
+
+function reviewRoundsKey(prId: string, mode: WalkthroughMode): string {
+  return `${prId}:${mode}`;
+}
+
+export function getReviewRounds(
+  prId: string,
+  mode: WalkthroughMode = getSelectedMode(prId),
+): WalkthroughReviewRoundsResponse | null {
+  const entry = reviewRounds.entries.get(reviewRoundsKey(prId, mode));
+  return entry?.status === "ready" ? entry.data : null;
+}
+
+export function getHasUnreviewedCommits(
+  prId: string,
+  mode: WalkthroughMode = getSelectedMode(prId),
+): boolean {
+  return getReviewRounds(prId, mode)?.hasNewCommits ?? false;
+}
+
+export async function loadReviewRounds(
+  prId: string,
+  mode: WalkthroughMode = getSelectedMode(prId),
+): Promise<WalkthroughReviewRoundsResponse | null> {
+  const key = reviewRoundsKey(prId, mode);
+  const inflight = pendingReviewRoundLoads.get(key);
+  if (inflight) return inflight;
+
+  const promise = (async () => {
+    reviewRounds.entries.set(key, { status: "loading" });
+    try {
+      const res = await fetch(
+        `${API_BASE_URL}/api/reviews/${prId}/walkthrough/rounds?mode=${mode}`,
+        {
+          headers: authHeaders(),
+          credentials: "include",
+        },
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as WalkthroughReviewRoundsResponse;
+      reviewRounds.entries.set(key, { status: "ready", data });
+      return data;
+    } catch (e) {
+      reviewRounds.entries.set(key, {
+        status: "error",
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return null;
+    } finally {
+      pendingReviewRoundLoads.delete(key);
+    }
+  })();
+
+  pendingReviewRoundLoads.set(key, promise);
+  return promise;
+}
+
+export function refreshReviewRoundsForPrs(prIds: readonly string[]): void {
+  for (const prId of prIds) {
+    const mode = getSelectedMode(prId);
+    if (
+      reviewRounds.entries.has(reviewRoundsKey(prId, mode)) ||
+      store.entries.has(prId) ||
+      store.activePrId === prId
+    ) {
+      void loadReviewRounds(prId, mode);
+    }
+  }
+}
+
+export async function selectWalkthroughReport(
+  prId: string,
+  walkthroughId: string | null,
+  mode: WalkthroughMode = getSelectedMode(prId),
+): Promise<void> {
+  store.selectedReportIds.set(prId, walkthroughId);
+  store.activePrId = prId;
+  clearAnimationTrackers(prId);
+  const ok = await hydrateFromCache(prId, {
+    mode,
+    reportId: walkthroughId,
+    replace: true,
+  });
+  if (!ok) {
+    updateEntry(prId, (entry) => {
+      entry.isStreaming = false;
+      entry.streamError =
+        walkthroughId === null
+          ? "Failed to load the latest walkthrough report."
+          : "Failed to load the selected walkthrough report.";
+    });
+  }
+}
 
 function setPending(prId: string, action: PendingAction): void {
   pendingActions.map.set(prId, action);
@@ -612,6 +752,7 @@ export function applyEvents(prId: string, events: WalkthroughStreamEvent[]): voi
           entry.doneReceived = false;
           entry.streamError = null;
           entry.superseded = false;
+          entry.historical = false;
           entry.liveGeneration = true;
           entry.phase = "connecting";
           entry.phaseMessage = "Starting walkthrough…";
@@ -681,6 +822,19 @@ export function onWalkthroughEvent(
   seq: number,
   event: WalkthroughStreamEvent,
 ): void {
+  const selectedReportId = store.selectedReportIds.get(prId) ?? null;
+  if (selectedReportId !== null && selectedReportId !== walkthroughId) {
+    if (event.type === "lifecycle:complete") {
+      void loadReviewRounds(prId, getSelectedMode(prId));
+      if (store.activePrId !== prId) {
+        toast.success("Walkthrough ready", {
+          description: "Switch to that PR to review.",
+        });
+      }
+    }
+    return;
+  }
+
   const cursor = store.lastSeenSeq.get(walkthroughId) ?? -1;
   if (seq <= cursor) {
     wtTrace(
@@ -714,6 +868,17 @@ export function onWalkthroughEvent(
   // Stamp stream liveness so the stall watchdog measures from the last
   // genuinely-delivered event rather than from stream start.
   lastEventAtByPr.set(prId, Date.now());
+
+  if (event.type === "lifecycle:complete") {
+    const entry = store.entries.get(prId);
+    if (
+      entry &&
+      (entry.summary === null || entry.blocks.length === 0 || entry.ratings.length < 9)
+    ) {
+      void hydrateFromCache(prId, { activate: store.activePrId === prId });
+    }
+    void loadReviewRounds(prId, getSelectedMode(prId));
+  }
 
   // Background-completion toast: only if the completion event landed on a
   // PR the user isn't actively viewing.
@@ -848,10 +1013,16 @@ export function getSelectedMode(prId: string): WalkthroughMode {
  */
 export async function hydrateFromCache(
   prId: string,
-  options?: { activate?: boolean; mode?: WalkthroughMode },
+  options?: {
+    activate?: boolean;
+    mode?: WalkthroughMode;
+    replace?: boolean;
+    reportId?: string | null;
+  },
 ): Promise<boolean> {
   const mode = options?.mode ?? getSelectedMode(prId);
-  const key = `${prId}:${mode}`;
+  const reportId = options?.reportId ?? null;
+  const key = `${prId}:${mode}:${reportId ?? "current"}`;
   const inflight = pendingHydration.get(key);
   if (inflight) {
     wtTrace("lifecycle", `hydrateFromCache deduped prId=${prId}`);
@@ -869,12 +1040,20 @@ export async function hydrateFromCache(
 
 async function doHydrateFromCache(
   prId: string,
-  options?: { activate?: boolean; mode?: WalkthroughMode },
+  options?: {
+    activate?: boolean;
+    mode?: WalkthroughMode;
+    replace?: boolean;
+    reportId?: string | null;
+  },
 ): Promise<boolean> {
   const mode = options?.mode ?? getSelectedMode(prId);
+  const reportId = options?.reportId ?? null;
   wtTrace("lifecycle", `hydrateFromCache enter prId=${prId}`);
   const existing = store.entries.get(prId);
   if (
+    !options?.replace &&
+    reportId === null &&
     existing &&
     existing.mode === mode &&
     existing.summary !== null &&
@@ -890,13 +1069,14 @@ async function doHydrateFromCache(
   }
 
   try {
-    const res = await fetch(
-      `${API_BASE_URL}/api/reviews/${prId}/walkthrough/current?mode=${mode}`,
-      {
-        headers: authHeaders(),
-        credentials: "include",
-      },
-    );
+    const endpoint =
+      reportId === null
+        ? `${API_BASE_URL}/api/reviews/${prId}/walkthrough/current?mode=${mode}`
+        : `${API_BASE_URL}/api/reviews/${prId}/walkthrough/report/${reportId}?mode=${mode}`;
+    const res = await fetch(endpoint, {
+      headers: authHeaders(),
+      credentials: "include",
+    });
     if (!res.ok) {
       wtTrace("lifecycle", `hydrateFromCache prId=${prId} httpStatus=${res.status} → false`);
       return false;
@@ -933,10 +1113,12 @@ async function doHydrateFromCache(
     const body = (await res.json()) as
       | { status: "not_found" }
       | {
-          status: "complete" | "generating" | "error";
+          status: "complete" | "generating" | "error" | "superseded";
           walkthrough: WalkthroughPayload;
           snapshotAt: string;
           seqAt?: number;
+          stale?: boolean;
+          historical?: boolean;
         };
 
     if (body.status === "not_found") {
@@ -953,7 +1135,7 @@ async function doHydrateFromCache(
       `hydrateFromCache prId=${prId} status=${status} blocks=${wt.blocks.length} issues=${wt.issues.length} ratings=${wt.ratings.length} semanticSteps=${wt.semanticSteps?.length ?? 0} hasSentiment=${wt.sentiment !== null && wt.sentiment !== undefined}`,
     );
 
-    const previous = store.entries.get(prId);
+    const previous = options?.replace ? undefined : store.entries.get(prId);
     // Clone (don't reuse `previous`): `setEntry` writes into a SvelteMap, whose
     // `set` only fires reactivity when the stored *reference* changes
     // (`prev_res !== value`). Mutating `previous` in place and re-setting the
@@ -1006,9 +1188,12 @@ async function doHydrateFromCache(
     entry.isStreaming = isGenerating;
     entry.tokenUsage = coerceTokenUsage(wt.tokenUsage);
     entry.streamError = isError
-      ? "Walkthrough generation failed. Resume or regenerate to retry."
+      ? body.historical === true
+        ? null
+        : "Walkthrough generation failed. Resume or regenerate to retry."
       : null;
-    entry.superseded = false;
+    entry.superseded = body.stale === true;
+    entry.historical = body.historical === true;
     entry.phase = isGenerating ? "writing" : "finishing";
     entry.phaseMessage = isGenerating ? "Resuming walkthrough…" : "Complete";
     entry.liveGeneration = isGenerating;
@@ -1017,6 +1202,7 @@ async function doHydrateFromCache(
     if (previous?.source === "remote") entry.source = "remote";
     if (isGenerating) entry.streamStartedAt = Date.now();
     setEntry(prId, entry);
+    store.selectedReportIds.set(prId, body.historical === true ? wt.id : null);
 
     // Math.max so SSE can't regress the cursor below what it already advanced
     // past during the fetch window.
@@ -1132,12 +1318,13 @@ export async function pollCloneUntilResolved(
 export async function startWalkthrough(
   prId: string,
   mode: WalkthroughMode = getSelectedMode(prId),
+  generationMode: "full" | "incremental" = "full",
 ): Promise<Response | null> {
   try {
     return await fetch(`${API_BASE_URL}/api/reviews/${prId}/walkthrough/start`, {
       method: "POST",
       headers: { ...authHeaders(), "Content-Type": "application/json" },
-      body: JSON.stringify({ mode }),
+      body: JSON.stringify({ mode, generationMode }),
     });
   } catch (e) {
     wtTrace(
@@ -1167,6 +1354,8 @@ export async function generateWalkthrough(
   const seed = freshEntry();
   seed.mode = mode;
   seed.phaseMessage = "Starting walkthrough…";
+  seed.historical = false;
+  store.selectedReportIds.set(prId, null);
   setEntry(prId, seed);
   store.activePrId = prId;
 
@@ -1224,24 +1413,28 @@ export function abort(prId: string): void {
 export async function regenerate(
   prId: string,
   mode: WalkthroughMode = getSelectedMode(prId),
+  generationMode: "full" | "incremental" = "incremental",
 ): Promise<void> {
   if (pendingActions.map.has(prId)) return;
   setPending(prId, "regenerate");
   try {
     clearAnimationTrackers(prId);
     deleteEntry(prId);
+    store.selectedReportIds.set(prId, null);
     store.activePrId = prId;
 
     const entry = freshEntry();
     entry.mode = mode;
-    entry.phaseMessage = "Regenerating...";
+    entry.historical = false;
+    entry.phaseMessage =
+      generationMode === "incremental" ? "Reviewing new commits..." : "Regenerating...";
     setEntry(prId, entry);
 
     try {
       await fetch(`${API_BASE_URL}/api/reviews/${prId}/walkthrough/regenerate`, {
         method: "POST",
         headers: { ...authHeaders(), "Content-Type": "application/json" },
-        body: JSON.stringify({ mode }),
+        body: JSON.stringify({ mode, generationMode }),
       });
     } catch {
       // Non-fatal — the start call below will still create a fresh job.
@@ -1252,10 +1445,14 @@ export async function regenerate(
     // entry, so dropping it here would only cause `_active` to flip to
     // undefined and flash the "Generate walkthrough" pill between the
     // regenerate and start round-trips.
-    await startWalkthrough(prId, mode);
+    await startWalkthrough(prId, mode, generationMode);
   } finally {
     clearPending(prId);
   }
+}
+
+export function regenerateFromScratch(prId: string): Promise<void> {
+  return regenerate(prId, getSelectedMode(prId), "full");
 }
 
 export async function resume(
@@ -1274,9 +1471,20 @@ export async function resume(
         headers: { ...authHeaders(), "Content-Type": "application/json" },
         body: JSON.stringify({ mode }),
       });
-      if (!res.ok) return;
-    } catch {
-      // best-effort
+      if (!res.ok) {
+        updateEntry(prId, (e) => {
+          e.streamError =
+            res.status === 404
+              ? "No resumable walkthrough was found. Review new commits or regenerate instead."
+              : `Failed to resume walkthrough (HTTP ${res.status}).`;
+        });
+      }
+    } catch (err) {
+      updateEntry(prId, (e) => {
+        e.streamError = `Failed to resume walkthrough: ${
+          err instanceof Error ? err.message : String(err)
+        }`;
+      });
     }
   } finally {
     clearPending(prId);
@@ -1291,7 +1499,12 @@ export async function resume(
  */
 export async function invalidateForPull(prId: string): Promise<void> {
   clearAnimationTrackers(prId);
-  deleteEntry(prId);
+  updateEntry(prId, (entry) => {
+    entry.superseded = true;
+    entry.isStreaming = false;
+    entry.liveGeneration = false;
+    entry.streamError = null;
+  });
   try {
     await fetch(`${API_BASE_URL}/api/reviews/${prId}/walkthrough/regenerate`, {
       method: "POST",

--- a/apps/web/src/lib/stores/walkthrough.svelte.ts
+++ b/apps/web/src/lib/stores/walkthrough.svelte.ts
@@ -1500,9 +1500,30 @@ export async function resume(
 ): Promise<void> {
   if (pendingActions.map.has(prId)) return;
   setPending(prId, "resume");
+  store.selectedReportIds.set(prId, null);
+  store.activePrId = prId;
+  if (!store.entries.has(prId)) {
+    const seed = freshEntry();
+    seed.mode = mode;
+    seed.historical = false;
+    seed.liveGeneration = true;
+    seed.phaseMessage = "Resuming walkthrough...";
+    setEntry(prId, seed);
+  }
   try {
     updateEntry(prId, (e) => {
+      e.mode = mode;
+      e.isStreaming = true;
+      e.doneReceived = false;
       e.streamError = null;
+      e.superseded = false;
+      e.historical = false;
+      e.liveGeneration = true;
+      e.cloneInProgress = false;
+      e.cloneRepoId = null;
+      e.phase = "connecting";
+      e.phaseMessage = "Resuming walkthrough...";
+      e.streamStartedAt = Date.now();
     });
     try {
       const res = await fetch(`${API_BASE_URL}/api/reviews/${prId}/walkthrough/resume`, {
@@ -1512,14 +1533,26 @@ export async function resume(
       });
       if (!res.ok) {
         updateEntry(prId, (e) => {
+          e.isStreaming = false;
+          e.liveGeneration = false;
           e.streamError =
             res.status === 404
               ? "No resumable walkthrough was found. Review new commits or regenerate instead."
               : `Failed to resume walkthrough (HTTP ${res.status}).`;
         });
+        return;
+      }
+
+      const started = (await res.json().catch(() => null)) as { walkthroughId?: string } | null;
+      if (started?.walkthroughId) {
+        updateEntry(prId, (e) => {
+          e.walkthroughId = started.walkthroughId ?? e.walkthroughId;
+        });
       }
     } catch (err) {
       updateEntry(prId, (e) => {
+        e.isStreaming = false;
+        e.liveGeneration = false;
         e.streamError = `Failed to resume walkthrough: ${
           err instanceof Error ? err.message : String(err)
         }`;

--- a/apps/web/src/routes/review/[prId]/+page.svelte
+++ b/apps/web/src/routes/review/[prId]/+page.svelte
@@ -139,12 +139,16 @@ let lastLoadedMode: ReviewMode | null = null;
 let lastLoadedAt = 0;
 const PR_REFETCH_WINDOW_MS = 60_000;
 
-function apiErrorMessage(error: { value?: unknown }, fallback: string): string {
+function apiErrorMessage(
+  error: { status?: number; value?: unknown },
+  fallback = "Failed to fetch PR files",
+): string {
   const value = error.value;
   if (typeof value !== "object" || value === null) return fallback;
   const body = value as Record<string, unknown>;
   if (typeof body.error === "string" && body.error.length > 0) return body.error;
   if (typeof body.message === "string" && body.message.length > 0) return body.message;
+  if (typeof error.status === "number") return `${fallback} (HTTP ${error.status})`;
   return fallback;
 }
 

--- a/packages/shared/src/walkthrough.ts
+++ b/packages/shared/src/walkthrough.ts
@@ -247,6 +247,42 @@ export type WalkthroughPipelinePhase = "none" | "A" | "B" | "C" | "D";
 /** Job lifecycle status. `WalkthroughJobs.setStatus` is the only writer. */
 export type WalkthroughStatus = "generating" | "complete" | "error" | "superseded";
 
+/**
+ * How a walkthrough row was produced.
+ *
+ * `full` analyzes the current PR diff without using a prior walkthrough as
+ * input. `incremental` still produces the same report shape, but the agent is
+ * expected to use the linked prior walkthrough and the new commit range as its
+ * starting point.
+ */
+export type WalkthroughGenerationMode = "full" | "incremental";
+
+export interface WalkthroughReviewRound {
+  id: string;
+  walkthroughId: string;
+  previousWalkthroughId: string | null;
+  roundNumber: number;
+  kind: WalkthroughGenerationMode;
+  visibility: "visible" | "hidden";
+  status: WalkthroughStatus;
+  fromSha: string | null;
+  toSha: string;
+  createdAt: string;
+  completedAt: string | null;
+  summary: string | null;
+  focusTitle: string | null;
+  prHeadSha: string;
+}
+
+export interface WalkthroughReviewRoundsResponse {
+  prId: string;
+  currentHeadSha: string | null;
+  latestReviewedHeadSha: string | null;
+  hasNewCommits: boolean;
+  nextBaseHeadSha: string | null;
+  rounds: WalkthroughReviewRound[];
+}
+
 // ── Walkthrough (cached & replayed) ─────────────────────────────────────────
 
 export interface Walkthrough {
@@ -276,6 +312,9 @@ export interface Walkthrough {
   modelUsed: string;
   tokenUsage: WalkthroughTokenUsage;
   prHeadSha: string;
+  generationMode?: WalkthroughGenerationMode;
+  parentWalkthroughId?: string | null;
+  baseHeadSha?: string | null;
   /**
    * ISO 8601 timestamp of the most recent chat-driven edit, or null if the
    * walkthrough has only ever been produced by the generation pipeline. See
@@ -323,6 +362,37 @@ export interface WalkthroughState {
   walkthroughId: string;
   prHeadSha: string;
   mode: WalkthroughMode;
+  generationMode: WalkthroughGenerationMode;
+  parentWalkthroughId: string | null;
+  baseHeadSha: string | null;
+  priorReview: {
+    walkthroughId: string;
+    prHeadSha: string;
+    summary: string;
+    riskLevel: RiskLevel;
+    sentiment: string | null;
+    semanticSteps: Array<{
+      semanticStepIndex: number;
+      title: string;
+      summary: string | null;
+    }>;
+    issues: Array<{
+      id: string;
+      severity: WalkthroughIssue["severity"];
+      title: string;
+      description: string;
+      filePath: string | null;
+      startLine: number | null;
+      endLine: number | null;
+      submittedAt: string | null;
+    }>;
+    ratings: Array<{
+      axis: RatingAxis;
+      verdict: Verdict;
+      confidence: Confidence;
+      rationale: string;
+    }>;
+  } | null;
   status: WalkthroughStatus;
   lastCompletedPhase: WalkthroughPipelinePhase;
   summary: string | null;


### PR DESCRIPTION
## Summary

Adds incremental walkthrough review rounds so subsequent PR review passes can focus on commits since the previous completed report while preserving prior reports for history.

Key changes:
- add persisted review rounds and walkthrough generation metadata
- add full vs incremental walkthrough generation paths
- add previous-report selection in the walkthrough UI
- keep retry/resume from creating duplicate same-SHA visible reports
- derive compact report focus titles from commit ranges
- scope report history by review mode
- harden walkthrough generation against stale/local diff contamination
- improve GitHub review submission handling for pending reviews

## Why

Review workflows often have multiple rounds: an initial walkthrough, requested changes, and later commits that need a focused follow-up. Regenerating from scratch wastes work and can hide whether new commits actually addressed the previous comments.

## Validation

- `bun run typecheck && bun run lint && bun run knip && bun run build`

## Notes

The migration is `0280_review_rounds` and was rebased on the latest `main` before opening this PR.