### PR TITLE
fix: persist DB in app-data dir so updates don't reset onboarding

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -24,7 +24,15 @@ import { Config, Effect } from "effect";
 export const ServerConfig = Config.all({
   port: Config.integer("PORT").pipe(Config.withDefault(API_PORT)),
   channel: Config.string("REVV_CHANNEL").pipe(Config.withDefault(DEFAULT_APP_CHANNEL)),
-  dbPath: Config.string("REVV_DB_PATH").pipe(Config.withDefault("./revv.db")),
+  // SQLite location. Empty (the default) means "auto-resolve to the per-user
+  // app-data dir" (`<appDataDir>/revv.db`) — the same durable tree as
+  // `auth.key` and the secret store, so the DB survives app updates. The old
+  // cwd-relative `./revv.db` default parked the file inside the launchd
+  // WorkingDirectory / git checkout and orphaned it on every update, forcing a
+  // full re-onboarding. `REVV_DB_PATH` overrides for dev/CI/self-hosting.
+  // Resolution lives in `db/index.ts` (`resolveDbPath`) to avoid a config↔paths
+  // import cycle.
+  dbPath: Config.string("REVV_DB_PATH").pipe(Config.withDefault("")),
   // Build edition. `oss` (default) authenticates via the classic OAuth App
   // with the coarse `repo` scope, bring-your-own-credentials, for self-hosting.
   // `pro` authenticates via the Revv GitHub App (fine-grained permissions,

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -53,13 +53,20 @@ function relocateLegacyDb(targetPath: string): void {
   console.log(`[db] Migrated database ${legacy} → ${targetPath}`);
 }
 
-/** Best-effort restriction of the DB file to owner-only. */
+/**
+ * Best-effort restriction of the DB file — and its WAL/SHM sidecars, which
+ * hold committed-but-uncheckpointed rows (session tokens included) — to
+ * owner-only. Sidecars only exist once WAL mode is active and a write has
+ * occurred, so call this *after* migrations run.
+ */
 function hardenDbFile(dbPath: string): void {
   if (dbPath === ":memory:" || dbPath === "") return;
-  try {
-    chmodSync(dbPath, DB_FILE_MODE);
-  } catch {
-    // Best-effort; the 0700 parent dir is the real backstop.
+  for (const file of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    try {
+      if (existsSync(file)) chmodSync(file, DB_FILE_MODE);
+    } catch {
+      // Best-effort; the 0700 parent dir is the real backstop.
+    }
   }
 }
 
@@ -276,7 +283,6 @@ export function createDb(path?: string) {
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
 
   const sqlite = new Database(dbPath, { create: true });
-  hardenDbFile(dbPath);
   sqlite.run("PRAGMA journal_mode = WAL");
   sqlite.run("PRAGMA foreign_keys = ON");
   sqlite.run("PRAGMA busy_timeout = 5000");
@@ -302,19 +308,20 @@ export function createDb(path?: string) {
     }
 
     const fresh = new Database(dbPath, { create: true });
-    hardenDbFile(dbPath);
     fresh.run("PRAGMA journal_mode = WAL");
     fresh.run("PRAGMA foreign_keys = ON");
     fresh.run("PRAGMA busy_timeout = 5000");
     const db = drizzle(fresh, { schema });
     migrate(db, { migrationsFolder: fileURLToPath(new URL("./migrations", import.meta.url)) });
     insertData(db, data);
+    hardenDbFile(dbPath);
     return db;
   }
 
   // ── Normal path ──────────────────────────────────────────
   const db = drizzle(sqlite, { schema });
   migrate(db, { migrationsFolder: fileURLToPath(new URL("./migrations", import.meta.url)) });
+  hardenDbFile(dbPath);
   return db;
 }
 

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -1,11 +1,67 @@
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, renameSync } from "node:fs";
-import { dirname } from "node:path";
+import { chmodSync, existsSync, mkdirSync, renameSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 import { serverEnv } from "../config";
+import { appDataDir } from "../paths";
 import * as schema from "./schema";
+
+// The DB may hold session bearer tokens; keep it owner-only. The enclosing
+// app-data dir is already 0700, but this is a defensive backstop in case
+// REVV_DB_PATH points somewhere with looser parent permissions.
+const DB_FILE_MODE = 0o600;
+
+/**
+ * Resolve the SQLite path. Precedence:
+ *   1. explicit `path` arg (tests pass `:memory:`)
+ *   2. `REVV_DB_PATH` env override (`serverEnv.dbPath`, non-empty)
+ *   3. default: `<appDataDir>/revv.db`
+ *
+ * The default lives here rather than in `config.ts` because `appDataDir()`
+ * reads `serverEnv`, and computing it inside the `Config` schema would form a
+ * `config → paths → config` import cycle evaluated before `serverEnv` exists.
+ */
+export function resolveDbPath(explicit?: string): string {
+  if (explicit) return explicit;
+  if (serverEnv.dbPath) return serverEnv.dbPath;
+  return join(appDataDir(), "revv.db");
+}
+
+/**
+ * One-time migration of a pre-existing DB from the legacy cwd-relative
+ * location (`<cwd>/revv.db` — historically the launchd WorkingDirectory / git
+ * checkout) into the canonical app-data location. Moves the WAL/SHM sidecars
+ * too so no uncommitted transactions — or session tokens — are left behind.
+ * No-op once the canonical DB exists or when already running from the
+ * canonical location.
+ */
+function relocateLegacyDb(targetPath: string): void {
+  if (targetPath === ":memory:" || targetPath === "") return;
+  const legacy = resolve(process.cwd(), "revv.db");
+  if (legacy === targetPath) return; // already canonical
+  if (existsSync(targetPath)) return; // canonical DB wins; leave legacy in place
+  if (!existsSync(legacy)) return; // nothing to migrate
+
+  mkdirSync(dirname(targetPath), { recursive: true, mode: 0o700 });
+  renameSync(legacy, targetPath);
+  for (const ext of ["-wal", "-shm"]) {
+    const from = `${legacy}${ext}`;
+    if (existsSync(from)) renameSync(from, `${targetPath}${ext}`);
+  }
+  console.log(`[db] Migrated database ${legacy} → ${targetPath}`);
+}
+
+/** Best-effort restriction of the DB file to owner-only. */
+function hardenDbFile(dbPath: string): void {
+  if (dbPath === ":memory:" || dbPath === "") return;
+  try {
+    chmodSync(dbPath, DB_FILE_MODE);
+  } catch {
+    // Best-effort; the 0700 parent dir is the real backstop.
+  }
+}
 
 // ── Pre-squash recovery ─────────────────────────────────────
 // TODO(2026-05-17): Revv squashed 21 incremental migrations into 4.
@@ -210,12 +266,17 @@ function insertData(freshDb: ReturnType<typeof drizzle>, d: Recovered) {
 }
 
 export function createDb(path?: string) {
-  const dbPath = path ?? serverEnv.dbPath;
+  const dbPath = resolveDbPath(path);
+
+  // Move a legacy cwd-relative DB into place before opening, so existing
+  // installs keep their onboarding/settings across the update that ships this.
+  relocateLegacyDb(dbPath);
 
   const dir = dirname(dbPath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
 
   const sqlite = new Database(dbPath, { create: true });
+  hardenDbFile(dbPath);
   sqlite.run("PRAGMA journal_mode = WAL");
   sqlite.run("PRAGMA foreign_keys = ON");
   sqlite.run("PRAGMA busy_timeout = 5000");
@@ -241,6 +302,7 @@ export function createDb(path?: string) {
     }
 
     const fresh = new Database(dbPath, { create: true });
+    hardenDbFile(dbPath);
     fresh.run("PRAGMA journal_mode = WAL");
     fresh.run("PRAGMA foreign_keys = ON");
     fresh.run("PRAGMA busy_timeout = 5000");

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -4,6 +4,7 @@ import { Elysia } from "elysia";
 import { stopAllAcpConnections } from "./ai/acp/acp-connection";
 import { auth } from "./auth";
 import { serverEnv } from "./config";
+import { resolveDbPath } from "./db/index";
 import { logError } from "./logger";
 import { recordSpan } from "./observability/tracer";
 import { chatRoute } from "./routes/chat";
@@ -42,7 +43,7 @@ import { acquireSingleInstance } from "./singleInstance";
 // (revv.db) environments stay independent.  If a stale instance is found it
 // is SIGTERM'd (then SIGKILL'd after 3 s) before we bind the port.
 const port = serverEnv.port;
-const releasePidFile = acquireSingleInstance(`${serverEnv.dbPath}.${serverEnv.channel}.pid`);
+const releasePidFile = acquireSingleInstance(`${resolveDbPath()}.${serverEnv.channel}.pid`);
 
 logError("server", `starting on port ${port}`);
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -635,6 +635,8 @@ write_launch_agent_plist() {
         <string>prod</string>
         <key>PORT</key>
         <string>45678</string>
+        <key>REVV_DB_PATH</key>
+        <string>${REVV_SUPPORT_DIR}/revv.db</string>
         <key>REVV_CLAUDE_BIN</key>
         <string>$claude_bin</string>
         <key>REVV_OPENCODE_BIN</key>


### PR DESCRIPTION
The SQLite DB defaulted to a cwd-relative `./revv.db`, which parked it inside the launchd WorkingDirectory / git checkout and got orphaned on every app update — forcing users to redo the entire onboarding. This resolves the DB to the durable per-user app-data dir (`<appDataDir>/revv.db`, the same tree as `auth.key` and the secret store) by default, with `REVV_DB_PATH` still overriding for dev/CI/self-hosting. A one-time startup relocation moves any legacy cwd DB (plus its WAL/SHM sidecars) into place so existing installs keep their onboarding and settings across the update. The DB file is now hardened to `0600` in a `0700` dir, the single-instance pid file is keyed off the resolved path, and the LaunchAgent plist sets `REVV_DB_PATH` explicitly as a belt-and-suspenders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)