### PR TITLE
fix(mcp): return 202 for notification-only HTTP MCP requests

### DIFF
--- a/apps/server/src/routes/mcp/utils.ts
+++ b/apps/server/src/routes/mcp/utils.ts
@@ -282,6 +282,17 @@ export function bindHttp<Ctx, Meta, Result extends McpToolResult>(
       debug(options.logScope, served);
     }
 
+    // All inbound messages were notifications/responses (no `id`), so there is
+    // nothing to reply with — e.g. the `notifications/initialized` handshake
+    // step. Per the MCP Streamable HTTP spec, return 202 Accepted with an empty
+    // body. Returning a bodyless 200 + `Content-Type: application/json` (the old
+    // behavior) makes strict clients try to JSON-parse an empty body and fail
+    // with "EOF while parsing a value at line 1 column 0" — this killed Codex's
+    // `rmcp` transport worker right after the initialized notification.
+    if (responses.length === 0) {
+      return new Response(null, { status: 202 });
+    }
+
     const payload = Array.isArray(body) ? responses : responses[0];
     return new Response(JSON.stringify(payload), {
       status: 200,


### PR DESCRIPTION
Codex's chat sessions died with `rmcp::transport::worker: worker quit with fatal: Deserialize error: EOF while parsing a value at line 1 column 0, when send initialized notification`, usually surfacing after a tool call. The shared HTTP MCP binder replied to notification-only input (e.g. the `notifications/initialized` handshake step) with a bodyless `200` plus a `Content-Type: application/json` header — because `JSON.stringify(undefined)` produces an empty body — and strict clients like Codex's `rmcp` transport try to JSON-parse that empty body, fail, and kill the worker so the next tool call breaks. This change returns a spec-compliant `202 Accepted` with an empty body when there are no responses to send. It fixes all three HTTP MCP transports (chat-context, walkthrough, recap) through the shared binder, and clients that tolerated the old response (Claude Code, opencode) are unaffected, preserving agent-path parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)