### PR TITLE
fix: ACP provider auth status

### DIFF
--- a/apps/server/src/ai/acp/acp-connection.ts
+++ b/apps/server/src/ai/acp/acp-connection.ts
@@ -34,7 +34,7 @@ import {
 import type { AcpAgentId } from "@revv/shared";
 import { debug } from "../../logger";
 import { resolveUserPath } from "../providers/cli-agent";
-import { type AcpLaunchConfig, resolveAcpLaunchById } from "./presets";
+import { type AcpLaunchConfig, resolveAcpProcessLaunchById } from "./presets";
 
 const IDLE_STOP_MS = 5 * 60 * 1000;
 
@@ -170,7 +170,12 @@ async function spawnConnection(
   config: AcpLaunchConfig,
   key: string,
 ): Promise<ConnectionEntry> {
-  const { command, args, env } = resolveAcpLaunchById(agent, config);
+  const { command, args, env } = resolveAcpProcessLaunchById(
+    agent,
+    config,
+    process.env,
+    resolveUserPath(),
+  );
   const proc = Bun.spawn([command, ...args], {
     cwd,
     stdin: "pipe",
@@ -180,7 +185,7 @@ async function spawnConnection(
     // inherited environment. PATH is widened to the user's login-shell PATH so
     // `npx`/`opencode` resolve even when the server inherited a sanitized PATH
     // (launchd / GUI launch) — matching how availability is detected.
-    env: { ...process.env, ...env, PATH: resolveUserPath() },
+    env,
   });
 
   // Bun's `proc.stdin` is a FileSink; wrap it as a WritableStream<Uint8Array>

--- a/apps/server/src/ai/acp/presets.test.ts
+++ b/apps/server/src/ai/acp/presets.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { ACP_AGENTS, getAcpAgent } from "@revv/shared";
 import { serverEnv } from "../../config";
-import { resolveAcpLaunchById, resolveGenerationModel } from "./presets";
+import { ACP_LOGIN_COMMAND } from "../providers/cli-agent";
+import {
+  resolveAcpLaunchById,
+  resolveAcpProcessLaunchById,
+  resolveGenerationModel,
+} from "./presets";
 
 describe("ACP agent registry", () => {
   it("is the single source of truth — adding an agent is one registry entry", () => {
@@ -88,12 +93,53 @@ describe("ACP launch presets", () => {
     ).toBe("true");
   });
 
+  it("strips stale Anthropic API credentials when Claude subscription auth exists", () => {
+    const launch = resolveAcpProcessLaunchById(
+      "claude-code",
+      { model: "claude-sonnet-4-6" },
+      {
+        ANTHROPIC_API_KEY: "stale-api-key",
+        ANTHROPIC_AUTH_TOKEN: "stale-bearer",
+        CLAUDE_CODE_OAUTH_TOKEN: "subscription-token",
+        KEEP_ME: "yes",
+      },
+      "/usr/bin",
+      { claudeSubscriptionAuth: true },
+    );
+
+    expect(launch.command).toBe("npx");
+    expect(launch.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(launch.env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(launch.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("subscription-token");
+    expect(launch.env.ANTHROPIC_MODEL).toBe("claude-sonnet-4-6");
+    expect(launch.env.KEEP_ME).toBe("yes");
+    expect(launch.env.PATH).toBe("/usr/bin");
+  });
+
+  it("keeps Anthropic API credentials when no Claude subscription auth exists", () => {
+    const launch = resolveAcpProcessLaunchById(
+      "claude-code",
+      {},
+      { ANTHROPIC_API_KEY: "api-key" },
+      "/usr/bin",
+      { claudeSubscriptionAuth: false },
+    );
+
+    expect(launch.env.ANTHROPIC_API_KEY).toBe("api-key");
+  });
+
   it("passes the selected model to opencode acp via --model", () => {
     if (serverEnv.acpCommand) return;
     expect(resolveAcpLaunchById("opencode", { model: "anthropic/claude-sonnet-4-6" })).toEqual({
       command: "opencode",
       args: ["acp", "--model", "anthropic/claude-sonnet-4-6"],
     });
+  });
+});
+
+describe("ACP login commands", () => {
+  it("uses Claude's subscription login path", () => {
+    expect(ACP_LOGIN_COMMAND["claude-code"]).toEqual(["claude", "auth", "login", "--claudeai"]);
   });
 });
 

--- a/apps/server/src/ai/acp/presets.ts
+++ b/apps/server/src/ai/acp/presets.ts
@@ -17,13 +17,19 @@ import {
   type ThinkingEffort,
 } from "@revv/shared";
 import { serverEnv } from "../../config";
-import { isCommandOnPath } from "../providers/cli-agent";
+import { detectClaudeSubscriptionAuth, isCommandOnPath } from "../providers/cli-agent";
 
 export interface AcpLaunch {
   readonly command: string;
   readonly args: readonly string[];
   /** Extra env vars merged over `process.env` when spawning (Claude Code model/effort/context). */
   readonly env?: Readonly<Record<string, string>>;
+}
+
+export interface AcpProcessLaunch {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: Readonly<Record<string, string>>;
 }
 
 /**
@@ -36,6 +42,14 @@ export interface AcpLaunchConfig {
   readonly model?: string | undefined;
   readonly thinkingEffort?: ThinkingEffort | undefined;
   readonly contextWindow?: ContextWindow | undefined;
+}
+
+export interface AcpProcessEnvOptions {
+  /**
+   * Test seam for the Claude subscription status probe. Production leaves it
+   * undefined so subscription verification is read from the host.
+   */
+  readonly claudeSubscriptionAuth?: boolean | undefined;
 }
 
 // Revv thinking-effort tier → Codex `model_reasoning_effort`. Codex has no
@@ -119,6 +133,61 @@ export function resolveAcpLaunchById(id: AcpAgentId, config: AcpLaunchConfig = {
     command: def.command,
     args,
     ...(Object.keys(env).length > 0 ? { env } : {}),
+  };
+}
+
+/**
+ * Build the environment for an ACP subprocess. Claude Code subscription auth is
+ * fragile when a stale `ANTHROPIC_API_KEY`/`ANTHROPIC_AUTH_TOKEN` is inherited:
+ * Claude Code documents that those credentials can take precedence over a valid
+ * Pro/Max subscription and produce 401s. When subscription credentials are
+ * verified, drop the generic API credentials for the Claude ACP adapter while
+ * preserving `CLAUDE_CODE_OAUTH_TOKEN` and all Revv model/context overrides.
+ */
+function buildAcpProcessEnv(
+  id: AcpAgentId,
+  inheritedEnv: Readonly<Record<string, string | undefined>>,
+  launchEnv: Readonly<Record<string, string>> | undefined,
+  path: string,
+  options: AcpProcessEnvOptions = {},
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(inheritedEnv)) {
+    if (value !== undefined) env[key] = value;
+  }
+
+  const hasClaudeSubscriptionAuth =
+    options.claudeSubscriptionAuth ?? (id === "claude-code" && detectClaudeSubscriptionAuth());
+  if (id === "claude-code" && hasClaudeSubscriptionAuth) {
+    delete env.ANTHROPIC_API_KEY;
+    delete env.ANTHROPIC_AUTH_TOKEN;
+  }
+
+  return {
+    ...env,
+    ...(launchEnv ?? {}),
+    PATH: path,
+  };
+}
+
+/**
+ * Resolve a complete subprocess launch for an ACP agent. The connection layer
+ * intentionally calls this instead of composing env itself: all per-adapter
+ * launch quirks stay in this preset module, while `acp-connection` remains a
+ * transport/pool implementation.
+ */
+export function resolveAcpProcessLaunchById(
+  id: AcpAgentId,
+  config: AcpLaunchConfig,
+  inheritedEnv: Readonly<Record<string, string | undefined>>,
+  path: string,
+  options: AcpProcessEnvOptions = {},
+): AcpProcessLaunch {
+  const launch = resolveAcpLaunchById(id, config);
+  return {
+    command: launch.command,
+    args: launch.args,
+    env: buildAcpProcessEnv(id, inheritedEnv, launch.env, path, options),
   };
 }
 

--- a/apps/server/src/ai/providers/cli-agent.ts
+++ b/apps/server/src/ai/providers/cli-agent.ts
@@ -41,6 +41,10 @@ import { CLI_CACHE_TTL_MS } from "../../constants";
 // filesystem probe.
 
 type CliAgent = "opencode" | "claude" | "codex";
+type AgentAuthStatus = Pick<
+  AgentStatus,
+  "authed" | "verified" | "authSource" | "authLabel" | "authWarning"
+>;
 
 let cachedPath: { value: string; expiresAt: number } | null = null;
 
@@ -98,6 +102,33 @@ function pinnedBin(agent: CliAgent): string {
   return pinned && existsSync(pinned) ? pinned : "";
 }
 
+function statusCommandEnv(omit: readonly string[] = []): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    PATH: resolveUserPath(),
+  };
+  for (const key of omit) delete env[key];
+  return env;
+}
+
+function commandStatusOk(
+  command: string,
+  args: readonly string[],
+  env = statusCommandEnv(),
+): boolean {
+  try {
+    execFileSync(command, args, {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      env,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /** Codex's config/auth dir — `$CODEX_HOME`, else `~/.codex`. */
 function codexHome(): string {
   const fromEnv = process.env.CODEX_HOME?.trim();
@@ -109,15 +140,81 @@ function codexLoggedIn(): boolean {
   return existsSync(join(codexHome(), "auth.json"));
 }
 
+function codexLoginVerified(): boolean {
+  return commandStatusOk(resolveCliBin("codex"), ["login", "status"]);
+}
+
+function codexAuthStatus(): AgentAuthStatus {
+  const hasLogin = codexLoggedIn();
+  const hasApiKey = !!process.env.OPENAI_API_KEY?.trim();
+  const verified = codexLoginVerified();
+  if (hasLogin && hasApiKey) {
+    return {
+      authed: true,
+      verified,
+      authSource: "local-credentials",
+      authLabel: verified ? "Codex login + OpenAI API key" : "Codex credentials configured",
+      authWarning:
+        "Both Codex login and OPENAI_API_KEY are present; provider precedence is owned by Codex.",
+    };
+  }
+  if (hasLogin) {
+    if (!verified) {
+      return {
+        authed: false,
+        verified: false,
+        authSource: "local-credentials",
+        authLabel: "Codex sign-in expired",
+        authWarning:
+          "Codex credential artifacts exist, but Codex login status does not confirm an active session. Sign in again with Codex.",
+      };
+    }
+    return {
+      authed: true,
+      verified: true,
+      authSource: "local-credentials",
+      authLabel: "Codex login",
+      authWarning: null,
+    };
+  }
+  if (hasApiKey) {
+    return {
+      authed: true,
+      verified,
+      authSource: "api-key",
+      authLabel: verified ? "OpenAI API key verified" : "OpenAI API key configured",
+      authWarning: verified
+        ? null
+        : "Revv found OPENAI_API_KEY, but Codex login status did not verify it without starting a generation.",
+    };
+  }
+  if (verified) {
+    return {
+      authed: true,
+      verified: true,
+      authSource: "local-credentials",
+      authLabel: "Codex login",
+      authWarning: null,
+    };
+  }
+  return {
+    authed: false,
+    verified: false,
+    authSource: "none",
+    authLabel: "Not signed in",
+    authWarning: null,
+  };
+}
+
 /**
- * Whether Claude Code is authenticated. The `claude-agent-acp` adapter runs on
- * the Claude Agent SDK (not the `claude` binary), so a logged-in user is usable
- * without the CLI on PATH. The SDK accepts, in order: an `ANTHROPIC_API_KEY`
- * env var; the OAuth creds Claude Code writes to `~/.claude/.credentials.json`
- * (Linux/other); or, on macOS, the same creds stored in the login Keychain.
+ * Whether Claude Code has subscription/OAuth credentials available. The
+ * `claude-agent-acp` adapter runs on the Claude Agent SDK, so a logged-in user
+ * is usable without the CLI on PATH. Subscription auth can come from a
+ * long-lived OAuth token, the credentials file Claude Code writes, or the macOS
+ * Keychain.
  */
-function claudeLoggedIn(): boolean {
-  if (process.env.ANTHROPIC_API_KEY?.trim()) return true;
+function detectClaudeSubscriptionAuthHint(): boolean {
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN?.trim()) return true;
   if (existsSync(join(homedir(), ".claude", ".credentials.json"))) return true;
   if (platform() === "darwin") {
     try {
@@ -132,6 +229,87 @@ function claudeLoggedIn(): boolean {
     }
   }
   return false;
+}
+
+function claudeSubscriptionVerified(): boolean {
+  try {
+    const out = execFileSync(resolveCliBin("claude"), ["auth", "status", "--json"], {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+      env: statusCommandEnv(["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"]),
+    }).trim();
+    if (!out) return true;
+    const parsed = JSON.parse(out) as { loggedIn?: unknown };
+    return parsed.loggedIn === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether Claude Code subscription/OAuth auth is verified by Claude's own CLI
+ * status command. Credential artifacts alone are intentionally not enough:
+ * logout can leave files/keychain records behind even though launches fail with
+ * "Authentication required".
+ */
+export function detectClaudeSubscriptionAuth(): boolean {
+  return claudeSubscriptionVerified();
+}
+
+function claudeApiCredentialsConfigured(): boolean {
+  return !!(process.env.ANTHROPIC_API_KEY?.trim() || process.env.ANTHROPIC_AUTH_TOKEN?.trim());
+}
+
+function claudeLoggedIn(): boolean {
+  return claudeSubscriptionVerified() || claudeApiCredentialsConfigured();
+}
+
+function claudeAuthStatus(): AgentAuthStatus {
+  const hasSubscriptionHint = detectClaudeSubscriptionAuthHint();
+  const hasVerifiedSubscription = claudeSubscriptionVerified();
+  const hasApiCredentials = claudeApiCredentialsConfigured();
+  if (hasVerifiedSubscription) {
+    return {
+      authed: true,
+      verified: true,
+      authSource: "subscription",
+      authLabel: hasApiCredentials
+        ? "Claude subscription (API key ignored by Revv)"
+        : "Claude subscription",
+      authWarning: hasApiCredentials
+        ? "ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN is also present. Revv strips it for Claude ACP so the subscription is used."
+        : null,
+    };
+  }
+  if (hasApiCredentials) {
+    return {
+      authed: true,
+      verified: false,
+      authSource: "api-key",
+      authLabel: "Anthropic API key configured",
+      authWarning: hasSubscriptionHint
+        ? "Claude Code sign-in is not active. Revv will keep Anthropic API credentials instead of treating the stale Claude session as connected."
+        : null,
+    };
+  }
+  if (hasSubscriptionHint) {
+    return {
+      authed: false,
+      verified: false,
+      authSource: "subscription",
+      authLabel: "Claude sign-in expired",
+      authWarning:
+        "Claude credential artifacts exist, but Claude reports authentication is required. Sign in again with Claude Code.",
+    };
+  }
+  return {
+    authed: false,
+    verified: false,
+    authSource: "none",
+    authLabel: "Not signed in",
+    authWarning: null,
+  };
 }
 
 /**
@@ -160,6 +338,79 @@ function cursorLoggedIn(): boolean {
   return candidates.some((p) => existsSync(p));
 }
 
+function cursorLoginVerified(): boolean {
+  return commandStatusOk(resolveCommandPath("cursor-agent") ?? "cursor-agent", ["status"]);
+}
+
+function cursorAuthStatus(): AgentAuthStatus {
+  const verified = cursorLoginVerified();
+  if (process.env.CURSOR_API_KEY?.trim()) {
+    return {
+      authed: true,
+      verified,
+      authSource: "api-key",
+      authLabel: verified ? "Cursor API key verified" : "Cursor API key configured",
+      authWarning: verified
+        ? null
+        : "Revv found CURSOR_API_KEY, but Cursor status did not verify it without starting a generation.",
+    };
+  }
+  if (cursorLoggedIn()) {
+    if (!verified) {
+      return {
+        authed: false,
+        verified: false,
+        authSource: "local-credentials",
+        authLabel: "Cursor sign-in expired",
+        authWarning:
+          "Cursor credential artifacts exist, but Cursor status does not confirm an active session. Sign in again with Cursor.",
+      };
+    }
+    return {
+      authed: true,
+      verified: true,
+      authSource: "local-credentials",
+      authLabel: "Cursor login",
+      authWarning: null,
+    };
+  }
+  if (verified) {
+    return {
+      authed: true,
+      verified: true,
+      authSource: "local-credentials",
+      authLabel: "Cursor login",
+      authWarning: null,
+    };
+  }
+  return {
+    authed: false,
+    verified: false,
+    authSource: "none",
+    authLabel: "Not signed in",
+    authWarning: null,
+  };
+}
+
+function agentAuthStatus(agent: AcpAgentId): AgentAuthStatus {
+  switch (agent) {
+    case "opencode":
+      return {
+        authed: true,
+        verified: true,
+        authSource: "not-required",
+        authLabel: "No sign-in required",
+        authWarning: null,
+      };
+    case "claude-code":
+      return claudeAuthStatus();
+    case "codex":
+      return codexAuthStatus();
+    case "cursor":
+      return cursorAuthStatus();
+  }
+}
+
 /**
  * Whether the given registry agent is *authenticated* (logged in), independent
  * of whether its CLI is on PATH. Onboarding uses this to distinguish
@@ -168,16 +419,7 @@ function cursorLoggedIn(): boolean {
  * reports authed.
  */
 export function detectAgentAuth(agent: AcpAgentId): boolean {
-  switch (agent) {
-    case "opencode":
-      return true;
-    case "claude-code":
-      return claudeLoggedIn();
-    case "codex":
-      return codexLoggedIn();
-    case "cursor":
-      return cursorLoggedIn();
-  }
+  return agentAuthStatus(agent).authed;
 }
 
 /**
@@ -270,8 +512,10 @@ export const ACP_CLI_NAME: Record<AcpAgentId, "opencode" | "claude" | "codex" | 
  * Each is a dedicated, exit-after-auth login subcommand (verified against the
  * vendors' published CLI docs + the installed binaries' `--help`), so the
  * login flow's "spawn → wait for exit → re-check auth" model holds:
- *   - claude-code: `claude auth login`  (`/login` is the in-REPL slash command,
- *     NOT a CLI subcommand).
+ *   - claude-code: `claude auth login --claudeai`  (`/login` is the in-REPL
+ *     slash command, NOT a CLI subcommand). The explicit `--claudeai` matters:
+ *     Revv's Claude path is meant to use the user's Claude subscription, while
+ *     `--console` is the API-billing path.
  *   - codex:       `codex login`.
  *   - cursor:      `cursor-agent login` (the docs alias the binary as `agent`,
  *     but the installed binary — and our `ACP_CLI_NAME.cursor` key — is
@@ -282,10 +526,28 @@ export const ACP_CLI_NAME: Record<AcpAgentId, "opencode" | "claude" | "codex" | 
  */
 export const ACP_LOGIN_COMMAND: Record<AcpAgentId, readonly string[] | null> = {
   opencode: null,
-  "claude-code": ["claude", "auth", "login"],
+  "claude-code": ["claude", "auth", "login", "--claudeai"],
   codex: ["codex", "login"],
   cursor: ["cursor-agent", "login"],
 };
+
+/**
+ * Resolve the login command's argv[0] through the same pinned-bin / login-shell
+ * PATH chain used by runtime launches. This keeps the embedded login terminal
+ * working in packaged app launches where `claude`/`codex` are not on the
+ * sanitized process PATH.
+ */
+export function resolveAgentLoginCommand(agent: AcpAgentId): readonly string[] | null {
+  const argv = ACP_LOGIN_COMMAND[agent];
+  if (!argv) return null;
+  const [command, ...args] = argv;
+  if (!command) return argv;
+
+  const cli = ACP_CLI_NAME[agent];
+  const resolved =
+    cli === "cursor-agent" ? (resolveCommandPath(cli) ?? command) : resolveCliBin(cli);
+  return [resolved, ...args];
+}
 
 /** Whether the given registry agent's CLI is present (or otherwise usable). */
 export function detectAgentCli(agent: AcpAgentId): boolean {
@@ -303,11 +565,12 @@ export function detectAgentStatus(): AgentStatusReport {
   const agents = Object.fromEntries(
     ACP_AGENT_IDS.map((id) => {
       const cmd = ACP_LOGIN_COMMAND[id];
+      const auth = agentAuthStatus(id);
       return [
         id,
         {
           installed: detectAgentCli(id),
-          authed: detectAgentAuth(id),
+          ...auth,
           loginCommand: cmd ? cmd.join(" ") : null,
         } satisfies AgentStatus,
       ];

--- a/apps/server/src/services/AgentLogin.ts
+++ b/apps/server/src/services/AgentLogin.ts
@@ -2,9 +2,9 @@ import { platform } from "node:os";
 import type { AcpAgentId, LoginEvent } from "@revv/shared";
 import { Context, Effect, Layer } from "effect";
 import {
-  ACP_LOGIN_COMMAND,
   detectAgentAuth,
   invalidateCliAgentCache,
+  resolveAgentLoginCommand,
   resolveUserPath,
 } from "../ai/providers/cli-agent";
 import { debug, logError } from "../logger";
@@ -106,7 +106,7 @@ export const AgentLoginServiceLive = Layer.effect(
     };
 
     const spawnLogin = (job: LoginJob, broadcast: (event: LoginEvent) => void): void => {
-      const argv = ACP_LOGIN_COMMAND[job.agentId];
+      const argv = resolveAgentLoginCommand(job.agentId);
       if (!argv) {
         // No login needed (opencode) — succeed immediately and idempotently.
         broadcast({ type: "done", success: true });

--- a/apps/web/src/lib/components/layout/AgentSelector.svelte
+++ b/apps/web/src/lib/components/layout/AgentSelector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { ACP_AGENTS, type AcpAgentId } from "@revv/shared";
+import { ACP_AGENTS, type AcpAgentId, type AgentStatus } from "@revv/shared";
 import Check from "phosphor-svelte/lib/Check";
 import { acpAgentIcon } from "$lib/components/icons/acpAgentIcon";
 import {
@@ -9,7 +9,9 @@ import {
 } from "$lib/components/ui/popover/index.js";
 import {
   cascadeChatAgentChange,
+  fetchAgentStatus,
   fetchModels,
+  getAgentStatus,
   getSettings,
   resolveChatAgentId,
   updateSettings,
@@ -23,6 +25,34 @@ let currentId = $derived(resolveChatAgentId(getSettings()));
 let current = $derived(ACP_AGENTS.find((a) => a.id === currentId));
 let currentLabel = $derived(current?.label ?? "Agent");
 let CurrentIcon = $derived(acpAgentIcon(current?.icon ?? "generic"));
+let status = $state(getAgentStatus());
+let currentStatus = $derived(status?.agents[currentId] ?? null);
+
+$effect(() => {
+  if (!open) return;
+  void refreshStatus();
+});
+
+async function refreshStatus(): Promise<void> {
+  status = await fetchAgentStatus();
+}
+
+function isReady(s: AgentStatus | null | undefined): boolean {
+  return !!s?.installed && s.authed;
+}
+
+function statusLabel(s: AgentStatus | null | undefined): string {
+  if (!s) return "Not checked";
+  if (!s.installed) return "Not installed";
+  if (!s.authed) return "Needs sign-in";
+  return s.authLabel;
+}
+
+function statusDotClass(s: AgentStatus | null | undefined): string {
+  if (!s) return "bg-text-muted";
+  if (isReady(s) && s.verified) return "bg-success";
+  return "bg-warning";
+}
 
 function select(id: AcpAgentId) {
   // opencode's catalog is dynamic — kick off a fetch so the cascade can pick a
@@ -37,20 +67,25 @@ function select(id: AcpAgentId) {
 	<PopoverTrigger>
 		<SelectTrigger label={currentLabel}>
 			{#snippet icon()}
-				<div class="h-1.5 w-1.5 rounded-full bg-accent"></div>
+				<div class={`h-1.5 w-1.5 rounded-full ${statusDotClass(currentStatus)}`}></div>
 				<CurrentIcon size={12} class="text-text-muted" />
 			{/snippet}
 		</SelectTrigger>
 	</PopoverTrigger>
-	<PopoverContent class="w-40 p-1" align="start" side="top">
+	<PopoverContent class="w-64 p-1" align="start" side="top">
 		{#each ACP_AGENTS as opt (opt.id)}
 			{@const OptIcon = acpAgentIcon(opt.icon)}
+			{@const optStatus = status?.agents[opt.id] ?? null}
 			<button
 				class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-text-secondary transition-colors hover:bg-bg-tertiary"
 				onclick={() => select(opt.id)}
 			>
 				<OptIcon size={12} class="text-text-muted" />
-				<span class="flex-1 text-left">{opt.label}</span>
+				<span class={`h-1.5 w-1.5 shrink-0 rounded-full ${statusDotClass(optStatus)}`}></span>
+				<span class="min-w-0 flex-1 text-left">
+					<span class="block truncate text-text-primary">{opt.label}</span>
+					<span class="block truncate text-[11px] text-text-muted">{statusLabel(optStatus)}</span>
+				</span>
 				{#if currentId === opt.id}
 					<Check size={12} weight="regular" class="text-accent" />
 				{/if}

--- a/apps/web/src/lib/components/settings/SettingsModal.svelte
+++ b/apps/web/src/lib/components/settings/SettingsModal.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-import { ACP_AGENTS, type RecapAgentChoice, type Repository } from "@revv/shared";
+import {
+  ACP_AGENTS,
+  type AgentStatus,
+  type AgentStatusReport,
+  type RecapAgentChoice,
+  type Repository,
+} from "@revv/shared";
 import { Dialog as DialogPrimitive } from "bits-ui";
 import RotateCcw from "phosphor-svelte/lib/ArrowCounterClockwise";
 import ExternalLink from "phosphor-svelte/lib/ArrowSquareOut";
@@ -29,7 +35,9 @@ import { Switch } from "$lib/components/ui/switch";
 import { getUser, removeAccount, resetOnboarding, signOut } from "$lib/stores/auth.svelte";
 import { deleteRepo, getRepositories } from "$lib/stores/prs.svelte";
 import {
+  fetchAgentStatus,
   fetchModels,
+  getAgentStatus,
   getAvailableModels,
   getSettings,
   updateSettings,
@@ -297,10 +305,14 @@ const intervalOptions = [
 // ── AI Configuration ──────────────────────────────────────────────────────
 let aiConfigured = $state(false);
 let aiStatusLoading = $state(true);
+let providerStatus = $state<AgentStatusReport | null>(getAgentStatus());
+let providerStatusLoading = $state(false);
 // Agent / review-model / context-window / thinking-effort are configured from
 // the chat bottom bar (capability-driven per the selected ACP agent); the
 // settings modal only keeps the low-cost suggestions model + limits.
 let aiAgent = $derived(getSettings()?.aiAgent ?? "opencode");
+let currentAgent = $derived(ACP_AGENTS.find((a) => a.id === aiAgent));
+let currentAgentStatus = $derived(providerStatus?.agents[aiAgent] ?? null);
 let modelOptions = $derived(getAvailableModels(aiAgent));
 let currentSuggestionsModel = $derived(getSettings()?.aiSuggestionsModel ?? "");
 let currentSuggestionsModelLabel = $derived(
@@ -310,6 +322,7 @@ let currentSuggestionsModelLabel = $derived(
 $effect(() => {
   if (open) {
     fetchAiStatus();
+    void refreshProviderStatus();
     // Populate the suggestions-model dropdown for the current agent (boot
     // prefetch usually covers this; this backstops a cold cache).
     void fetchModels(aiAgent);
@@ -331,6 +344,31 @@ async function fetchAiStatus(): Promise<void> {
   } finally {
     aiStatusLoading = false;
   }
+}
+
+async function refreshProviderStatus(): Promise<void> {
+  providerStatusLoading = true;
+  try {
+    providerStatus = await fetchAgentStatus();
+  } finally {
+    providerStatusLoading = false;
+  }
+}
+
+function providerReady(s: AgentStatus | null | undefined): boolean {
+  return !!s?.installed && s.authed;
+}
+
+function providerStatusText(s: AgentStatus | null | undefined): string {
+  if (!s) return "Not checked";
+  if (!s.installed) return "Agent not installed";
+  if (!s.authed) return "Needs sign-in";
+  return s.authLabel;
+}
+
+function providerStateLabel(s: AgentStatus | null | undefined): string {
+  if (!providerReady(s)) return "Action needed";
+  return s?.verified ? "Connected" : "Configured";
 }
 
 // ── Max turns ─────────────────────────────────────────────────────────────
@@ -535,6 +573,51 @@ const themeOptions: { value: ThemePreference; label: string; icon: typeof Sun }[
 			<!-- AI Configuration -->
 			<section id="section-ai" class="settings-section">
 				<h2 class="section-head-title">AI Configuration</h2>
+
+				<div class="settings-subgroup">
+					<h3 class="settings-subgroup-heading">Provider</h3>
+
+					<div class="settings-row">
+						<div class="settings-row-info">
+							<p class="settings-row-label">{currentAgent?.label ?? 'Agent'}</p>
+							<p class="settings-row-hint">
+								{#if providerStatusLoading}
+									Checking provider connection…
+								{:else}
+									{providerStatusText(currentAgentStatus)}
+								{/if}
+							</p>
+							{#if currentAgentStatus?.authWarning}
+								<p class="provider-warning">
+									<TriangleAlert size={12} weight="fill" />
+									<span>{currentAgentStatus.authWarning}</span>
+								</p>
+							{/if}
+						</div>
+						<div class="provider-status-action">
+							<div class="status-line">
+								{#if providerStatusLoading}
+									<Loader2 size={11} weight="regular" class="motion-essential-spin text-text-muted" />
+									<span class="status-line-text">Checking</span>
+								{:else if providerReady(currentAgentStatus)}
+									<span
+										class="status-line-dot"
+										class:status-line-dot--success={currentAgentStatus?.verified}
+										class:status-line-dot--warning={!currentAgentStatus?.verified}
+										aria-hidden="true"
+									></span>
+									<span class="status-line-text">{providerStateLabel(currentAgentStatus)}</span>
+								{:else}
+									<span class="status-line-dot status-line-dot--warning" aria-hidden="true"></span>
+									<span class="status-line-text">Action needed</span>
+								{/if}
+							</div>
+							<Button variant="ghost" size="sm" onclick={refreshProviderStatus} disabled={providerStatusLoading} class="text-xs">
+								Check again
+							</Button>
+						</div>
+					</div>
+				</div>
 
 				<!-- Suggestions model (agent, review model, context window, and thinking
 				     effort are configured from the chat bottom bar). -->
@@ -1394,6 +1477,24 @@ const themeOptions: { value: ThemePreference; label: string; icon: typeof Sun }[
 
 	.status-line-dot--warning {
 		background: var(--color-warning);
+	}
+
+	.provider-status-action {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		flex-shrink: 0;
+	}
+
+	.provider-warning {
+		margin-top: 6px;
+		display: flex;
+		align-items: flex-start;
+		gap: 6px;
+		max-width: 440px;
+		font-size: 11px;
+		line-height: 1.45;
+		color: var(--color-warning);
 	}
 
 	/* ── Probe result (test connection feedback) ── */

--- a/packages/shared/src/acp-agents.ts
+++ b/packages/shared/src/acp-agents.ts
@@ -182,8 +182,9 @@ export function getAgentCapabilities(id: AcpAgentId): AcpAgentCapabilities {
  *   - `installed` — the agent's CLI is present on PATH (or pinned via the
  *     LaunchAgent `REVV_*_BIN` env vars), or — for the SDK/auth-store agents —
  *     otherwise usable.
- *   - `authed` — the user is logged in. opencode needs no login, so it always
- *     reports `true`.
+ *   - `authed` — usable credentials are configured. opencode needs no login,
+ *     so it always reports `true`.
+ *   - `verified` — the provider's own status command confirmed the session.
  * `loginCommand` is the agent's official interactive login command (joined
  * argv), surfaced so the UI can show a manual hint where the embedded PTY login
  * isn't available; `null` for agents that need no login (opencode).
@@ -191,6 +192,22 @@ export function getAgentCapabilities(id: AcpAgentId): AcpAgentCapabilities {
 export interface AgentStatus {
   installed: boolean;
   authed: boolean;
+  /**
+   * `true` only when the provider's own status command confirms the session.
+   * Env keys and credential files can make an agent usable, but they are
+   * reported as configured rather than verified unless the provider can prove
+   * the connection without starting a generation.
+   */
+  verified: boolean;
+  authSource:
+    | "none"
+    | "not-required"
+    | "subscription"
+    | "api-key"
+    | "local-credentials"
+    | "unknown";
+  authLabel: string;
+  authWarning: string | null;
   loginCommand: string | null;
 }
 


### PR DESCRIPTION
This fixes ACP provider readiness so the UI distinguishes configured credentials from a verified live connection. Claude Code, Codex, and Cursor now use their provider status commands, stale credential artifacts surface as sign-in-expired/action-needed states, and opencode remains verified when available because it needs no login. Claude ACP launches now strip inherited Anthropic API credentials only when Claude subscription auth is actually verified, while the provider picker/settings UI shows auth source, warnings, and Connected vs Configured state. Validated with `bun test apps/server/src/ai/acp/presets.test.ts` and `bun run typecheck && bun run lint && bun run knip && bun run build`.