### PR TITLE
fix(chat): resolve chat-push session by configured ACP agent id

### DIFF
--- a/apps/server/src/services/ChatChangesPush.ts
+++ b/apps/server/src/services/ChatChangesPush.ts
@@ -41,6 +41,7 @@
 //   - if not, `git merge --abort` so the worktree returns to a clean
 //     `pr-{N}` checkout and the user can decide what to do.
 
+import { ACP_AGENT_IDS } from "@revv/shared";
 import { Context, Data, Effect, Layer, Queue } from "effect";
 import { serverEnv } from "../config";
 import {
@@ -52,7 +53,7 @@ import {
 import { logError } from "../logger";
 import { AiService } from "./Ai";
 import { Broadcaster } from "./Broadcaster";
-import { ChatSessionService } from "./ChatSession";
+import { type ChatSessionRow, ChatSessionService } from "./ChatSession";
 import type { DbService } from "./Db";
 import type { GitHubEtagCache } from "./GitHubEtagCache";
 import {
@@ -295,12 +296,22 @@ export const ChatChangesPushServiceLive = Layer.effect(
           );
         }
 
-        // Find a chat session for the PR's current head SHA. Try both
-        // agent flavors — pick whichever one has commits.
-        const opencodeSession = yield* chatSessions.findLatestForPr(pr.id, "opencode");
-        const claudeSession = yield* chatSessions.findLatestForPr(pr.id, "claude");
-        const codexSession = yield* chatSessions.findLatestForPr(pr.id, "codex");
-        const session = opencodeSession ?? claudeSession ?? codexSession;
+        // Find a chat session for the PR. Prefer the currently-configured
+        // chat agent, then fall back to any other ACP agent that has a
+        // session for this PR (the user may have switched agents after the
+        // conversation was created). Scanning the full registry keeps this in
+        // step with `ACP_AGENT_IDS` instead of a hand-maintained agent list.
+        const settingsService = yield* SettingsService;
+        const configuredAgent = yield* settingsService.resolveChatAgentId();
+        const agentOrder = [
+          configuredAgent,
+          ...ACP_AGENT_IDS.filter((id) => id !== configuredAgent),
+        ];
+        let session: ChatSessionRow | null = null;
+        for (const agent of agentOrder) {
+          session = yield* chatSessions.findLatestForPr(pr.id, agent);
+          if (session) break;
+        }
         if (!session) {
           return yield* Effect.fail(new NoChatSessionError({ prId: params.prId }));
         }


### PR DESCRIPTION
The chat-push preflight in `ChatChangesPush` looked up the session under the legacy agent ids `claude`/`opencode`/`codex`, but after chat went ACP-only the default Claude agent's id became `claude-code`, so its sessions were never found and push failed with "No chat session found for this PR". This now resolves the configured chat agent via `resolveChatAgentId()` and falls back to scanning the full `ACP_AGENT_IDS` registry (covering an agent switch mid-conversation), keeping the lookup in step with the registry instead of a hand-maintained list. Fixes push for anyone on the default Claude Code agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)