### PR TITLE
feat(onboarding): robust agent detection + generalized OS-aware install

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/ai/acp/acp-connection.ts
+++ b/apps/server/src/ai/acp/acp-connection.ts
@@ -32,6 +32,7 @@ import {
 } from "@agentclientprotocol/sdk";
 import type { AcpAgentId } from "@revv/shared";
 import { debug } from "../../logger";
+import { resolveUserPath } from "../providers/cli-agent";
 import { type AcpLaunchConfig, resolveAcpLaunchById } from "./presets";
 
 const IDLE_STOP_MS = 5 * 60 * 1000;
@@ -149,8 +150,10 @@ async function spawnConnection(
     stdout: "pipe",
     stderr: "pipe",
     // Per-adapter model/effort/context env (Claude Code) layered over the
-    // inherited environment.
-    env: { ...process.env, ...env },
+    // inherited environment. PATH is widened to the user's login-shell PATH so
+    // `npx`/`opencode` resolve even when the server inherited a sanitized PATH
+    // (launchd / GUI launch) — matching how availability is detected.
+    env: { ...process.env, ...env, PATH: resolveUserPath() },
   });
 
   // Bun's `proc.stdin` is a FileSink; wrap it as a WritableStream<Uint8Array>

--- a/apps/server/src/ai/acp/presets.ts
+++ b/apps/server/src/ai/acp/presets.ts
@@ -8,7 +8,6 @@
 // model protocol — per-adapter injection of the selected model / thinking-effort
 // / context-window at launch time (args for Codex/opencode, env for Claude Code).
 
-import { execSync } from "node:child_process";
 import {
   type AcpAgentId,
   type ContextWindow,
@@ -18,6 +17,7 @@ import {
   type ThinkingEffort,
 } from "@revv/shared";
 import { serverEnv } from "../../config";
+import { isCommandOnPath } from "../providers/cli-agent";
 
 export interface AcpLaunch {
   readonly command: string;
@@ -146,14 +146,12 @@ export function resolveGenerationModel(
 
 /**
  * Best-effort availability check for a registry agent's command. `npx`/`bunx`
- * are treated as always available; any other command is probed with `which`.
+ * are treated as always available; any other command is probed against the
+ * user's login-shell PATH (see `isCommandOnPath`), so a server launched with a
+ * sanitized PATH still finds shell-managed installs.
  */
 export function isAcpAgentAvailable(id: AcpAgentId): boolean {
   const { command } = resolveAcpLaunchById(id);
   if (command === "npx" || command === "bunx") return true;
-  try {
-    return execSync(`which ${command}`, { encoding: "utf-8", timeout: 3000 }).trim().length > 0;
-  } catch {
-    return false;
-  }
+  return isCommandOnPath(command);
 }

--- a/apps/server/src/ai/providers/cli-agent.ts
+++ b/apps/server/src/ai/providers/cli-agent.ts
@@ -1,8 +1,14 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
-import { type AcpAgentId, getAgentCapabilities } from "@revv/shared";
+import {
+  ACP_AGENT_IDS,
+  type AcpAgentId,
+  type AgentStatus,
+  type AgentStatusReport,
+  getAgentCapabilities,
+} from "@revv/shared";
 import { serverEnv } from "../../config";
 import { CLI_CACHE_TTL_MS } from "../../constants";
 
@@ -69,7 +75,9 @@ function loginShellPath(): string | null {
   const inner = isFish ? "string join : $PATH" : 'printf %s "$PATH"';
   try {
     // `-lic`: login + interactive so PATH set in either profile or rc is sourced.
-    const out = execSync(`${shell} -lic '${inner}'`, {
+    // `execFileSync` (argv form) — never interpolate `$SHELL` into a shell string;
+    // a `$SHELL` with spaces or metacharacters would otherwise mis-parse.
+    const out = execFileSync(shell, ["-lic", inner], {
       encoding: "utf-8",
       timeout: 4000,
       stdio: ["ignore", "pipe", "ignore"],
@@ -114,7 +122,7 @@ function claudeLoggedIn(): boolean {
   if (platform() === "darwin") {
     try {
       // Existence probe only (no `-w`): returns attributes, doesn't print the secret.
-      execSync('security find-generic-password -s "Claude Code-credentials"', {
+      execFileSync("security", ["find-generic-password", "-s", "Claude Code-credentials"], {
         timeout: 3000,
         stdio: "ignore",
       });
@@ -127,12 +135,58 @@ function claudeLoggedIn(): boolean {
 }
 
 /**
+ * Whether the user has logged in to Cursor's CLI. `cursor-agent` persists its
+ * session token after `cursor-agent login`; an env-injected `CURSOR_API_KEY`
+ * also counts. The on-disk location isn't part of Cursor's public contract, so
+ * we probe the credential files seen across versions/platforms — XDG
+ * (`~/.config/cursor-agent`, `~/.local/share/cursor-agent`) and the legacy
+ * `~/.cursor` dir.
+ *
+ * NOTE: re-verify these paths against a real `cursor-agent` install — if Cursor
+ * moves its credential file, only this allowlist needs updating. A miss here is
+ * conservative (UI shows "Sign in" for an already-authed Cursor), never unsafe.
+ */
+function cursorLoggedIn(): boolean {
+  if (process.env.CURSOR_API_KEY?.trim()) return true;
+  const home = homedir();
+  const candidates = [
+    join(home, ".config", "cursor-agent", "credentials.json"),
+    join(home, ".config", "cursor-agent", "auth.json"),
+    join(home, ".local", "share", "cursor-agent", "credentials.json"),
+    join(home, ".local", "share", "cursor-agent", "auth.json"),
+    join(home, ".cursor", "credentials.json"),
+    join(home, ".cursor", "auth.json"),
+  ];
+  return candidates.some((p) => existsSync(p));
+}
+
+/**
+ * Whether the given registry agent is *authenticated* (logged in), independent
+ * of whether its CLI is on PATH. Onboarding uses this to distinguish
+ * installed-but-not-logged-in (show "Sign in") from ready-to-use (show
+ * "Continue"). opencode needs no login — it's a local engine — so it always
+ * reports authed.
+ */
+export function detectAgentAuth(agent: AcpAgentId): boolean {
+  switch (agent) {
+    case "opencode":
+      return true;
+    case "claude-code":
+      return claudeLoggedIn();
+    case "codex":
+      return codexLoggedIn();
+    case "cursor":
+      return cursorLoggedIn();
+  }
+}
+
+/**
  * Absolute path of `command` if found on the user's login-shell PATH, else null.
  */
 function resolveCommandPath(command: string): string | null {
   const isWin = platform() === "win32";
   try {
-    const out = execSync(`${isWin ? "where" : "which"} ${command}`, {
+    const out = execFileSync(isWin ? "where" : "which", [command], {
       encoding: "utf-8",
       timeout: 3000,
       env: { ...process.env, PATH: resolveUserPath() },
@@ -184,6 +238,82 @@ export function checkCliAvailability(agent: CliAgent): boolean {
  */
 export function invalidateCliAgentCache(): void {
   cachedPath = null;
+}
+
+// ── Onboarding agent status ────────────────────────────────────────────────────
+//
+// The single detection surface the onboarding agent step consumes — both
+// "installed?" and "logged in?" for every registry agent, plus the per-agent
+// login command and whether this host can drive an embedded PTY login. Keeping
+// it here (the canonical CLI-detection module) means the UI hits one endpoint
+// and the install/login services don't each own half of the detection logic.
+
+/**
+ * Registry id → the CLI binary whose presence means the agent is set up
+ * locally. The SDK/auth-store agents (claude, codex) honor their `REVV_*_BIN`
+ * pins via `checkCliAvailability`; Cursor's `cursor-agent` has no pin, so it's a
+ * bare PATH probe. Adding a registry agent surfaces a type error here until its
+ * detection is wired — a deliberate compile-time nudge.
+ */
+export const ACP_CLI_NAME: Record<AcpAgentId, "opencode" | "claude" | "codex" | "cursor-agent"> = {
+  "claude-code": "claude",
+  opencode: "opencode",
+  codex: "codex",
+  cursor: "cursor-agent",
+};
+
+/**
+ * Per-agent interactive login command. `null` means the agent needs no login
+ * (opencode is a local engine). Mirrors the `Record<AcpAgentId, …>` shape used
+ * across the registry so adding an ACP agent forces a decision here.
+ *
+ * Each is a dedicated, exit-after-auth login subcommand (verified against the
+ * vendors' published CLI docs + the installed binaries' `--help`), so the
+ * login flow's "spawn → wait for exit → re-check auth" model holds:
+ *   - claude-code: `claude auth login`  (`/login` is the in-REPL slash command,
+ *     NOT a CLI subcommand).
+ *   - codex:       `codex login`.
+ *   - cursor:      `cursor-agent login` (the docs alias the binary as `agent`,
+ *     but the installed binary — and our `ACP_CLI_NAME.cursor` key — is
+ *     `cursor-agent`).
+ * Each CLI opens the user's browser itself; the login UI's auth-url scan only
+ * powers a fallback link. Surfaced in {@link AgentStatus.loginCommand} as the
+ * manual hint where the embedded PTY login isn't available (Windows).
+ */
+export const ACP_LOGIN_COMMAND: Record<AcpAgentId, readonly string[] | null> = {
+  opencode: null,
+  "claude-code": ["claude", "auth", "login"],
+  codex: ["codex", "login"],
+  cursor: ["cursor-agent", "login"],
+};
+
+/** Whether the given registry agent's CLI is present (or otherwise usable). */
+export function detectAgentCli(agent: AcpAgentId): boolean {
+  const cli = ACP_CLI_NAME[agent];
+  return cli === "cursor-agent" ? isCommandOnPath(cli) : checkCliAvailability(cli);
+}
+
+/**
+ * One-shot onboarding detection snapshot for every registry agent: installed +
+ * authed + the manual login command, plus whether this host supports the
+ * embedded PTY login (POSIX-only). The single source of truth the agent step's
+ * adaptive CTA reads.
+ */
+export function detectAgentStatus(): AgentStatusReport {
+  const agents = Object.fromEntries(
+    ACP_AGENT_IDS.map((id) => {
+      const cmd = ACP_LOGIN_COMMAND[id];
+      return [
+        id,
+        {
+          installed: detectAgentCli(id),
+          authed: detectAgentAuth(id),
+          loginCommand: cmd ? cmd.join(" ") : null,
+        } satisfies AgentStatus,
+      ];
+    }),
+  ) as Record<AcpAgentId, AgentStatus>;
+  return { embeddedLoginSupported: platform() !== "win32", agents };
 }
 
 // ── Dynamic model listing ─────────────────────────────────────────────────────

--- a/apps/server/src/ai/providers/cli-agent.ts
+++ b/apps/server/src/ai/providers/cli-agent.ts
@@ -1,5 +1,7 @@
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
 import { type AcpAgentId, getAgentCapabilities } from "@revv/shared";
 import { serverEnv } from "../../config";
 import { CLI_CACHE_TTL_MS } from "../../constants";
@@ -8,21 +10,75 @@ import { CLI_CACHE_TTL_MS } from "../../constants";
 //
 // Resolution chain, in order:
 //
-//   1. REVV_CLAUDE_BIN / REVV_OPENCODE_BIN — absolute paths baked into the
-//      LaunchAgent at install time by `write_launch_agent_plist` in
-//      scripts/lib/common.sh (which runs `command -v <tool>` with the
-//      installer's shell PATH). Survives restricted LaunchAgent PATH.
-//   2. `which <tool>` at runtime — covers `make dev` / dev shells where the
-//      env var isn't in play and PATH is rich.
+//   1. REVV_CLAUDE_BIN / REVV_OPENCODE_BIN / REVV_CODEX_BIN — absolute paths
+//      baked into the LaunchAgent at install time by `write_launch_agent_plist`
+//      in scripts/lib/common.sh (which runs `command -v <tool>` with the
+//      installer's shell PATH). Survives a restricted LaunchAgent PATH.
+//   2. Auth-only fallback for the npx-adapter agents whose adapter authenticates
+//      from a local store instead of shelling out to the named CLI:
+//        • Codex  — `@zed-industries/codex-acp` reads `~/.codex/auth.json`
+//          (honoring `CODEX_HOME`). CLI *or* Codex desktop app login counts.
+//        • Claude — `claude-agent-acp` runs on the Claude Agent SDK; an
+//          `ANTHROPIC_API_KEY`, `~/.claude/.credentials.json`, or the macOS
+//          Keychain login counts.
+//      opencode (own binary) and Cursor (`cursor-agent-acp` shells out to the
+//      `cursor-agent` CLI) are excluded — they genuinely need their binary.
+//   3. `which <tool>` resolved against the user's *login-shell* PATH — not the
+//      process PATH. A server launched by launchd / a GUI inherits a sanitized
+//      PATH that omits where CLIs actually live (nvm, Homebrew on Apple Silicon,
+//      npm global prefixes, app-managed bin dirs). Probing the login shell makes
+//      detection match what the user sees in a terminal. Falls back to the
+//      process PATH when there's no usable login shell (e.g. Windows).
 //
-// No hardcoded dir list: if neither source finds the binary, treat it as
-// not installed.
-//
-// Detection is cached per-agent with a short TTL (see CLI_CACHE_TTL_MS).
-
-let cachedCliAuth: { result: boolean; expiresAt: number; agent: string } | null = null;
+// The (expensive) login-shell PATH lookup is resolved once and cached with a
+// short TTL (see CLI_CACHE_TTL_MS); `which` against that PATH is a cheap
+// filesystem probe.
 
 type CliAgent = "opencode" | "claude" | "codex";
+
+let cachedPath: { value: string; expiresAt: number } | null = null;
+
+/**
+ * The directories the user's interactive login shell would search, merged onto
+ * the process PATH. This is the PATH detection and ACP launches should use —
+ * see the resolution-chain note above for why the inherited process PATH is not
+ * enough. Result is cached; `invalidateCliAgentCache` drops it.
+ */
+export function resolveUserPath(): string {
+  if (cachedPath && Date.now() < cachedPath.expiresAt) return cachedPath.value;
+  const base = process.env.PATH ?? "";
+  const login = loginShellPath();
+  const value = login
+    ? Array.from(new Set([...base.split(":"), ...login.split(":")].filter(Boolean))).join(":")
+    : base;
+  cachedPath = { value, expiresAt: Date.now() + CLI_CACHE_TTL_MS };
+  return value;
+}
+
+/**
+ * Ask the user's login shell for its PATH. Returns `null` on Windows, when no
+ * `$SHELL` is set, or if the probe fails — callers fall back to the process
+ * PATH. fish stores `$PATH` as a list, so it needs `string join`; POSIX shells
+ * (bash/zsh) get `printf`. `command -v` is intentionally avoided here so one
+ * probe yields the whole PATH rather than one binary.
+ */
+function loginShellPath(): string | null {
+  const shell = process.env.SHELL;
+  if (!shell || platform() === "win32") return null;
+  const isFish = /(^|\/)fish$/.test(shell);
+  const inner = isFish ? "string join : $PATH" : 'printf %s "$PATH"';
+  try {
+    // `-lic`: login + interactive so PATH set in either profile or rc is sourced.
+    const out = execSync(`${shell} -lic '${inner}'`, {
+      encoding: "utf-8",
+      timeout: 4000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
 
 function pinnedBin(agent: CliAgent): string {
   const pinned =
@@ -34,14 +90,68 @@ function pinnedBin(agent: CliAgent): string {
   return pinned && existsSync(pinned) ? pinned : "";
 }
 
+/** Codex's config/auth dir — `$CODEX_HOME`, else `~/.codex`. */
+function codexHome(): string {
+  const fromEnv = process.env.CODEX_HOME?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : join(homedir(), ".codex");
+}
+
+/** The user has logged in to Codex (via CLI or the desktop app) if its auth file exists. */
+function codexLoggedIn(): boolean {
+  return existsSync(join(codexHome(), "auth.json"));
+}
+
+/**
+ * Whether Claude Code is authenticated. The `claude-agent-acp` adapter runs on
+ * the Claude Agent SDK (not the `claude` binary), so a logged-in user is usable
+ * without the CLI on PATH. The SDK accepts, in order: an `ANTHROPIC_API_KEY`
+ * env var; the OAuth creds Claude Code writes to `~/.claude/.credentials.json`
+ * (Linux/other); or, on macOS, the same creds stored in the login Keychain.
+ */
+function claudeLoggedIn(): boolean {
+  if (process.env.ANTHROPIC_API_KEY?.trim()) return true;
+  if (existsSync(join(homedir(), ".claude", ".credentials.json"))) return true;
+  if (platform() === "darwin") {
+    try {
+      // Existence probe only (no `-w`): returns attributes, doesn't print the secret.
+      execSync('security find-generic-password -s "Claude Code-credentials"', {
+        timeout: 3000,
+        stdio: "ignore",
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Absolute path of `command` if found on the user's login-shell PATH, else null.
+ */
+function resolveCommandPath(command: string): string | null {
+  const isWin = platform() === "win32";
+  try {
+    const out = execSync(`${isWin ? "where" : "which"} ${command}`, {
+      encoding: "utf-8",
+      timeout: 3000,
+      env: { ...process.env, PATH: resolveUserPath() },
+    }).trim();
+    return out.length > 0 ? (out.split("\n")[0] ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
 function isCliAgentAvailable(agent: CliAgent): boolean {
   if (pinnedBin(agent)) return true;
-  try {
-    const result = execSync(`which ${agent}`, { encoding: "utf-8", timeout: 3000 });
-    return result.trim().length > 0;
-  } catch {
-    return false;
-  }
+  // Agents whose ACP adapter is npx-based and authenticates from a local store
+  // (rather than shelling out to the named CLI) are usable when logged in, even
+  // with no binary on PATH. opencode is intentionally excluded: it launches via
+  // its own `opencode` binary, so the binary is genuinely required.
+  if (agent === "codex" && codexLoggedIn()) return true;
+  if (agent === "claude" && claudeLoggedIn()) return true;
+  return resolveCommandPath(agent) !== null;
 }
 
 /**
@@ -50,40 +160,30 @@ function isCliAgentAvailable(agent: CliAgent): boolean {
  * directly as argv[0] of a spawn call.
  */
 export function resolveCliBin(agent: CliAgent): string {
-  return pinnedBin(agent) || agent;
+  return pinnedBin(agent) || resolveCommandPath(agent) || agent;
 }
 
 /**
- * Bare `which <command>` probe — no env-pin, no cache. Used by onboarding to
- * detect agent CLIs that have no `REVV_*_BIN` pin (e.g. Cursor's `cursor-agent`),
- * where the pinned/cached `checkCliAvailability` path doesn't apply.
+ * Whether `command` resolves on the user's login-shell PATH. Used by onboarding
+ * to detect agent CLIs that have no `REVV_*_BIN` pin (e.g. Cursor's
+ * `cursor-agent`), where the pinned `checkCliAvailability` path doesn't apply.
  */
 export function isCommandOnPath(command: string): boolean {
-  try {
-    return execSync(`which ${command}`, { encoding: "utf-8", timeout: 3000 }).trim().length > 0;
-  } catch {
-    return false;
-  }
+  return resolveCommandPath(command) !== null;
 }
 
 export function checkCliAvailability(agent: CliAgent): boolean {
-  if (cachedCliAuth && Date.now() < cachedCliAuth.expiresAt && cachedCliAuth.agent === agent) {
-    return cachedCliAuth.result;
-  }
-
-  const available = isCliAgentAvailable(agent);
-  cachedCliAuth = { result: available, expiresAt: Date.now() + CLI_CACHE_TTL_MS, agent };
-  return available;
+  return isCliAgentAvailable(agent);
 }
 
 /**
- * Drop the cached availability result so the next `checkCliAvailability`
- * call hits the filesystem again. Called by the install-opencode flow
- * after a successful install — without this the TTL would mask the
- * newly-present binary until the cache naturally expired.
+ * Drop the cached login-shell PATH so the next availability check re-probes the
+ * shell and filesystem. Called by the onboarding install flow after a
+ * successful install — without this the TTL would mask the newly-present binary
+ * until the cache naturally expired.
  */
 export function invalidateCliAgentCache(): void {
-  cachedCliAuth = null;
+  cachedPath = null;
 }
 
 // ── Dynamic model listing ─────────────────────────────────────────────────────

--- a/apps/server/src/routes/onboarding.ts
+++ b/apps/server/src/routes/onboarding.ts
@@ -1,4 +1,4 @@
-import type { InstallEvent } from "@revv/shared";
+import { type InstallEvent, isAcpAgentId } from "@revv/shared";
 import { eq } from "drizzle-orm";
 import { Effect } from "effect";
 import { Elysia } from "elysia";
@@ -14,10 +14,10 @@ import { createSseStream, sseHeaders } from "./reviews/sse";
  *
  * - `/complete` and `/reset` are the gate flips for the `onboardedAt`
  *   column the SvelteKit `OnboardingGate` reads.
- * - `/agent-availability` / `/install-opencode` are the agent-step plumbing:
- *   detect which CLI agents are installed and (if neither is) run the
- *   official opencode installer with a streamed log so the user can see
- *   progress without leaving the onboarding wizard.
+ * - `/agent-availability` / `/install` are the agent-step plumbing: detect
+ *   which CLI agents are installed and run the selected agent's official
+ *   installer with a streamed log so the user can see progress without
+ *   leaving the onboarding wizard.
  */
 export const onboardingRoutes = new Elysia({ prefix: "/api/onboarding" })
   .use(withAuth)
@@ -65,7 +65,8 @@ export const onboardingRoutes = new Elysia({ prefix: "/api/onboarding" })
   /**
    * Snapshot of which CLI agents are present on PATH (or pinned via the
    * LaunchAgent env vars). Used by the agent-selection onboarding step to
-   * decide between the picker and the install-opencode prompt.
+   * tag each picker option installed/not-installed and key the adaptive
+   * Install/Continue CTA.
    */
   .get("/agent-availability", async (ctx) => {
     try {
@@ -77,13 +78,19 @@ export const onboardingRoutes = new Elysia({ prefix: "/api/onboarding" })
     }
   })
   /**
-   * Kick off (or join) the opencode install job. Idempotent at the
-   * process-lifetime level — concurrent requests get the same `jobId`.
+   * Kick off (or join) the install job for the selected registry agent.
+   * Idempotent per agent — concurrent requests for the same agent get the
+   * same `jobId`. Body: `{ agent: AcpAgentId }`.
    */
-  .post("/install-opencode", async (ctx) => {
+  .post("/install", async (ctx) => {
     try {
+      const agent = (ctx.body as { agent?: unknown } | undefined)?.agent;
+      if (typeof agent !== "string" || !isAcpAgentId(agent)) {
+        ctx.set.status = 400;
+        return { error: "Invalid or missing agent" };
+      }
       return await AppRuntime.runPromise(
-        Effect.flatMap(OnboardingService, (s) => s.startInstallOpencode()),
+        Effect.flatMap(OnboardingService, (s) => s.startInstall(agent)),
       );
     } catch (e) {
       return handleAppError(e, ctx);
@@ -94,7 +101,7 @@ export const onboardingRoutes = new Elysia({ prefix: "/api/onboarding" })
    * subscription point and then forwards live events until `done`. Closes
    * the stream after `done` (success or failure).
    */
-  .get("/install-opencode/stream", async (ctx) => {
+  .get("/install/stream", async (ctx) => {
     const jobId = ctx.query?.jobId;
     if (typeof jobId !== "string" || jobId.length === 0) {
       ctx.set.status = 400;

--- a/apps/server/src/routes/onboarding.ts
+++ b/apps/server/src/routes/onboarding.ts
@@ -1,23 +1,71 @@
-import { type InstallEvent, isAcpAgentId } from "@revv/shared";
+import { type InstallEvent, isAcpAgentId, type LoginEvent } from "@revv/shared";
 import { eq } from "drizzle-orm";
 import { Effect } from "effect";
 import { Elysia } from "elysia";
 import { db } from "../auth";
 import { user } from "../db/schema";
 import { AppRuntime } from "../runtime";
+import { AgentLoginService } from "../services/AgentLogin";
 import { OnboardingService } from "../services/Onboarding";
 import { handleAppError, withAuth } from "./middleware";
 import { createSseStream, sseHeaders } from "./reviews/sse";
+
+/**
+ * Stream a job's events over SSE. Validates `jobId`, opens an SSE stream,
+ * resolves the subscription (via the owning service), replays the captured
+ * buffer, and forwards live events until the terminal `{ type: 'done' }` — then
+ * closes the stream. Shared by the install and login streams, which differ only
+ * in their service and their "unknown job" error text.
+ */
+async function streamJobEvents<E extends { type: string }>(
+  ctx: { query: Record<string, string | undefined>; set: { status?: number | string } },
+  resolve: (
+    jobId: string,
+    send: (event: E) => void,
+  ) => Promise<{ found: boolean; unsubscribe: () => void }>,
+  notFoundEvent: E,
+): Promise<Response | { error: string }> {
+  const jobId = ctx.query?.jobId;
+  if (typeof jobId !== "string" || jobId.length === 0) {
+    ctx.set.status = 400;
+    return { error: "Missing jobId" };
+  }
+
+  const { stream, writer, stopHeartbeat, onCancel } = createSseStream();
+  onCancel(() => stopHeartbeat());
+
+  const send = (event: E): void => {
+    writer.send(event);
+    if (event.type === "done") writer.sendDone();
+  };
+
+  try {
+    const sub = await resolve(jobId, send);
+    if (!sub.found) {
+      send(notFoundEvent);
+      return new Response(stream, { headers: sseHeaders });
+    }
+    onCancel(sub.unsubscribe);
+  } catch (err) {
+    // The shared terminal `done` shape across both event unions — `writer.send`
+    // takes `unknown`, so no generic cast is needed to close the stream.
+    const message = err instanceof Error ? err.message : "Subscription failed";
+    writer.send({ type: "done", success: false, error: message });
+    writer.sendDone();
+  }
+
+  return new Response(stream, { headers: sseHeaders });
+}
 
 /**
  * Onboarding routes.
  *
  * - `/complete` and `/reset` are the gate flips for the `onboardedAt`
  *   column the SvelteKit `OnboardingGate` reads.
- * - `/agent-availability` / `/install` are the agent-step plumbing: detect
- *   which CLI agents are installed and run the selected agent's official
- *   installer with a streamed log so the user can see progress without
- *   leaving the onboarding wizard.
+ * - `/agent-status` / `/install` / `/login` are the agent-step plumbing: detect
+ *   which CLI agents are set up, run the selected agent's official installer,
+ *   and drive its interactive login — each streaming progress over SSE so the
+ *   user never leaves the onboarding wizard.
  */
 export const onboardingRoutes = new Elysia({ prefix: "/api/onboarding" })
   .use(withAuth)
@@ -63,15 +111,15 @@ export const onboardingRoutes = new Elysia({ prefix: "/api/onboarding" })
     }
   })
   /**
-   * Snapshot of which CLI agents are present on PATH (or pinned via the
-   * LaunchAgent env vars). Used by the agent-selection onboarding step to
-   * tag each picker option installed/not-installed and key the adaptive
-   * Install/Continue CTA.
+   * Single detection snapshot the agent-selection step consumes: per-agent
+   * installed + authed + login command, plus whether this host supports the
+   * embedded PTY login. Drives the picker's installed/needs-sign-in tags and the
+   * adaptive Install / Sign-in / Continue CTA.
    */
-  .get("/agent-availability", async (ctx) => {
+  .get("/agent-status", async (ctx) => {
     try {
       return await AppRuntime.runPromise(
-        Effect.flatMap(OnboardingService, (s) => s.detectAgents()),
+        Effect.flatMap(OnboardingService, (s) => s.detectAgentStatus()),
       );
     } catch (e) {
       return handleAppError(e, ctx);
@@ -101,42 +149,82 @@ export const onboardingRoutes = new Elysia({ prefix: "/api/onboarding" })
    * subscription point and then forwards live events until `done`. Closes
    * the stream after `done` (success or failure).
    */
-  .get("/install/stream", async (ctx) => {
-    const jobId = ctx.query?.jobId;
-    if (typeof jobId !== "string" || jobId.length === 0) {
-      ctx.set.status = 400;
-      return { error: "Missing jobId" };
-    }
-
-    const { stream, writer, stopHeartbeat, onCancel } = createSseStream();
-    onCancel(() => stopHeartbeat());
-
-    const send = (event: InstallEvent): void => {
-      writer.send(event);
-      if (event.type === "done") writer.sendDone();
-    };
-
+  .get("/install/stream", (ctx) =>
+    streamJobEvents<InstallEvent>(
+      ctx,
+      (jobId, send) =>
+        AppRuntime.runPromise(Effect.flatMap(OnboardingService, (s) => s.subscribe(jobId, send))),
+      { type: "done", success: false, error: "Unknown install job" },
+    ),
+  )
+  /**
+   * Kick off (or join) the interactive login job for the selected agent — its
+   * official login command runs in a PTY whose output streams back over SSE.
+   * Idempotent per agent. Body: `{ agent: AcpAgentId }`.
+   */
+  .post("/login", async (ctx) => {
     try {
-      const sub = await AppRuntime.runPromise(
-        Effect.flatMap(OnboardingService, (s) => s.subscribe(jobId, send)),
-      );
-
-      if (!sub.found) {
-        writer.send({
-          type: "done",
-          success: false,
-          error: "Unknown install job",
-        } satisfies InstallEvent);
-        writer.sendDone();
-        return new Response(stream, { headers: sseHeaders });
+      const agent = (ctx.body as { agent?: unknown } | undefined)?.agent;
+      if (typeof agent !== "string" || !isAcpAgentId(agent)) {
+        ctx.set.status = 400;
+        return { error: "Invalid or missing agent" };
       }
-
-      onCancel(sub.unsubscribe);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Subscription failed";
-      writer.send({ type: "done", success: false, error: message } satisfies InstallEvent);
-      writer.sendDone();
+      return await AppRuntime.runPromise(
+        Effect.flatMap(AgentLoginService, (s) => s.startLogin(agent)),
+      );
+    } catch (e) {
+      return handleAppError(e, ctx);
     }
-
-    return new Response(stream, { headers: sseHeaders });
-  });
+  })
+  /**
+   * Forward a chunk of user keystrokes to the login job's PTY (e.g. a pasted
+   * auth code). Body: `{ jobId, data }`.
+   */
+  .post("/login/input", async (ctx) => {
+    try {
+      const body = ctx.body as { jobId?: unknown; data?: unknown } | undefined;
+      const jobId = body?.jobId;
+      const data = body?.data;
+      if (typeof jobId !== "string" || jobId.length === 0 || typeof data !== "string") {
+        ctx.set.status = 400;
+        return { error: "Missing jobId or data" };
+      }
+      return await AppRuntime.runPromise(
+        Effect.flatMap(AgentLoginService, (s) => s.writeInput(jobId, data)),
+      );
+    } catch (e) {
+      return handleAppError(e, ctx);
+    }
+  })
+  /**
+   * Tear down a login job's PTY when the user abandons sign-in (skip / unmount /
+   * navigate-away), so the spawned interactive CLI never orphans on the server.
+   * Idempotent. Body: `{ jobId }`.
+   */
+  .post("/login/cancel", async (ctx) => {
+    try {
+      const jobId = (ctx.body as { jobId?: unknown } | undefined)?.jobId;
+      if (typeof jobId !== "string" || jobId.length === 0) {
+        ctx.set.status = 400;
+        return { error: "Missing jobId" };
+      }
+      return await AppRuntime.runPromise(
+        Effect.flatMap(AgentLoginService, (s) => s.cancelLogin(jobId)),
+      );
+    } catch (e) {
+      return handleAppError(e, ctx);
+    }
+  })
+  /**
+   * SSE stream of `LoginEvent`s. Replays the terminal output captured up to the
+   * subscription point and then forwards live events until `done`. Closes the
+   * stream after `done` (success or failure).
+   */
+  .get("/login/stream", (ctx) =>
+    streamJobEvents<LoginEvent>(
+      ctx,
+      (jobId, send) =>
+        AppRuntime.runPromise(Effect.flatMap(AgentLoginService, (s) => s.subscribe(jobId, send))),
+      { type: "done", success: false, error: "Unknown login job" },
+    ),
+  );

--- a/apps/server/src/services/AgentLogin.ts
+++ b/apps/server/src/services/AgentLogin.ts
@@ -1,0 +1,222 @@
+import { platform } from "node:os";
+import type { AcpAgentId, LoginEvent } from "@revv/shared";
+import { Context, Effect, Layer } from "effect";
+import {
+  ACP_LOGIN_COMMAND,
+  detectAgentAuth,
+  invalidateCliAgentCache,
+  resolveUserPath,
+} from "../ai/providers/cli-agent";
+import { debug, logError } from "../logger";
+import { EventJobRegistry, type Job, type JobSubscription } from "./jobs/EventJobRegistry";
+
+// ── Agent login service ───────────────────────────────────────────────────────
+//
+// Drives an agent's interactive CLI login *inside Revv* rather than sending the
+// user out to a separate terminal. Each login runs the agent's official login
+// command (see `ACP_LOGIN_COMMAND` in cli-agent.ts) in a spawned
+// pseudo-terminal (PTY); the raw terminal bytes stream to the onboarding UI's
+// xterm instance over SSE, and the user's keystrokes flow back via `writeInput`.
+//
+// The pub/sub plumbing (per-agent idempotent job map, replay buffer,
+// late-subscriber replay, commit-then-broadcast) lives in the shared
+// `EventJobRegistry`. The only login-specific state is the PTY: a login is
+// interactive, so the subprocess handle rides on the job's `meta` so keystrokes
+// can be written to its terminal and the output scanned for the first auth URL.
+// `cancelLogin` tears that PTY down so an abandoned login never orphans a
+// long-lived interactive CLI on the server.
+//
+// State is intentionally ephemeral — a `kill -9` mid-login just means the user
+// re-runs the login from the picker, and the auth re-check on next boot reflects
+// whatever the CLI actually persisted to disk.
+
+/** Default PTY geometry. The web's xterm fits to its container and the size is
+ * cosmetic for these short login flows, so a sane fixed default is enough. */
+const PTY_COLS = 80;
+const PTY_ROWS = 24;
+
+/** Matches the first URL the login CLI prints, so the UI can open it. */
+const URL_RE = /https?:\/\/[^\s"'<>]+/;
+
+/** Login-specific job state carried on the registry job's `meta` slot. */
+interface LoginMeta {
+  /** Live subprocess so `writeInput` can forward keystrokes to its PTY. */
+  proc: ReturnType<typeof Bun.spawn> | null;
+  /** Accumulated stdout, scanned once for the first auth URL. */
+  urlScan: string;
+  /** True once an `auth-url` event has been emitted (emit at most once). */
+  authUrlSent: boolean;
+}
+
+type LoginJob = Job<LoginEvent, LoginMeta>;
+
+export class AgentLoginService extends Context.Tag("AgentLoginService")<
+  AgentLoginService,
+  {
+    /**
+     * Start the agent's interactive login in a PTY if no login for that agent is
+     * running, or return the id of the in-flight job. Idempotent per agent.
+     * Agents with no login command (opencode) get a job that immediately emits a
+     * successful `done`.
+     */
+    startLogin: (agent: AcpAgentId) => Effect.Effect<{ jobId: string }>;
+    /** Forward a chunk of user input to the login job's PTY. No-op if unknown/terminal. */
+    writeInput: (jobId: string, data: string) => Effect.Effect<{ ok: boolean }>;
+    /**
+     * Kill the login job's PTY and retire the job, so an abandoned login (skip /
+     * unmount / navigate-away) never leaves a long-lived interactive CLI running
+     * on the server. Idempotent and safe on unknown/already-finished jobs.
+     */
+    cancelLogin: (jobId: string) => Effect.Effect<{ ok: boolean }>;
+    /**
+     * Register a callback that receives every `LoginEvent` for the job: first the
+     * full replay buffer (fired synchronously before subscribe returns), then
+     * live events. If the job is already terminal the listener fires through the
+     * replay and is never registered for live events.
+     */
+    subscribe: (
+      jobId: string,
+      onEvent: (event: LoginEvent) => void,
+    ) => Effect.Effect<JobSubscription>;
+  }
+>() {}
+
+export const AgentLoginServiceLive = Layer.effect(
+  AgentLoginService,
+  Effect.gen(function* () {
+    const jobs = new EventJobRegistry<LoginEvent, LoginMeta>("agent-login");
+
+    const scanForAuthUrl = (
+      job: LoginJob,
+      chunk: string,
+      broadcast: (event: LoginEvent) => void,
+    ): void => {
+      if (job.meta.authUrlSent) return;
+      job.meta.urlScan += chunk;
+      const match = URL_RE.exec(job.meta.urlScan);
+      if (match) {
+        job.meta.authUrlSent = true;
+        broadcast({ type: "auth-url", url: match[0] });
+        // The scan buffer has served its purpose — drop it to bound memory.
+        job.meta.urlScan = "";
+      } else if (job.meta.urlScan.length > 64_000) {
+        // Bound the scan buffer if the CLI never prints a URL.
+        job.meta.urlScan = job.meta.urlScan.slice(-8_000);
+      }
+    };
+
+    const spawnLogin = (job: LoginJob, broadcast: (event: LoginEvent) => void): void => {
+      const argv = ACP_LOGIN_COMMAND[job.agentId];
+      if (!argv) {
+        // No login needed (opencode) — succeed immediately and idempotently.
+        broadcast({ type: "done", success: true });
+        return;
+      }
+
+      // PTY is POSIX-only; Windows degrades to a browser-handoff path the UI
+      // owns, so we don't attempt to spawn a terminal there.
+      if (platform() === "win32") {
+        broadcast({
+          type: "done",
+          success: false,
+          error:
+            "Embedded sign-in isn't supported on Windows yet — open the agent's CLI to log in.",
+        });
+        return;
+      }
+
+      debug("agent-login", `spawning login (${job.agentId}): ${argv.join(" ")}`);
+
+      const decoder = new TextDecoder();
+      let proc: ReturnType<typeof Bun.spawn>;
+      try {
+        proc = Bun.spawn([...argv], {
+          // Resolve against the user's login-shell PATH so a freshly-installed
+          // CLI (e.g. `cursor-agent`) is found without a server restart.
+          env: { ...process.env, PATH: resolveUserPath() },
+          terminal: {
+            cols: PTY_COLS,
+            rows: PTY_ROWS,
+            data: (_term, bytes) => {
+              const chunk = decoder.decode(bytes, { stream: true });
+              if (chunk.length > 0) {
+                broadcast({ type: "data", chunk });
+                scanForAuthUrl(job, chunk, broadcast);
+              }
+            },
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        broadcast({ type: "data", chunk: `\r\nFailed to start login: ${message}\r\n` });
+        broadcast({ type: "done", success: false, error: message });
+        return;
+      }
+      job.meta.proc = proc;
+
+      void (async () => {
+        const code = await proc.exited;
+        // The CLI just wrote credentials to disk — drop the cached PATH/auth
+        // probe so the re-check sees them.
+        invalidateCliAgentCache();
+        const success = detectAgentAuth(job.agentId);
+        if (success) {
+          broadcast({ type: "done", success: true });
+        } else {
+          const error =
+            code === 0
+              ? `Login finished but ${job.agentId} still isn't authenticated`
+              : `Login exited with code ${code}`;
+          broadcast({ type: "done", success: false, error });
+        }
+      })();
+    };
+
+    return {
+      startLogin: (agent) =>
+        Effect.sync(() =>
+          jobs.start(agent, () => ({ proc: null, urlScan: "", authUrlSent: false }), spawnLogin),
+        ),
+
+      writeInput: (jobId, data) =>
+        Effect.sync(() => {
+          const job = jobs.findById(jobId);
+          if (!job || job.done || !job.meta.proc) return { ok: false };
+          try {
+            job.meta.proc.terminal?.write(data);
+            return { ok: true };
+          } catch (err) {
+            logError(
+              "agent-login",
+              "write input failed:",
+              err instanceof Error ? err.message : String(err),
+            );
+            return { ok: false };
+          }
+        }),
+
+      cancelLogin: (jobId) =>
+        Effect.sync(() => {
+          const job = jobs.findById(jobId);
+          if (!job) return { ok: false };
+          // Kill the interactive CLI (best-effort) and retire the job so a
+          // re-opened sign-in for this agent spawns a fresh PTY rather than
+          // rejoining a wedged one. The lingering `proc.exited` handler then
+          // fires on a subscriber-less job — harmless.
+          try {
+            job.meta.proc?.kill();
+          } catch (err) {
+            logError(
+              "agent-login",
+              "kill login proc failed:",
+              err instanceof Error ? err.message : String(err),
+            );
+          }
+          jobs.delete(jobId);
+          return { ok: true };
+        }),
+
+      subscribe: (jobId, onEvent) => Effect.sync(() => jobs.subscribe(jobId, onEvent)),
+    };
+  }),
+);

--- a/apps/server/src/services/AppLayer.ts
+++ b/apps/server/src/services/AppLayer.ts
@@ -1,5 +1,6 @@
 import { Layer } from "effect";
 import { CacheStatsLive, InvalidationBusLive } from "../cache/index";
+import { AgentLoginServiceLive } from "./AgentLogin";
 import { AiServiceLive } from "./Ai";
 import { BroadcasterLive } from "./Broadcaster";
 import { GcsBlobStoreLive } from "./blob/GcsBlobStore";
@@ -81,6 +82,7 @@ const BaseLayers = Layer.mergeAll(
   FileContentServiceLive,
   CacheServiceLive,
   OnboardingServiceLive,
+  AgentLoginServiceLive,
   ChatSessionServiceWithDeps,
   ChatMcpTokensLive,
   // Unified cache layer (M1 Foundations) — InvalidationBus is live with zero

--- a/apps/server/src/services/Onboarding.ts
+++ b/apps/server/src/services/Onboarding.ts
@@ -1,38 +1,32 @@
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
-import {
-  ACP_AGENT_IDS,
-  type AcpAgentId,
-  type AgentAvailability,
-  type InstallEvent,
-} from "@revv/shared";
+import type { AcpAgentId, AgentStatusReport, InstallEvent } from "@revv/shared";
 import { Context, Effect, Layer } from "effect";
 import {
-  checkCliAvailability,
+  ACP_CLI_NAME,
+  detectAgentStatus,
   invalidateCliAgentCache,
   isCommandOnPath,
 } from "../ai/providers/cli-agent";
 import { debug, logError } from "../logger";
+import { EventJobRegistry, type Job, type JobSubscription } from "./jobs/EventJobRegistry";
 
 // ── Onboarding service ──────────────────────────────────────────────────────
 //
 // One-shot installer plumbing the agent step of onboarding uses to:
-//   1. Detect which registry agents' CLIs (opencode / claude / codex / cursor)
-//      are present on PATH.
+//   1. Detect which registry agents are set up — see `detectAgentStatus` in
+//      `cli-agent.ts`, the single detection surface (installed + authed).
 //   2. Run the official install script for whichever registry agent the user
 //      selects when it isn't already present.
 //
 // Each agent ships an official one-line installer (see `AGENT_INSTALL`). We
-// spawn it once per agent per server lifetime — a second `startInstall(agent)`
-// call for an in-flight agent returns the running job's id instead of
-// double-spawning. Installs for different agents run independently.
-//
-// Events are kept in a small in-memory log so a late SSE subscriber (e.g.
-// the client tab that started the install reconnects after a slow render)
-// can replay the full transcript and still react to `done` correctly. The
-// log is purely ephemeral — a kill -9 mid-install just means the user
-// sees the prompt again on next boot, which is the desired behavior.
+// spawn it once per agent per server lifetime via the shared
+// `EventJobRegistry` — a second `startInstall(agent)` call for an in-flight
+// agent rides the running job instead of double-spawning. Installs for
+// different agents run independently. The registry's ephemeral replay buffer
+// lets a late SSE subscriber replay the full transcript and still react to
+// `done`; a kill -9 mid-install just re-shows the prompt on next boot.
 
 /**
  * Per-agent install registry: the official one-line installer argv (POSIX vs
@@ -90,28 +84,6 @@ const AGENT_INSTALL: Record<
   },
 };
 
-// Registry id → the CLI binary whose presence means the agent is set up
-// locally. The legacy three honor their `REVV_*_BIN` pins via
-// `checkCliAvailability`; Cursor's `cursor-agent` has no pin, so it's a bare
-// PATH probe. Adding a registry agent surfaces a type error here until its
-// detection is wired — a deliberate compile-time nudge.
-const ACP_CLI_NAME: Record<AcpAgentId, "opencode" | "claude" | "codex" | "cursor-agent"> = {
-  "claude-code": "claude",
-  opencode: "opencode",
-  codex: "codex",
-  cursor: "cursor-agent",
-};
-
-function detectAgentCli(cli: (typeof ACP_CLI_NAME)[AcpAgentId]): boolean {
-  return cli === "cursor-agent" ? isCommandOnPath(cli) : checkCliAvailability(cli);
-}
-
-function detectAgentsSync(): AgentAvailability {
-  return Object.fromEntries(
-    ACP_AGENT_IDS.map((id) => [id, detectAgentCli(ACP_CLI_NAME[id])]),
-  ) as AgentAvailability;
-}
-
 /**
  * Prepend the directories the given agent's official installer writes to
  * (e.g. `~/.opencode/bin`, `~/.local/bin`) onto `process.env.PATH`, so the next
@@ -134,27 +106,15 @@ function augmentPathForInstall(binDirs: {
   }
 }
 
-interface InstallJob {
-  jobId: string;
-  agentId: AcpAgentId;
-  events: InstallEvent[];
-  done: boolean;
-  subscribers: Set<(event: InstallEvent) => void>;
-}
-
-/** Subscription handle returned by `subscribe`. */
-export interface InstallSubscription {
-  /** True when the job id matched and the subscriber is registered. */
-  found: boolean;
-  /** Drop the listener. Safe to call multiple times. */
-  unsubscribe: () => void;
-}
-
 export class OnboardingService extends Context.Tag("OnboardingService")<
   OnboardingService,
   {
-    /** Read PATH for opencode + claude. Cheap; cached per the cli-agent module's TTL. */
-    detectAgents: () => Effect.Effect<AgentAvailability>;
+    /**
+     * One-shot detection snapshot for the agent step — installed + authed +
+     * login command per registry agent, plus whether this host supports the
+     * embedded PTY login. Cheap; cached per the cli-agent module's TTL.
+     */
+    detectAgentStatus: () => Effect.Effect<AgentStatusReport>;
     /**
      * Start the given agent's official install script if no job for that agent
      * is running, or return the id of the in-flight job. Idempotent per agent —
@@ -172,43 +132,17 @@ export class OnboardingService extends Context.Tag("OnboardingService")<
     subscribe: (
       jobId: string,
       onEvent: (event: InstallEvent) => void,
-    ) => Effect.Effect<InstallSubscription>;
+    ) => Effect.Effect<JobSubscription>;
   }
 >() {}
 
 export const OnboardingServiceLive = Layer.effect(
   OnboardingService,
   Effect.gen(function* () {
-    // Per-agent job state: each agent's install is process-lifetime idempotent.
-    // Holding this in a closure Map (not a Ref) is intentional — it's read and
-    // written only from the service's own handlers, and ref-style serialization
-    // buys us nothing here.
-    const currentJobs = new Map<AcpAgentId, InstallJob>();
-
-    const broadcast = (job: InstallJob, event: InstallEvent): void => {
-      job.events.push(event);
-      // Iterate over a snapshot — listeners may unsubscribe themselves
-      // synchronously when they see `done`, mutating the underlying set.
-      const snapshot = Array.from(job.subscribers);
-      for (const sub of snapshot) {
-        try {
-          sub(event);
-        } catch (err) {
-          logError(
-            "onboarding-install",
-            "subscriber threw:",
-            err instanceof Error ? err.message : String(err),
-          );
-        }
-      }
-      if (event.type === "done") {
-        job.done = true;
-        job.subscribers.clear();
-      }
-    };
+    const jobs = new EventJobRegistry<InstallEvent, Record<string, never>>("onboarding-install");
 
     const drainStream = async (
-      job: InstallJob,
+      broadcast: (event: InstallEvent) => void,
       // Bun.spawn's `.stdout` is typed as `number | ReadableStream<Uint8Array>
       // | undefined` because callers can request a file-descriptor instead.
       // We always pipe, so a narrowing guard is enough to satisfy the type.
@@ -227,11 +161,11 @@ export const OnboardingServiceLive = Layer.effect(
           while (nl >= 0) {
             const line = buffer.slice(0, nl).replace(/\r$/, "");
             buffer = buffer.slice(nl + 1);
-            if (line.length > 0) broadcast(job, { type: "log", line });
+            if (line.length > 0) broadcast({ type: "log", line });
             nl = buffer.indexOf("\n");
           }
         }
-        if (buffer.length > 0) broadcast(job, { type: "log", line: buffer });
+        if (buffer.length > 0) broadcast({ type: "log", line: buffer });
       } catch (err) {
         logError(
           "onboarding-install",
@@ -247,7 +181,10 @@ export const OnboardingServiceLive = Layer.effect(
       }
     };
 
-    const spawnInstall = (job: InstallJob): void => {
+    const spawnInstall = (
+      job: Job<InstallEvent, Record<string, never>>,
+      broadcast: (event: InstallEvent) => void,
+    ): void => {
       const isWindows = platform() === "win32";
       const spec = AGENT_INSTALL[job.agentId];
       // Pipe the agent's official installer into the matching shell. On
@@ -256,7 +193,7 @@ export const OnboardingServiceLive = Layer.effect(
       const argv = [...(isWindows ? spec.windows : spec.unix)];
 
       debug("onboarding-install", `spawning installer (${job.agentId}): ${argv.join(" ")}`);
-      broadcast(job, { type: "log", line: `> ${argv.join(" ")}` });
+      broadcast({ type: "log", line: `> ${argv.join(" ")}` });
 
       let proc: ReturnType<typeof Bun.spawn>;
       try {
@@ -266,84 +203,44 @@ export const OnboardingServiceLive = Layer.effect(
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        broadcast(job, { type: "log", line: `Failed to start installer: ${message}` });
-        broadcast(job, { type: "done", success: false, error: message });
+        broadcast({ type: "log", line: `Failed to start installer: ${message}` });
+        broadcast({ type: "done", success: false, error: message });
         return;
       }
 
       void (async () => {
-        await Promise.all([drainStream(job, proc.stdout), drainStream(job, proc.stderr)]);
+        await Promise.all([
+          drainStream(broadcast, proc.stdout),
+          drainStream(broadcast, proc.stderr),
+        ]);
         const code = await proc.exited;
         augmentPathForInstall(spec.binDirs);
         invalidateCliAgentCache();
-        const installed = detectAgentCli(ACP_CLI_NAME[job.agentId]);
-        const success = code === 0 && installed;
+        // Confirm the install with a strict PATH probe — NOT the auth-inclusive
+        // availability check. An already-authed agent (e.g. Claude creds in the
+        // Keychain) would make that check pass even if the installer exited 0
+        // without placing the binary, falsely reporting success.
+        const cli = ACP_CLI_NAME[job.agentId];
+        const onPath = isCommandOnPath(cli);
+        const success = code === 0 && onPath;
         if (success) {
-          broadcast(job, { type: "done", success: true });
+          broadcast({ type: "done", success: true });
         } else {
           const error =
             code !== 0
               ? `Installer exited with code ${code}`
-              : `Installer finished but ${ACP_CLI_NAME[job.agentId]} is still not on PATH`;
-          broadcast(job, { type: "done", success: false, error });
+              : `Installer finished but ${cli} is still not on PATH`;
+          broadcast({ type: "done", success: false, error });
         }
       })();
     };
 
     return {
-      detectAgents: () => Effect.sync(detectAgentsSync),
+      detectAgentStatus: () => Effect.sync(detectAgentStatus),
 
-      startInstall: (agent) =>
-        Effect.sync(() => {
-          const running = currentJobs.get(agent);
-          if (running && !running.done) {
-            return { jobId: running.jobId };
-          }
-          const job: InstallJob = {
-            jobId: crypto.randomUUID(),
-            agentId: agent,
-            events: [],
-            done: false,
-            subscribers: new Set(),
-          };
-          currentJobs.set(agent, job);
-          spawnInstall(job);
-          return { jobId: job.jobId };
-        }),
+      startInstall: (agent) => Effect.sync(() => jobs.start(agent, () => ({}), spawnInstall)),
 
-      subscribe: (jobId, onEvent) =>
-        Effect.sync(() => {
-          // Resolve the job by id across all per-agent slots.
-          const job = Array.from(currentJobs.values()).find((j) => j.jobId === jobId);
-          if (!job) {
-            return {
-              found: false,
-              unsubscribe: () => {
-                /* no-op */
-              },
-            };
-          }
-          // Drain the replay synchronously so no `broadcast` can interleave
-          // between snapshot and registration — the event loop can't run
-          // an async install-stdout callback while this loop is hot. Once
-          // registered below, future broadcasts arrive in strict order.
-          for (const event of job.events) onEvent(event);
-          if (job.done) {
-            return {
-              found: true,
-              unsubscribe: () => {
-                /* no-op — job already terminal */
-              },
-            };
-          }
-          job.subscribers.add(onEvent);
-          return {
-            found: true,
-            unsubscribe: () => {
-              job.subscribers.delete(onEvent);
-            },
-          };
-        }),
+      subscribe: (jobId, onEvent) => Effect.sync(() => jobs.subscribe(jobId, onEvent)),
     };
   }),
 );

--- a/apps/server/src/services/Onboarding.ts
+++ b/apps/server/src/services/Onboarding.ts
@@ -20,12 +20,13 @@ import { debug, logError } from "../logger";
 // One-shot installer plumbing the agent step of onboarding uses to:
 //   1. Detect which registry agents' CLIs (opencode / claude / codex / cursor)
 //      are present on PATH.
-//   2. Run the official opencode install script when none is detected.
+//   2. Run the official install script for whichever registry agent the user
+//      selects when it isn't already present.
 //
-// The install script lives upstream (https://opencode.ai/install for
-// macOS/Linux, https://opencode.ai/install.ps1 for Windows). We spawn it
-// once per server lifetime — a second `startInstall()` call returns the
-// running job's id instead of double-spawning.
+// Each agent ships an official one-line installer (see `AGENT_INSTALL`). We
+// spawn it once per agent per server lifetime — a second `startInstall(agent)`
+// call for an in-flight agent returns the running job's id instead of
+// double-spawning. Installs for different agents run independently.
 //
 // Events are kept in a small in-memory log so a late SSE subscriber (e.g.
 // the client tab that started the install reconnects after a slow render)
@@ -33,8 +34,61 @@ import { debug, logError } from "../logger";
 // log is purely ephemeral — a kill -9 mid-install just means the user
 // sees the prompt again on next boot, which is the desired behavior.
 
-const INSTALL_BIN_DIRS_UNIX = [".opencode/bin", ".local/bin"] as const;
-const INSTALL_BIN_DIRS_WINDOWS = [".opencode/bin"] as const;
+/**
+ * Per-agent install registry: the official one-line installer argv (POSIX vs
+ * Windows) plus the home-relative bin dirs that installer writes to, which we
+ * prepend to `PATH` so the freshly-installed binary is found without waiting
+ * for a shell re-source or server restart.
+ *
+ * Mirrors the `Record<AcpAgentId, …>` shape used elsewhere in the registry so
+ * adding an ACP agent surfaces a compile-time error here until its installer is
+ * wired — a deliberate nudge. Commands track each vendor's published installer.
+ */
+const AGENT_INSTALL: Record<
+  AcpAgentId,
+  {
+    unix: readonly string[];
+    windows: readonly string[];
+    binDirs: { unix: readonly string[]; windows: readonly string[] };
+  }
+> = {
+  opencode: {
+    unix: ["bash", "-c", "curl -fsSL https://opencode.ai/install | bash"],
+    windows: [
+      "powershell",
+      "-NoProfile",
+      "-Command",
+      "iwr -useb https://opencode.ai/install.ps1 | iex",
+    ],
+    binDirs: { unix: [".opencode/bin", ".local/bin"], windows: [".opencode/bin"] },
+  },
+  "claude-code": {
+    unix: ["bash", "-c", "curl -fsSL https://claude.ai/install.sh | bash"],
+    windows: ["powershell", "-NoProfile", "-Command", "irm https://claude.ai/install.ps1 | iex"],
+    binDirs: { unix: [".local/bin"], windows: [".local/bin"] },
+  },
+  codex: {
+    unix: ["bash", "-c", "curl -fsSL https://chatgpt.com/codex/install.sh | sh"],
+    windows: [
+      "powershell",
+      "-ExecutionPolicy",
+      "ByPass",
+      "-Command",
+      "irm https://chatgpt.com/codex/install.ps1 | iex",
+    ],
+    binDirs: { unix: [".local/bin"], windows: [".local/bin"] },
+  },
+  cursor: {
+    unix: ["bash", "-c", "curl https://cursor.com/install -fsS | bash"],
+    windows: [
+      "powershell",
+      "-NoProfile",
+      "-Command",
+      "irm 'https://cursor.com/install?win32=true' | iex",
+    ],
+    binDirs: { unix: [".local/bin"], windows: [".local/bin"] },
+  },
+};
 
 // Registry id → the CLI binary whose presence means the agent is set up
 // locally. The legacy three honor their `REVV_*_BIN` pins via
@@ -59,19 +113,19 @@ function detectAgentsSync(): AgentAvailability {
 }
 
 /**
- * Prepend the directories the official opencode installer writes to
- * (`~/.opencode/bin` and friends) onto `process.env.PATH`, so the next
- * `which opencode` invocation finds the freshly-installed binary without
- * waiting for the user's shell config to be re-sourced or for a server
- * restart.
+ * Prepend the directories the given agent's official installer writes to
+ * (e.g. `~/.opencode/bin`, `~/.local/bin`) onto `process.env.PATH`, so the next
+ * availability probe finds the freshly-installed binary without waiting for the
+ * user's shell config to be re-sourced or for a server restart.
  */
-function augmentPathForInstall(): void {
+function augmentPathForInstall(binDirs: {
+  unix: readonly string[];
+  windows: readonly string[];
+}): void {
   const home = homedir();
-  const sep = platform() === "win32" ? ";" : ":";
-  const dirs =
-    platform() === "win32"
-      ? INSTALL_BIN_DIRS_WINDOWS.map((d) => join(home, d))
-      : INSTALL_BIN_DIRS_UNIX.map((d) => join(home, d));
+  const isWindows = platform() === "win32";
+  const sep = isWindows ? ";" : ":";
+  const dirs = (isWindows ? binDirs.windows : binDirs.unix).map((d) => join(home, d));
   const current = process.env.PATH ?? "";
   const existing = current.split(sep);
   const toPrepend = dirs.filter((d) => existsSync(d) && !existing.includes(d));
@@ -82,6 +136,7 @@ function augmentPathForInstall(): void {
 
 interface InstallJob {
   jobId: string;
+  agentId: AcpAgentId;
   events: InstallEvent[];
   done: boolean;
   subscribers: Set<(event: InstallEvent) => void>;
@@ -101,11 +156,12 @@ export class OnboardingService extends Context.Tag("OnboardingService")<
     /** Read PATH for opencode + claude. Cheap; cached per the cli-agent module's TTL. */
     detectAgents: () => Effect.Effect<AgentAvailability>;
     /**
-     * Start the opencode install script if no job is running, or return the
-     * id of the in-flight job. Always idempotent — callers can race and the
-     * second one rides the first.
+     * Start the given agent's official install script if no job for that agent
+     * is running, or return the id of the in-flight job. Idempotent per agent —
+     * callers can race and the second one rides the first. Installs for
+     * different agents run independently.
      */
-    startInstallOpencode: () => Effect.Effect<{ jobId: string }>;
+    startInstall: (agent: AcpAgentId) => Effect.Effect<{ jobId: string }>;
     /**
      * Register a callback that receives every `InstallEvent` for the job:
      * first the full replay buffer (fired synchronously before subscribe
@@ -123,11 +179,11 @@ export class OnboardingService extends Context.Tag("OnboardingService")<
 export const OnboardingServiceLive = Layer.effect(
   OnboardingService,
   Effect.gen(function* () {
-    // Single-job state: install is process-lifetime idempotent. Holding
-    // this in a closure (not a Ref) is intentional — the field is read
-    // and written only from the service's own handlers, and ref-style
-    // serialization buys us nothing here.
-    let currentJob: InstallJob | null = null;
+    // Per-agent job state: each agent's install is process-lifetime idempotent.
+    // Holding this in a closure Map (not a Ref) is intentional — it's read and
+    // written only from the service's own handlers, and ref-style serialization
+    // buys us nothing here.
+    const currentJobs = new Map<AcpAgentId, InstallJob>();
 
     const broadcast = (job: InstallJob, event: InstallEvent): void => {
       job.events.push(event);
@@ -193,19 +249,13 @@ export const OnboardingServiceLive = Layer.effect(
 
     const spawnInstall = (job: InstallJob): void => {
       const isWindows = platform() === "win32";
-      // Pipe the official installer into the matching shell. On macOS/Linux
-      // we use `bash -c` (the installer is bash). On Windows the canonical
-      // path is the PowerShell one-liner.
-      const argv = isWindows
-        ? [
-            "powershell",
-            "-NoProfile",
-            "-Command",
-            "iwr -useb https://opencode.ai/install.ps1 | iex",
-          ]
-        : ["bash", "-c", "curl -fsSL https://opencode.ai/install | bash"];
+      const spec = AGENT_INSTALL[job.agentId];
+      // Pipe the agent's official installer into the matching shell. On
+      // macOS/Linux that's a `bash -c "curl … | sh"` line; on Windows it's the
+      // vendor's PowerShell one-liner.
+      const argv = [...(isWindows ? spec.windows : spec.unix)];
 
-      debug("onboarding-install", `spawning installer: ${argv.join(" ")}`);
+      debug("onboarding-install", `spawning installer (${job.agentId}): ${argv.join(" ")}`);
       broadcast(job, { type: "log", line: `> ${argv.join(" ")}` });
 
       let proc: ReturnType<typeof Bun.spawn>;
@@ -224,9 +274,9 @@ export const OnboardingServiceLive = Layer.effect(
       void (async () => {
         await Promise.all([drainStream(job, proc.stdout), drainStream(job, proc.stderr)]);
         const code = await proc.exited;
-        augmentPathForInstall();
+        augmentPathForInstall(spec.binDirs);
         invalidateCliAgentCache();
-        const installed = checkCliAvailability("opencode");
+        const installed = detectAgentCli(ACP_CLI_NAME[job.agentId]);
         const success = code === 0 && installed;
         if (success) {
           broadcast(job, { type: "done", success: true });
@@ -234,7 +284,7 @@ export const OnboardingServiceLive = Layer.effect(
           const error =
             code !== 0
               ? `Installer exited with code ${code}`
-              : "Installer finished but opencode is still not on PATH";
+              : `Installer finished but ${ACP_CLI_NAME[job.agentId]} is still not on PATH`;
           broadcast(job, { type: "done", success: false, error });
         }
       })();
@@ -243,26 +293,29 @@ export const OnboardingServiceLive = Layer.effect(
     return {
       detectAgents: () => Effect.sync(detectAgentsSync),
 
-      startInstallOpencode: () =>
+      startInstall: (agent) =>
         Effect.sync(() => {
-          if (currentJob && !currentJob.done) {
-            return { jobId: currentJob.jobId };
+          const running = currentJobs.get(agent);
+          if (running && !running.done) {
+            return { jobId: running.jobId };
           }
           const job: InstallJob = {
             jobId: crypto.randomUUID(),
+            agentId: agent,
             events: [],
             done: false,
             subscribers: new Set(),
           };
-          currentJob = job;
+          currentJobs.set(agent, job);
           spawnInstall(job);
           return { jobId: job.jobId };
         }),
 
       subscribe: (jobId, onEvent) =>
         Effect.sync(() => {
-          const job = currentJob;
-          if (!job || job.jobId !== jobId) {
+          // Resolve the job by id across all per-agent slots.
+          const job = Array.from(currentJobs.values()).find((j) => j.jobId === jobId);
+          if (!job) {
             return {
               found: false,
               unsubscribe: () => {

--- a/apps/server/src/services/jobs/EventJobRegistry.ts
+++ b/apps/server/src/services/jobs/EventJobRegistry.ts
@@ -1,0 +1,150 @@
+import type { AcpAgentId } from "@revv/shared";
+import { logError } from "../../logger";
+
+// ── Generic event-job registry ────────────────────────────────────────────────
+//
+// Shared backbone for the onboarding install (`Onboarding.ts`) and interactive
+// login (`AgentLogin.ts`) services. Both run one process-lifetime-idempotent job
+// per `AcpAgentId`, accumulate the job's events in an ephemeral replay buffer,
+// and fan them out to SSE subscribers — committing each event to the buffer
+// before broadcasting so a late subscriber replays the full transcript and still
+// reacts to the terminal `{ type: 'done' }` event correctly.
+//
+// State is intentionally ephemeral. A `kill -9` mid-job just means the user
+// re-runs it from the onboarding picker; nothing here needs to survive a crash.
+//
+// Per-feature extras (the login PTY handle, its auth-url scan buffer) ride on the
+// job's `meta` slot so neither service has to re-implement the pub/sub plumbing.
+
+/** Any event a job can broadcast; `{ type: 'done' }` closes the job. */
+type JobEvent = { type: string };
+
+export interface Job<E extends JobEvent, M> {
+  jobId: string;
+  agentId: AcpAgentId;
+  /** Replay buffer — every broadcast event, in order. */
+  events: E[];
+  done: boolean;
+  subscribers: Set<(event: E) => void>;
+  /** Per-feature mutable state (e.g. the login PTY handle). */
+  meta: M;
+}
+
+/** Subscription handle returned by {@link EventJobRegistry.subscribe}. */
+export interface JobSubscription {
+  /** True when the job id matched and the subscriber is registered. */
+  found: boolean;
+  /** Drop the listener. Safe to call multiple times. */
+  unsubscribe: () => void;
+}
+
+export class EventJobRegistry<E extends JobEvent, M> {
+  // Per-agent job state: read and written only from the owning service's
+  // handlers, so a plain Map (not a Ref) is sufficient — ref-style
+  // serialization buys nothing here.
+  private readonly jobs = new Map<AcpAgentId, Job<E, M>>();
+
+  constructor(private readonly logTag: string) {}
+
+  /**
+   * Commit `event` to the job's replay buffer, then fan it out to a snapshot of
+   * the current subscribers (listeners may unsubscribe themselves synchronously
+   * when they see `done`, mutating the live set). A terminal `{ type: 'done' }`
+   * marks the job done and clears its subscribers.
+   */
+  broadcast(job: Job<E, M>, event: E): void {
+    job.events.push(event);
+    const snapshot = Array.from(job.subscribers);
+    for (const sub of snapshot) {
+      try {
+        sub(event);
+      } catch (err) {
+        logError(
+          this.logTag,
+          "subscriber threw:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+    if (event.type === "done") {
+      job.done = true;
+      job.subscribers.clear();
+    }
+  }
+
+  /**
+   * Start-or-join. Returns the in-flight job's id when one is already running for
+   * `agentId`; otherwise creates a fresh job (its `meta` seeded by `makeMeta`),
+   * registers it, and invokes `spawn` to drive it. `spawn` receives the job plus
+   * a `broadcast` bound to it. Idempotent per agent — racing callers ride the
+   * first job.
+   */
+  start(
+    agentId: AcpAgentId,
+    makeMeta: () => M,
+    spawn: (job: Job<E, M>, broadcast: (event: E) => void) => void,
+  ): { jobId: string } {
+    const running = this.jobs.get(agentId);
+    if (running && !running.done) {
+      return { jobId: running.jobId };
+    }
+    const job: Job<E, M> = {
+      jobId: crypto.randomUUID(),
+      agentId,
+      events: [],
+      done: false,
+      subscribers: new Set(),
+      meta: makeMeta(),
+    };
+    this.jobs.set(agentId, job);
+    spawn(job, (event) => this.broadcast(job, event));
+    return { jobId: job.jobId };
+  }
+
+  /** Resolve a job by its id across all per-agent slots. */
+  findById(jobId: string): Job<E, M> | undefined {
+    for (const job of this.jobs.values()) {
+      if (job.jobId === jobId) return job;
+    }
+    return undefined;
+  }
+
+  /**
+   * Forget a job so a subsequent `start` for the same agent spawns fresh.
+   * Used to retire a cancelled job whose underlying resource (e.g. a login PTY)
+   * has been torn down.
+   */
+  delete(jobId: string): void {
+    for (const [agentId, job] of this.jobs.entries()) {
+      if (job.jobId === jobId) {
+        this.jobs.delete(agentId);
+        return;
+      }
+    }
+  }
+
+  /**
+   * Register a callback that receives every event for the job: first the full
+   * replay buffer (drained synchronously, before this returns, so no broadcast
+   * interleaves between the snapshot and registration), then live events. If the
+   * job is already terminal the listener fires through the replay and is never
+   * registered for live events.
+   */
+  subscribe(jobId: string, onEvent: (event: E) => void): JobSubscription {
+    const job = this.findById(jobId);
+    if (!job) {
+      return { found: false, unsubscribe: () => {} };
+    }
+    for (const event of job.events) onEvent(event);
+    if (job.done) {
+      return { found: true, unsubscribe: () => {} };
+    }
+    job.subscribers.add(onEvent);
+    return {
+      found: true,
+      unsubscribe: () => {
+        job.subscribers.delete(onEvent);
+      },
+    };
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,8 @@
     "@pierre/trees": "^1.0.0-beta.3",
     "@revv/shared": "workspace:*",
     "@tauri-apps/api": "^2.10.1",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "better-auth": "^1.6.3",
     "bits-ui": "^2.16.3",
     "clsx": "^2.1.1",

--- a/apps/web/src/lib/components/onboarding/AgentLoginTerminal.svelte
+++ b/apps/web/src/lib/components/onboarding/AgentLoginTerminal.svelte
@@ -1,0 +1,310 @@
+<script lang="ts">
+import type { AcpAgentId, LoginEvent } from "@revv/shared";
+import type { FitAddon } from "@xterm/addon-fit";
+import type { Terminal } from "@xterm/xterm";
+import ArrowSquareOut from "phosphor-svelte/lib/ArrowSquareOut";
+import { onDestroy, onMount } from "svelte";
+import { API_BASE_URL } from "$lib/api/base-url";
+import { prefersReducedMotion } from "$lib/motion";
+import { authHeaders } from "$lib/utils/session-token";
+import { parseSSEBuffer } from "$lib/utils/sse-parser";
+// xterm ships its own canvas/DOM — acceptable for a literal terminal. The
+// stylesheet is required for layout; the JS is dynamically imported in onMount
+// so it never runs during SSR / prerender.
+import "@xterm/xterm/css/xterm.css";
+
+interface Props {
+  /** Agent whose login command runs in the spawned PTY. */
+  agent: AcpAgentId;
+  /** Human label for the lede / buttons. */
+  agentLabel: string;
+  /** Fired once the CLI reports a successful, freshly-verified login. */
+  onDone: () => void;
+  /** Abandon the embedded login (keeps the agent installed, just not authed). */
+  onSkip: () => void;
+}
+
+let { agent, agentLabel, onDone, onSkip }: Props = $props();
+
+let container: HTMLDivElement;
+let term: Terminal | null = null;
+let fit: FitAddon | null = null;
+let jobId: string | null = null;
+let abort: AbortController | null = null;
+
+let authUrl = $state<string | null>(null);
+let failed = $state(false);
+let errorMsg = $state<string | null>(null);
+
+async function openBrowser(url: string): Promise<void> {
+  // Same handoff the GitHub device-flow login uses (auth.svelte.ts): the Tauri
+  // opener in the desktop shell, `window.open` in browser dev.
+  try {
+    const { isTauri } = await import("$lib/utils/platform");
+    if (isTauri()) {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl(url);
+    } else {
+      window.open(url, "_blank");
+    }
+  } catch {
+    // Opening the browser is best-effort — the URL is also visible in the
+    // terminal and behind the "Reopen sign-in page" button.
+  }
+}
+
+async function sendInput(data: string): Promise<void> {
+  if (!jobId) return;
+  try {
+    await fetch(`${API_BASE_URL}/api/onboarding/login/input`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ jobId, data }),
+    });
+  } catch {
+    // A dropped keystroke is non-fatal — the user can retype.
+  }
+}
+
+/**
+ * Tell the server to kill the login PTY when this terminal goes away (skip,
+ * agent switch, navigating off the onboarding step). Without this an abandoned
+ * `claude auth login` / `codex login` / `cursor-agent login` keeps running on
+ * the server until it self-exits — and the idempotent job map would rejoin the
+ * wedged process on a re-open. `keepalive` lets the request outlive unmount.
+ */
+function cancelLogin(): void {
+  if (!jobId) return;
+  try {
+    void fetch(`${API_BASE_URL}/api/onboarding/login/cancel`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ jobId }),
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    // Best-effort teardown — a server restart reclaims any straggler anyway.
+  }
+}
+
+function applyEvent(event: LoginEvent): void {
+  if (event.type === "data") {
+    term?.write(event.chunk);
+    return;
+  }
+  if (event.type === "auth-url") {
+    // The login CLI opens the user's browser itself — we only surface the URL
+    // as a fallback button so we don't pop a second browser tab.
+    authUrl = event.url;
+    return;
+  }
+  // done
+  if (event.success) {
+    onDone();
+  } else {
+    failed = true;
+    errorMsg = event.error ?? "Sign-in failed.";
+  }
+}
+
+async function streamLoginEvents(id: string, signal: AbortSignal): Promise<void> {
+  const url = `${API_BASE_URL}/api/onboarding/login/stream?jobId=${encodeURIComponent(id)}`;
+  const res = await fetch(url, { headers: authHeaders(), signal });
+  if (!res.ok || !res.body) {
+    failed = true;
+    errorMsg = `Sign-in stream failed (HTTP ${res.status})`;
+    return;
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const result = parseSSEBuffer<LoginEvent>(buffer);
+    buffer = result.remaining;
+    for (const event of result.events) applyEvent(event);
+    if (result.done) break;
+  }
+}
+
+function onResize(): void {
+  try {
+    fit?.fit();
+  } catch {
+    // fit() can throw if the container has zero size mid-transition.
+  }
+}
+
+onMount(async () => {
+  // 1. Start (or join) the login job.
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/onboarding/login`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ agent }),
+    });
+    if (!res.ok) {
+      failed = true;
+      errorMsg = `Failed to start sign-in (HTTP ${res.status})`;
+      return;
+    }
+    ({ jobId } = (await res.json()) as { jobId: string });
+  } catch (e) {
+    failed = true;
+    errorMsg = e instanceof Error ? e.message : "Failed to start sign-in";
+    return;
+  }
+
+  // 2. Mount the terminal (client-only import).
+  const [{ Terminal }, { FitAddon }] = await Promise.all([
+    import("@xterm/xterm"),
+    import("@xterm/addon-fit"),
+  ]);
+  term = new Terminal({
+    convertEol: false,
+    cursorBlink: !prefersReducedMotion(),
+    fontSize: 12,
+    fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+    allowTransparency: true,
+    theme: { background: "#00000000" },
+  });
+  fit = new FitAddon();
+  term.loadAddon(fit);
+  term.open(container);
+  onResize();
+  term.onData((d) => void sendInput(d));
+  window.addEventListener("resize", onResize);
+
+  // 3. Stream the PTY output.
+  const ctrl = new AbortController();
+  abort = ctrl;
+  void streamLoginEvents(jobId, ctrl.signal);
+});
+
+onDestroy(() => {
+  abort?.abort();
+  // Kill the server-side PTY too — aborting the SSE fetch alone leaves the
+  // login CLI running. Covers skip, agent switch, and navigating away.
+  cancelLogin();
+  window.removeEventListener("resize", onResize);
+  term?.dispose();
+  term = null;
+  fit = null;
+});
+</script>
+
+<div class="login">
+	<p class="lede">
+		Sign in to <em>{agentLabel}</em> below. Your browser should open
+		automatically — complete the login there, then return here.
+	</p>
+
+	{#if authUrl}
+		<button class="auth-url" onclick={() => authUrl && openBrowser(authUrl)}>
+			<ArrowSquareOut size={14} />
+			<span>Open sign-in page</span>
+		</button>
+	{/if}
+
+	<div class="terminal-frame" class:error={failed}>
+		<div class="terminal" bind:this={container}></div>
+	</div>
+
+	{#if failed}
+		<div class="login-error">{errorMsg ?? 'Sign-in failed.'}</div>
+	{/if}
+
+	<div class="login-actions">
+		<button class="secondary" onclick={onSkip}>Skip for now</button>
+	</div>
+</div>
+
+<style>
+	.login {
+		display: flex;
+		flex-direction: column;
+		gap: 18px;
+	}
+
+	.lede {
+		font-family: 'Newsreader', Georgia, serif;
+		font-size: 16px;
+		line-height: 1.6;
+		color: var(--ob-text-body);
+		margin: 0;
+	}
+
+	.lede em {
+		font-style: italic;
+		color: var(--ob-text-italic);
+	}
+
+	.auth-url {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		align-self: flex-start;
+		background: none;
+		border: 0;
+		padding: 0;
+		color: var(--ob-text-muted);
+		font-family: var(--font-mono, 'JetBrains Mono', monospace);
+		font-size: 10.5px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		cursor: pointer;
+		transition: color var(--duration-snap) var(--ease-out-expo);
+	}
+
+	.auth-url:hover {
+		color: var(--ob-text-italic);
+	}
+
+	.terminal-frame {
+		padding: 12px;
+		border: 1px solid var(--ob-border);
+		border-radius: 2px;
+		background: var(--ob-hover-subtle);
+		height: 280px;
+		overflow: hidden;
+	}
+
+	.terminal-frame.error {
+		border-color: var(--ob-text-label);
+	}
+
+	.terminal {
+		width: 100%;
+		height: 100%;
+	}
+
+	.login-error {
+		font-family: var(--font-mono, 'JetBrains Mono', monospace);
+		font-size: 11.5px;
+		color: var(--ob-text-italic);
+	}
+
+	.login-actions {
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	.secondary {
+		background: none;
+		border: 0;
+		padding: 8px 4px;
+		color: var(--ob-text-muted);
+		font-family: var(--font-mono, 'JetBrains Mono', monospace);
+		font-size: 10.5px;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		cursor: pointer;
+		transition: color var(--duration-snap) var(--ease-out-expo);
+	}
+
+	.secondary:hover {
+		color: var(--ob-text-italic);
+	}
+</style>

--- a/apps/web/src/lib/components/onboarding/AgentLoginTerminal.svelte
+++ b/apps/web/src/lib/components/onboarding/AgentLoginTerminal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { AcpAgentId, LoginEvent } from "@revv/shared";
 import type { FitAddon } from "@xterm/addon-fit";
-import type { Terminal } from "@xterm/xterm";
+import type { ITheme, Terminal } from "@xterm/xterm";
 import ArrowSquareOut from "phosphor-svelte/lib/ArrowSquareOut";
 import { onDestroy, onMount } from "svelte";
 import { API_BASE_URL } from "$lib/api/base-url";
@@ -137,6 +137,57 @@ function onResize(): void {
   }
 }
 
+/**
+ * xterm can't resolve CSS `var()` — it needs literal color/font strings to
+ * measure glyph cells and paint. Read the resolved onboarding tokens off the
+ * mounted element so the terminal tracks light/dark mode and the warm paper
+ * palette instead of xterm's default white-on-black (invisible here) plus its
+ * garish bright-ANSI colors.
+ */
+function readTerminalStyle(el: HTMLElement): {
+  fontFamily: string;
+  theme: ITheme;
+} {
+  const cs = getComputedStyle(el);
+  const v = (name: string, fallback: string): string =>
+    cs.getPropertyValue(name).trim() || fallback;
+
+  const fg = v("--ob-text", "#2a2825");
+  const muted = v("--ob-text-muted", "#9a958c");
+  const dim = v("--ob-text-dimmed", "#c4bfb6");
+  const accent = v("--ob-text-italic", "#6b5d3e");
+  const heading = v("--ob-text-heading", "#1a1816");
+
+  return {
+    fontFamily: v("--font-mono", '"JetBrains Mono", "Fira Code", monospace'),
+    theme: {
+      background: "#00000000",
+      foreground: fg,
+      cursor: accent,
+      cursorAccent: v("--ob-bg", "#faf9f6"),
+      selectionBackground: v("--ob-row-highlight", "rgba(107, 93, 62, 0.18)"),
+      // Map the 16 ANSI slots onto the onboarding palette so CLI-colored
+      // output (cyan tips, dim hints, bold headings) reads on the paper bg.
+      black: dim,
+      red: v("--ob-error", "#b5494b"),
+      green: accent,
+      yellow: accent,
+      blue: muted,
+      magenta: accent,
+      cyan: muted,
+      white: fg,
+      brightBlack: muted,
+      brightRed: v("--ob-error", "#b5494b"),
+      brightGreen: accent,
+      brightYellow: accent,
+      brightBlue: muted,
+      brightMagenta: accent,
+      brightCyan: muted,
+      brightWhite: heading,
+    },
+  };
+}
+
 onMount(async () => {
   // 1. Start (or join) the login job.
   try {
@@ -162,13 +213,14 @@ onMount(async () => {
     import("@xterm/xterm"),
     import("@xterm/addon-fit"),
   ]);
+  const { fontFamily, theme } = readTerminalStyle(container);
   term = new Terminal({
     convertEol: false,
     cursorBlink: !prefersReducedMotion(),
     fontSize: 12,
-    fontFamily: "var(--font-mono, 'JetBrains Mono', monospace)",
+    fontFamily,
     allowTransparency: true,
-    theme: { background: "#00000000" },
+    theme,
   });
   fit = new FitAddon();
   term.loadAddon(fit);

--- a/apps/web/src/lib/components/onboarding/StepAgent.svelte
+++ b/apps/web/src/lib/components/onboarding/StepAgent.svelte
@@ -2,7 +2,7 @@
 import {
   ACP_AGENTS,
   type AcpAgentId,
-  type AgentAvailability,
+  type AgentStatusReport,
   type InstallEvent,
 } from "@revv/shared";
 import ChevronLeft from "phosphor-svelte/lib/CaretLeft";
@@ -12,15 +12,16 @@ import { acpAgentIcon } from "$lib/components/icons/acpAgentIcon";
 import Dotmatrix from "$lib/components/ui/dotmatrix/Dotmatrix.svelte";
 import {
   cascadeChatAgentChange,
-  fetchAgentAvailability,
+  fetchAgentStatus,
   fetchModels,
-  getAgentAvailability,
+  getAgentStatus,
   getSettings,
   resolveChatAgentId,
   updateSettings,
 } from "$lib/stores/settings.svelte";
 import { authHeaders } from "$lib/utils/session-token";
 import { parseSSEBuffer } from "$lib/utils/sse-parser";
+import AgentLoginTerminal from "./AgentLoginTerminal.svelte";
 
 interface Props {
   onContinue: () => void;
@@ -32,60 +33,84 @@ interface Props {
 let { onContinue, onBack, onSkip }: Props = $props();
 
 const OPENCODE: AcpAgentId = "opencode";
-
-// ── Detection state ──────────────────────────────────────────────────────
-//
-// Two rendering modes:
-//   - 'loading' — initial detection in flight
-//   - 'picker'  — the agent list; the install log shows inline as a sub-state
-//                 (keyed on `installingAgent`) while a job runs.
-let mode = $state<"loading" | "picker">("loading");
-let availability = $state<AgentAvailability | null>(null);
-
-// Picker state: pre-select the current chat agent, falling back to opencode if
-// either the settings haven't loaded or the saved agent isn't installed (rare —
-// but if so, prefer an installed one over the empty pre-selection).
-let selected = $state<AcpAgentId>(resolveChatAgentId(getSettings()));
-let isSaving = $state(false);
-
-// Install sub-state — rendered in place of the actions while a job runs.
-// `installingAgent` is the agent whose installer is in flight (or whose run
-// just failed); null means no install is showing.
-let installingAgent = $state<AcpAgentId | null>(null);
-let installLog = $state<string[]>([]);
-let installFailed = $state(false);
-let installError = $state<string | null>(null);
-let installAbort: AbortController | null = null;
 const LOG_TAIL = 6;
 
-// True once detection has resolved and nothing is installed — we advertise
-// opencode (pre-selected, free / no sign-in) as the zero-config option.
-const noneInstalled = $derived(
-  availability !== null && !ACP_AGENTS.some((a) => availability?.[a.id]),
-);
-// Whether the currently-selected agent is installed — drives the adaptive CTA.
-const selectedInstalled = $derived(availability?.[selected] ?? false);
+// ── State ──────────────────────────────────────────────────────────────────
+//
+// `mode` gates the loading screen vs. the picker. `status` is the server's
+// one-shot detection snapshot (per-agent installed + authed + login command,
+// plus whether this host can drive the embedded PTY login). `install` is a
+// tagged request-state union; `signingIn` is the agent whose embedded sign-in
+// terminal is mounted. The adaptive CTA is derived from all three (see `cta`).
+type InstallState =
+  | { kind: "idle" }
+  | { kind: "running"; agent: AcpAgentId; log: string[] }
+  | { kind: "failed"; agent: AcpAgentId; log: string[]; error: string };
+
+let mode = $state<"loading" | "picker">("loading");
+let status = $state<AgentStatusReport | null>(null);
+let install = $state<InstallState>({ kind: "idle" });
+let signingIn = $state<AcpAgentId | null>(null);
+let isSaving = $state(false);
+let installAbort: AbortController | null = null;
+
+// Picker selection: pre-select the current chat agent, falling back to opencode
+// if the settings haven't loaded or the saved agent isn't installed.
+let selected = $state<AcpAgentId>(resolveChatAgentId(getSettings()));
+
+// ── Derived ──────────────────────────────────────────────────────────────
+const selectedInstalled = $derived(status?.agents[selected]?.installed ?? false);
+// When detection hasn't resolved (null) treat the selection as authed so a
+// probe failure never blocks Continue.
+const selectedAuthed = $derived(status ? (status.agents[selected]?.authed ?? false) : true);
 const selectedLabel = $derived(ACP_AGENTS.find((a) => a.id === selected)?.label ?? selected);
+// Manual login command for the no-embedded-PTY fallback — server-provided, so
+// there's a single source of truth for each agent's login command.
+const selectedLoginCommand = $derived(
+  status?.agents[selected]?.loginCommand ?? `${selected} login`,
+);
+// True once detection resolved and nothing is installed — we advertise opencode
+// (pre-selected, free / no sign-in) as the zero-config option.
+const noneInstalled = $derived(
+  status !== null && !ACP_AGENTS.some((a) => status?.agents[a.id]?.installed),
+);
+
+// The single adaptive CTA state — one tagged value instead of an order-dependent
+// boolean ladder, so each arm's precondition is explicit and self-contained.
+type CtaState =
+  | { kind: "signing-in"; agent: AcpAgentId }
+  | { kind: "installing" }
+  | { kind: "install-failed" }
+  | { kind: "ready" }
+  | { kind: "needs-login" }
+  | { kind: "needs-login-manual" }
+  | { kind: "needs-install" };
+
+const cta = $derived.by((): CtaState => {
+  if (signingIn !== null) return { kind: "signing-in", agent: signingIn };
+  if (install.kind === "running") return { kind: "installing" };
+  if (install.kind === "failed") return { kind: "install-failed" };
+  if (!selectedInstalled) return { kind: "needs-install" };
+  if (selectedAuthed) return { kind: "ready" };
+  // Installed but not authed: embedded PTY login where the host supports it
+  // (the server is the authority), else a manual-command hint.
+  return status?.embeddedLoginSupported ? { kind: "needs-login" } : { kind: "needs-login-manual" };
+});
 
 onMount(async () => {
-  const cached = getAgentAvailability();
-  const data = cached ?? (await fetchAgentAvailability());
-  availability = data;
+  const data = getAgentStatus() ?? (await fetchAgentStatus());
+  status = data;
   if (!data) {
     // Detection failed — fall back to picker so the user isn't stuck.
     mode = "picker";
     return;
   }
-  if (ACP_AGENTS.some((a) => data[a.id])) {
+  const installed = ACP_AGENTS.filter((a) => data.agents[a.id]?.installed);
+  if (installed.length > 0) {
     // If the saved agent isn't installed, nudge the selection to the first
     // installed agent (registry order) so Continue doesn't pick a missing CLI.
     const saved = resolveChatAgentId(getSettings());
-    if (data[saved]) {
-      selected = saved;
-    } else {
-      const firstInstalled = ACP_AGENTS.find((a) => data[a.id]);
-      if (firstInstalled) selected = firstInstalled.id;
-    }
+    selected = data.agents[saved]?.installed ? saved : (installed[0]?.id ?? selected);
   } else {
     // Nothing installed — advertise opencode as the out-of-the-box option.
     selected = OPENCODE;
@@ -111,11 +136,7 @@ async function handleContinue(): Promise<void> {
 }
 
 async function handleInstall(agent: AcpAgentId): Promise<void> {
-  installingAgent = agent;
-  installFailed = false;
-  installError = null;
-  installLog = [];
-
+  install = { kind: "running", agent, log: [] };
   try {
     const startRes = await fetch(`${API_BASE_URL}/api/onboarding/install`, {
       method: "POST",
@@ -123,30 +144,51 @@ async function handleInstall(agent: AcpAgentId): Promise<void> {
       body: JSON.stringify({ agent }),
     });
     if (!startRes.ok) {
-      installFailed = true;
-      installError = `Failed to start installer (HTTP ${startRes.status})`;
+      install = {
+        kind: "failed",
+        agent,
+        log: currentLog(),
+        error: `Failed to start installer (HTTP ${startRes.status})`,
+      };
       return;
     }
     const { jobId } = (await startRes.json()) as { jobId: string };
 
     const ctrl = new AbortController();
     installAbort = ctrl;
-    await streamInstallEvents(jobId, ctrl.signal);
+    await streamInstallEvents(jobId, agent, ctrl.signal);
   } catch (err) {
     if ((err as Error)?.name === "AbortError") return;
-    installFailed = true;
-    installError = err instanceof Error ? err.message : "Install failed";
+    install = {
+      kind: "failed",
+      agent,
+      log: currentLog(),
+      error: err instanceof Error ? err.message : "Install failed",
+    };
   } finally {
     installAbort = null;
   }
 }
 
-async function streamInstallEvents(jobId: string, signal: AbortSignal): Promise<void> {
+/** Lines accumulated so far, preserved across a running → failed transition. */
+function currentLog(): string[] {
+  return install.kind === "idle" ? [] : install.log;
+}
+
+async function streamInstallEvents(
+  jobId: string,
+  agent: AcpAgentId,
+  signal: AbortSignal,
+): Promise<void> {
   const url = `${API_BASE_URL}/api/onboarding/install/stream?jobId=${encodeURIComponent(jobId)}`;
   const res = await fetch(url, { headers: authHeaders(), signal });
   if (!res.ok || !res.body) {
-    installFailed = true;
-    installError = `Stream failed (HTTP ${res.status})`;
+    install = {
+      kind: "failed",
+      agent,
+      log: currentLog(),
+      error: `Stream failed (HTTP ${res.status})`,
+    };
     return;
   }
   const reader = res.body.getReader();
@@ -158,31 +200,51 @@ async function streamInstallEvents(jobId: string, signal: AbortSignal): Promise<
     buffer += decoder.decode(value, { stream: true });
     const result = parseSSEBuffer<InstallEvent>(buffer);
     buffer = result.remaining;
-    for (const event of result.events) {
-      applyEvent(event);
-    }
+    for (const event of result.events) applyInstallEvent(event, agent);
     if (result.done) break;
   }
 }
 
-function applyEvent(event: InstallEvent): void {
+function applyInstallEvent(event: InstallEvent, agent: AcpAgentId): void {
   if (event.type === "log") {
-    installLog = [...installLog, event.line].slice(-LOG_TAIL);
+    if (install.kind === "running") {
+      install = { kind: "running", agent, log: [...install.log, event.line].slice(-LOG_TAIL) };
+    }
     return;
   }
-  if (event.type === "done") {
-    if (event.success) {
-      // Refresh detection so the just-installed agent shows the Installed tag
-      // and the CTA flips to Continue. Keep `selected` on that agent.
-      void (async () => {
-        availability = await fetchAgentAvailability();
-        installingAgent = null;
-      })();
-    } else {
-      installFailed = true;
-      installError = event.error ?? "Install failed";
-    }
+  // done
+  if (!event.success) {
+    install = { kind: "failed", agent, log: currentLog(), error: event.error ?? "Install failed" };
+    return;
   }
+  // Success — refresh detection so the just-installed agent shows the Installed
+  // tag. If it still needs a login and the host supports the embedded PTY,
+  // advance straight to sign-in; otherwise the CTA flips to Continue (or the
+  // manual hint where the embedded login isn't available).
+  void (async () => {
+    const data = await fetchAgentStatus();
+    status = data;
+    install = { kind: "idle" };
+    if (data && data.agents[agent]?.authed === false && data.embeddedLoginSupported) {
+      signingIn = agent;
+    }
+  })();
+}
+
+function handleSignIn(agent: AcpAgentId): void {
+  signingIn = agent;
+}
+
+async function onLoginDone(): Promise<void> {
+  // The CLI reported a verified login — refresh the snapshot so the CTA flips to
+  // Continue, then drop the terminal.
+  status = await fetchAgentStatus();
+  signingIn = null;
+}
+
+function onLoginSkip(): void {
+  // Unmounting the terminal triggers its onDestroy, which kills the server PTY.
+  signingIn = null;
 }
 
 function handleSkip(): void {
@@ -219,7 +281,7 @@ function handleSkip(): void {
 
 			{#each ACP_AGENTS as agent, i (agent.id)}
 				{@const AgentIcon = acpAgentIcon(agent.icon)}
-				{@const isInstalled = availability?.[agent.id] ?? false}
+				{@const isInstalled = status?.agents[agent.id]?.installed ?? false}
 				<label
 					class="option"
 					data-selected={selected === agent.id}
@@ -230,7 +292,7 @@ function handleSkip(): void {
 						name="agent"
 						value={agent.id}
 						bind:group={selected}
-						disabled={installingAgent !== null}
+						disabled={install.kind === 'running' || signingIn !== null}
 					/>
 					<span class="option-mark" aria-hidden="true"></span>
 					<span class="option-icon" aria-hidden="true">
@@ -253,26 +315,33 @@ function handleSkip(): void {
 			{/each}
 		</fieldset>
 
-		{#if installingAgent !== null && !installFailed}
+		{#if cta.kind === 'signing-in'}
+			<AgentLoginTerminal
+				agent={cta.agent}
+				agentLabel={ACP_AGENTS.find((a) => a.id === cta.agent)?.label ?? cta.agent}
+				onDone={onLoginDone}
+				onSkip={onLoginSkip}
+			/>
+		{:else if cta.kind === 'installing'}
 			<div class="installing">
 				<Dotmatrix variant="square-7" />
 				<div class="install-log">
-					{#if installLog.length === 0}
-						<div class="log-line log-muted">Starting installer…</div>
-					{:else}
-						{#each installLog as line, i (i)}
+					{#if install.kind === 'running' && install.log.length > 0}
+						{#each install.log as line, i (i)}
 							<div class="log-line">{line}</div>
 						{/each}
+					{:else}
+						<div class="log-line log-muted">Starting installer…</div>
 					{/if}
 				</div>
 				<button class="secondary" onclick={handleSkip}>Skip waiting</button>
 			</div>
-		{:else if installFailed}
+		{:else if cta.kind === 'install-failed' && install.kind === 'failed'}
 			<div class="install-log error">
-				{#each installLog as line, i (i)}
+				{#each install.log as line, i (i)}
 					<div class="log-line">{line}</div>
 				{/each}
-				<div class="log-line log-error">{installError ?? 'Install failed.'}</div>
+				<div class="log-line log-error">{install.error}</div>
 			</div>
 			<div class="install-actions">
 				<button class="primary" onclick={() => handleInstall(selected)}>
@@ -280,7 +349,7 @@ function handleSkip(): void {
 				</button>
 				<button class="secondary" onclick={handleSkip}>Skip for now</button>
 			</div>
-		{:else if selectedInstalled}
+		{:else if cta.kind === 'ready'}
 			<div class="actions">
 				<button class="primary" onclick={handleContinue} disabled={isSaving}>
 					<span>Continue</span>
@@ -295,6 +364,28 @@ function handleSkip(): void {
 						<path d="M0 5h16M12 1l4 4-4 4" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" />
 					</svg>
 				</button>
+			</div>
+		{:else if cta.kind === 'needs-login-manual'}
+			<div class="win-hint">
+				<p class="win-hint-text">
+					Signing in from inside Revv isn't available on this platform yet. Open a
+					terminal and run this to sign in to <em>{selectedLabel}</em>, then come
+					back and continue:
+				</p>
+				<code class="win-hint-cmd">{selectedLoginCommand}</code>
+			</div>
+			<div class="install-actions">
+				<button class="primary" onclick={handleContinue} disabled={isSaving}>
+					<span>Continue</span>
+				</button>
+				<button class="secondary" onclick={handleSkip}>Skip for now</button>
+			</div>
+		{:else if cta.kind === 'needs-login'}
+			<div class="install-actions">
+				<button class="primary" onclick={() => handleSignIn(selected)}>
+					<span>Sign in to {selectedLabel}</span>
+				</button>
+				<button class="secondary" onclick={handleSkip}>Skip for now</button>
 			</div>
 		{:else}
 			<div class="install-actions">
@@ -623,6 +714,37 @@ function handleSkip(): void {
 
 	.log-error {
 		color: var(--ob-text-italic);
+	}
+
+	.win-hint {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.win-hint-text {
+		font-family: 'Newsreader', Georgia, serif;
+		font-size: 15px;
+		line-height: 1.6;
+		color: var(--ob-text-body);
+		margin: 0;
+	}
+
+	.win-hint-text em {
+		font-style: italic;
+		color: var(--ob-text-italic);
+	}
+
+	.win-hint-cmd {
+		align-self: flex-start;
+		padding: 10px 14px;
+		border: 1px solid var(--ob-border);
+		border-radius: 2px;
+		background: var(--ob-hover-subtle);
+		font-family: var(--font-mono, 'JetBrains Mono', monospace);
+		font-size: 12.5px;
+		color: var(--ob-text-heading);
+		user-select: all;
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/lib/components/onboarding/StepAgent.svelte
+++ b/apps/web/src/lib/components/onboarding/StepAgent.svelte
@@ -35,11 +35,11 @@ const OPENCODE: AcpAgentId = "opencode";
 
 // ── Detection state ──────────────────────────────────────────────────────
 //
-// Three rendering modes:
+// Two rendering modes:
 //   - 'loading' — initial detection in flight
-//   - 'picker'  — at least one provider detected, user picks one
-//   - 'install' — none detected, offer to install opencode
-let mode = $state<"loading" | "picker" | "install">("loading");
+//   - 'picker'  — the agent list; the install log shows inline as a sub-state
+//                 (keyed on `installingAgent`) while a job runs.
+let mode = $state<"loading" | "picker">("loading");
 let availability = $state<AgentAvailability | null>(null);
 
 // Picker state: pre-select the current chat agent, falling back to opencode if
@@ -48,13 +48,24 @@ let availability = $state<AgentAvailability | null>(null);
 let selected = $state<AcpAgentId>(resolveChatAgentId(getSettings()));
 let isSaving = $state(false);
 
-// Install state.
-let installJobId = $state<string | null>(null);
+// Install sub-state — rendered in place of the actions while a job runs.
+// `installingAgent` is the agent whose installer is in flight (or whose run
+// just failed); null means no install is showing.
+let installingAgent = $state<AcpAgentId | null>(null);
 let installLog = $state<string[]>([]);
 let installFailed = $state(false);
 let installError = $state<string | null>(null);
 let installAbort: AbortController | null = null;
 const LOG_TAIL = 6;
+
+// True once detection has resolved and nothing is installed — we advertise
+// opencode (pre-selected, free / no sign-in) as the zero-config option.
+const noneInstalled = $derived(
+  availability !== null && !ACP_AGENTS.some((a) => availability?.[a.id]),
+);
+// Whether the currently-selected agent is installed — drives the adaptive CTA.
+const selectedInstalled = $derived(availability?.[selected] ?? false);
+const selectedLabel = $derived(ACP_AGENTS.find((a) => a.id === selected)?.label ?? selected);
 
 onMount(async () => {
   const cached = getAgentAvailability();
@@ -75,10 +86,11 @@ onMount(async () => {
       const firstInstalled = ACP_AGENTS.find((a) => data[a.id]);
       if (firstInstalled) selected = firstInstalled.id;
     }
-    mode = "picker";
   } else {
-    mode = "install";
+    // Nothing installed — advertise opencode as the out-of-the-box option.
+    selected = OPENCODE;
   }
+  mode = "picker";
 });
 
 onDestroy(() => {
@@ -98,15 +110,17 @@ async function handleContinue(): Promise<void> {
   }
 }
 
-async function handleInstall(): Promise<void> {
+async function handleInstall(agent: AcpAgentId): Promise<void> {
+  installingAgent = agent;
   installFailed = false;
   installError = null;
   installLog = [];
 
   try {
-    const startRes = await fetch(`${API_BASE_URL}/api/onboarding/install-opencode`, {
+    const startRes = await fetch(`${API_BASE_URL}/api/onboarding/install`, {
       method: "POST",
       headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ agent }),
     });
     if (!startRes.ok) {
       installFailed = true;
@@ -114,7 +128,6 @@ async function handleInstall(): Promise<void> {
       return;
     }
     const { jobId } = (await startRes.json()) as { jobId: string };
-    installJobId = jobId;
 
     const ctrl = new AbortController();
     installAbort = ctrl;
@@ -129,7 +142,7 @@ async function handleInstall(): Promise<void> {
 }
 
 async function streamInstallEvents(jobId: string, signal: AbortSignal): Promise<void> {
-  const url = `${API_BASE_URL}/api/onboarding/install-opencode/stream?jobId=${encodeURIComponent(jobId)}`;
+  const url = `${API_BASE_URL}/api/onboarding/install/stream?jobId=${encodeURIComponent(jobId)}`;
   const res = await fetch(url, { headers: authHeaders(), signal });
   if (!res.ok || !res.body) {
     installFailed = true;
@@ -159,12 +172,11 @@ function applyEvent(event: InstallEvent): void {
   }
   if (event.type === "done") {
     if (event.success) {
-      // Refresh detection so the picker pre-selects opencode and shows
-      // the Installed tag accurately.
+      // Refresh detection so the just-installed agent shows the Installed tag
+      // and the CTA flips to Continue. Keep `selected` on that agent.
       void (async () => {
         availability = await fetchAgentAvailability();
-        selected = OPENCODE;
-        mode = "picker";
+        installingAgent = null;
       })();
     } else {
       installFailed = true;
@@ -190,10 +202,16 @@ function handleSkip(): void {
 
 	{#if mode === 'loading'}
 		<p class="lede">Detecting installed agents…</p>
-	{:else if mode === 'picker'}
+	{:else}
 		<p class="lede">
-			Choose the agent that reads your pull requests. You can swap engines later
-			from settings.
+			{#if noneInstalled}
+				No agent is set up on this machine yet. <em>opencode</em> is free,
+				open-source, and works out of the box — no sign-in needed. Start with it,
+				or install another agent below.
+			{:else}
+				Choose the agent that reads your pull requests. You can swap engines later
+				from settings.
+			{/if}
 		</p>
 
 		<fieldset class="options">
@@ -201,12 +219,19 @@ function handleSkip(): void {
 
 			{#each ACP_AGENTS as agent, i (agent.id)}
 				{@const AgentIcon = acpAgentIcon(agent.icon)}
+				{@const isInstalled = availability?.[agent.id] ?? false}
 				<label
 					class="option"
 					data-selected={selected === agent.id}
 					style="--option-index: {i}"
 				>
-					<input type="radio" name="agent" value={agent.id} bind:group={selected} />
+					<input
+						type="radio"
+						name="agent"
+						value={agent.id}
+						bind:group={selected}
+						disabled={installingAgent !== null}
+					/>
 					<span class="option-mark" aria-hidden="true"></span>
 					<span class="option-icon" aria-hidden="true">
 						<AgentIcon size={20} />
@@ -214,10 +239,12 @@ function handleSkip(): void {
 					<span class="option-body">
 						<span class="option-row">
 							<span class="option-name">{agent.label}</span>
-							{#if availability?.[agent.id]}
+							{#if isInstalled}
 								<span class="option-tag tag-installed">installed</span>
+							{:else if agent.id === OPENCODE}
+								<span class="option-tag tag-free">free · no sign-in</span>
 							{:else}
-								<span class="option-tag tag-missing">not installed</span>
+								<span class="option-tag tag-missing">needs sign-in</span>
 							{/if}
 						</span>
 						<span class="option-host">{agent.description}</span>
@@ -226,48 +253,7 @@ function handleSkip(): void {
 			{/each}
 		</fieldset>
 
-		<div class="actions">
-			<button class="primary" onclick={handleContinue} disabled={isSaving}>
-				<span>Continue</span>
-				<svg
-					width="18"
-					height="10"
-					viewBox="0 0 18 10"
-					fill="none"
-					xmlns="http://www.w3.org/2000/svg"
-					aria-hidden="true"
-				>
-					<path d="M0 5h16M12 1l4 4-4 4" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" />
-				</svg>
-			</button>
-		</div>
-	{:else}
-		<p class="lede">
-			No AI agent was found on this machine. Install OpenCode to run reviews
-			locally — it ships as a single binary and takes about a minute.
-		</p>
-
-		{#if installJobId === null && !installFailed}
-			<div class="install-actions">
-				<button class="primary" onclick={handleInstall}>
-					<span>Install OpenCode</span>
-				</button>
-				<button class="secondary" onclick={handleSkip}>Skip for now</button>
-			</div>
-		{:else if installFailed}
-			<div class="install-log error">
-				{#each installLog as line, i (i)}
-					<div class="log-line">{line}</div>
-				{/each}
-				<div class="log-line log-error">{installError ?? 'Install failed.'}</div>
-			</div>
-			<div class="install-actions">
-				<button class="primary" onclick={handleInstall}>
-					<span>Retry</span>
-				</button>
-				<button class="secondary" onclick={handleSkip}>Skip for now</button>
-			</div>
-		{:else}
+		{#if installingAgent !== null && !installFailed}
 			<div class="installing">
 				<Dotmatrix variant="square-7" />
 				<div class="install-log">
@@ -280,6 +266,42 @@ function handleSkip(): void {
 					{/if}
 				</div>
 				<button class="secondary" onclick={handleSkip}>Skip waiting</button>
+			</div>
+		{:else if installFailed}
+			<div class="install-log error">
+				{#each installLog as line, i (i)}
+					<div class="log-line">{line}</div>
+				{/each}
+				<div class="log-line log-error">{installError ?? 'Install failed.'}</div>
+			</div>
+			<div class="install-actions">
+				<button class="primary" onclick={() => handleInstall(selected)}>
+					<span>Retry</span>
+				</button>
+				<button class="secondary" onclick={handleSkip}>Skip for now</button>
+			</div>
+		{:else if selectedInstalled}
+			<div class="actions">
+				<button class="primary" onclick={handleContinue} disabled={isSaving}>
+					<span>Continue</span>
+					<svg
+						width="18"
+						height="10"
+						viewBox="0 0 18 10"
+						fill="none"
+						xmlns="http://www.w3.org/2000/svg"
+						aria-hidden="true"
+					>
+						<path d="M0 5h16M12 1l4 4-4 4" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" />
+					</svg>
+				</button>
+			</div>
+		{:else}
+			<div class="install-actions">
+				<button class="primary" onclick={() => handleInstall(selected)}>
+					<span>Install {selectedLabel}</span>
+				</button>
+				<button class="secondary" onclick={handleSkip}>Skip for now</button>
 			</div>
 		{/if}
 	{/if}
@@ -465,6 +487,10 @@ function handleSkip(): void {
 	}
 
 	.tag-installed {
+		color: var(--ob-text-italic);
+	}
+
+	.tag-free {
 		color: var(--ob-text-italic);
 	}
 

--- a/apps/web/src/lib/stores/settings.svelte.ts
+++ b/apps/web/src/lib/stores/settings.svelte.ts
@@ -1,7 +1,7 @@
 import {
   ACP_AGENT_IDS,
   type AcpAgentId,
-  type AgentAvailability,
+  type AgentStatusReport,
   getAgentCapabilities,
   type UserSettings,
 } from "@revv/shared";
@@ -151,7 +151,7 @@ export function reset(): void {
   modelsByAgent = byAgent(() => []);
   modelsLoadedByAgent = byAgent(() => false);
   modelsInFlight = {};
-  agentAvailability = null;
+  agentStatus = null;
 }
 
 /**
@@ -228,28 +228,29 @@ export function cascadeChatAgentChange(acpId: AcpAgentId): SettingsUpdate {
   return update;
 }
 
-// ── Agent availability ──────────────────────────────────────────────────────
-// Cached snapshot of which CLI agents are installed locally. Used by the
-// onboarding agent step to decide between the picker and the install
-// prompt. Stays null until `fetchAgentAvailability()` runs, since first
-// render has nothing useful to show.
+// ── Agent status ──────────────────────────────────────────────────────────────
+// Cached one-shot detection snapshot — per-agent installed + authed + login
+// command, plus whether this host supports the embedded PTY login. Used by the
+// onboarding agent step to render the picker tags and the adaptive CTA. Stays
+// null until `fetchAgentStatus()` runs, since first render has nothing useful to
+// show.
 
-let agentAvailability = $state<AgentAvailability | null>(null);
+let agentStatus = $state<AgentStatusReport | null>(null);
 
-export function getAgentAvailability(): AgentAvailability | null {
-  return agentAvailability;
+export function getAgentStatus(): AgentStatusReport | null {
+  return agentStatus;
 }
 
-export async function fetchAgentAvailability(): Promise<AgentAvailability | null> {
+export async function fetchAgentStatus(): Promise<AgentStatusReport | null> {
   try {
-    const res = await fetch(`${API_BASE_URL}/api/onboarding/agent-availability`, {
+    const res = await fetch(`${API_BASE_URL}/api/onboarding/agent-status`, {
       headers: authHeaders(),
     });
-    if (!res.ok) return agentAvailability;
-    const data = (await res.json()) as AgentAvailability;
-    agentAvailability = data;
+    if (!res.ok) return agentStatus;
+    const data = (await res.json()) as AgentStatusReport;
+    agentStatus = data;
     return data;
   } catch {
-    return agentAvailability;
+    return agentStatus;
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
     },
     "apps/server": {
       "name": "@revv/server",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.26.0",
         "@effect/opentelemetry": "^0.63.0",
@@ -50,7 +50,7 @@
     },
     "apps/web": {
       "name": "@revv/web",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "@elysiajs/eden": "^1.4.9",
         "@internationalized/date": "^3.12.0",
@@ -59,6 +59,8 @@
         "@pierre/trees": "^1.0.0-beta.3",
         "@revv/shared": "workspace:*",
         "@tauri-apps/api": "^2.10.1",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "better-auth": "^1.6.3",
         "bits-ui": "^2.16.3",
         "clsx": "^2.1.1",
@@ -95,7 +97,7 @@
     },
     "packages/app": {
       "name": "@revv/app",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "@revv/ui": "workspace:*",
         "@tanstack/react-router": "^1.168.0",
@@ -116,14 +118,14 @@
     },
     "packages/shared": {
       "name": "@revv/shared",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "devDependencies": {
         "typescript": "^5.7.0",
       },
     },
     "packages/ui": {
       "name": "@revv/ui",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.4",
@@ -886,6 +888,10 @@
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.10.0", "", { "peerDependencies": { "@xterm/xterm": "^5.0.0" } }, "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ=="],
+
+    "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "revv",
   "private": true,
-  "packageManager": "bun@1.3.4",
+  "packageManager": "bun@1.3.5",
   "workspaces": {
     "packages": [
       "apps/*",

--- a/packages/shared/src/acp-agents.ts
+++ b/packages/shared/src/acp-agents.ts
@@ -177,10 +177,32 @@ export function getAgentCapabilities(id: AcpAgentId): AcpAgentCapabilities {
 }
 
 /**
- * Which agents' local CLIs are detected on PATH (or pinned via the LaunchAgent
- * `REVV_*_BIN` env vars). Keyed by registry id so the onboarding picker renders
- * straight from `ACP_AGENTS` and a new agent surfaces an availability flag
- * automatically. Surfaced during onboarding to tag installed/not-installed and
- * to decide whether to offer the opencode install fallback when none is present.
+ * Per-agent onboarding setup status. A single detection call resolves both
+ * facts the agent step needs so the UI never races two endpoints:
+ *   - `installed` — the agent's CLI is present on PATH (or pinned via the
+ *     LaunchAgent `REVV_*_BIN` env vars), or — for the SDK/auth-store agents —
+ *     otherwise usable.
+ *   - `authed` — the user is logged in. opencode needs no login, so it always
+ *     reports `true`.
+ * `loginCommand` is the agent's official interactive login command (joined
+ * argv), surfaced so the UI can show a manual hint where the embedded PTY login
+ * isn't available; `null` for agents that need no login (opencode).
  */
-export type AgentAvailability = Record<AcpAgentId, boolean>;
+export interface AgentStatus {
+  installed: boolean;
+  authed: boolean;
+  loginCommand: string | null;
+}
+
+/**
+ * Full onboarding detection snapshot: per-agent {@link AgentStatus} keyed by
+ * registry id (so the picker renders straight from `ACP_AGENTS` and a new agent
+ * surfaces automatically), plus whether this host can drive an agent's CLI
+ * login inside an embedded pseudo-terminal. The embedded PTY is POSIX-only, so
+ * `embeddedLoginSupported` is `false` on Windows and the UI falls back to the
+ * per-agent `loginCommand` hint. The server is the single authority on this.
+ */
+export interface AgentStatusReport {
+  embeddedLoginSupported: boolean;
+  agents: Record<AcpAgentId, AgentStatus>;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,7 +4,8 @@ export type {
   AcpAgentIconKey,
   AcpAgentId,
   AcpAgentModel,
-  AgentAvailability,
+  AgentStatus,
+  AgentStatusReport,
 } from "./acp-agents";
 export {
   ACP_AGENT_IDS,
@@ -96,6 +97,7 @@ export type {
   HunkDecision,
   HunkDecisionType,
   InstallEvent,
+  LoginEvent,
   MergeEligibility,
   MergeMethod,
   MessageType,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -80,6 +80,20 @@ export type InstallEvent =
   | { type: "log"; line: string }
   | { type: "done"; success: boolean; error?: string };
 
+/**
+ * Event frames emitted over SSE while the server drives an agent's interactive
+ * CLI login inside a spawned pseudo-terminal (e.g. `codex login`,
+ * `cursor-agent login`). `data` carries a raw terminal chunk to render into an
+ * xterm instance; `auth-url` is the first `https?://…` the CLI printed (so the
+ * UI can open it in the browser); the stream closes after `done`, whose
+ * `success` reflects a fresh auth re-check. On failure the message lives in
+ * `error`. Mirrors {@link InstallEvent}'s lifecycle.
+ */
+export type LoginEvent =
+  | { type: "data"; chunk: string }
+  | { type: "auth-url"; url: string }
+  | { type: "done"; success: boolean; error?: string };
+
 export type ThemePreference = "system" | "light" | "dark";
 
 export type DiffViewMode = "unified" | "split";


### PR DESCRIPTION
Agent CLI detection now resolves against the user's **login-shell PATH** rather than the sanitized PATH a launchd/GUI-launched server inherits, and treats a logged-in Codex/Claude (auth store / Keychain) as available even with no binary on PATH; ACP subprocess launches inherit the same widened PATH so `npx`/`opencode` resolve. The onboarding agent step is generalized from a hard-coded "install opencode" flow to installing **whichever registry agent the user picks** — via a per-agent, OS-aware install registry (argv + bin dirs), a per-agent idempotent job map, generalized `POST /api/onboarding/install` and `GET /install/stream` routes, and a single picker whose CTA adapts between **Install {agent}** and **Continue**. When nothing is installed the picker pre-selects and advertises opencode (free, open-source, no sign-in). Full CI passes locally (typecheck, lint, knip, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)