### PR TITLE
fix(acp): inject stored agent credentials so packaged installs authenticate

### DIFF
--- a/apps/server/src/ai/acp/presets.test.ts
+++ b/apps/server/src/ai/acp/presets.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { ACP_AGENTS, getAcpAgent } from "@revv/shared";
 import { serverEnv } from "../../config";
 import { ACP_LOGIN_COMMAND } from "../providers/cli-agent";
 import {
+  agentCredentialsMissing,
   resolveAcpLaunchById,
   resolveAcpProcessLaunchById,
   resolveGenerationModel,
+  setAgentCredentialCache,
+  withAgentAuthHint,
 } from "./presets";
 
 describe("ACP agent registry", () => {
@@ -140,6 +143,126 @@ describe("ACP launch presets", () => {
 describe("ACP login commands", () => {
   it("uses Claude's subscription login path", () => {
     expect(ACP_LOGIN_COMMAND["claude-code"]).toEqual(["claude", "auth", "login", "--claudeai"]);
+  });
+});
+// Injection and the missing-credential guard both read ambient env, so isolate
+// every test in these blocks from the runner's real credentials and reset the
+// module-level cache afterward (otherwise it would leak into the strict
+// `toEqual` env test above).
+function isolateAgentCredentials(): void {
+  const saved: Record<string, string | undefined> = {
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  };
+
+  beforeEach(() => {
+    for (const key of Object.keys(saved)) delete process.env[key];
+    setAgentCredentialCache({});
+  });
+
+  afterEach(() => {
+    setAgentCredentialCache({});
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+}
+
+describe("ACP agent credential injection", () => {
+  isolateAgentCredentials();
+
+  it("injects each agent's declared credential env var from the cache", () => {
+    if (serverEnv.acpCommand) return;
+    setAgentCredentialCache({
+      "claude-code": { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-abc" },
+      codex: { OPENAI_API_KEY: "sk-openai-xyz" },
+    });
+    expect(resolveAcpLaunchById("claude-code").env?.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+      "sk-ant-oat01-abc",
+    );
+    expect(resolveAcpLaunchById("codex").env?.OPENAI_API_KEY).toBe("sk-openai-xyz");
+  });
+
+  it("skips injection only when the credential's OWN env var is already inherited", () => {
+    if (serverEnv.acpCommand) return;
+    // Own var present → don't double-inject (returned env holds only overrides).
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "sk-ant-oat01-inherited";
+    process.env.OPENAI_API_KEY = "sk-openai-inherited";
+    setAgentCredentialCache({
+      "claude-code": { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-abc" },
+      codex: { OPENAI_API_KEY: "sk-openai-xyz" },
+    });
+    expect(resolveAcpLaunchById("claude-code").env?.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+    expect(resolveAcpLaunchById("codex").env?.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  it("still injects the stored token when only a hazard var (ANTHROPIC_API_KEY) is inherited", () => {
+    if (serverEnv.acpCommand) return;
+    // A stale ANTHROPIC_API_KEY must NOT suppress injection — it's a hazard that
+    // buildAcpProcessEnv drops in favor of the token, not a substitute for it.
+    process.env.ANTHROPIC_API_KEY = "sk-ant-api-key";
+    setAgentCredentialCache({ "claude-code": { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-abc" } });
+    expect(resolveAcpLaunchById("claude-code").env?.CLAUDE_CODE_OAUTH_TOKEN).toBe(
+      "sk-ant-oat01-abc",
+    );
+  });
+
+  it("only injects env vars the agent declares", () => {
+    if (serverEnv.acpCommand) return;
+    // opencode declares no credentials, so a stray cache entry is never injected.
+    setAgentCredentialCache({ opencode: { SOMETHING: "x" } });
+    expect(resolveAcpLaunchById("opencode").env).toBeUndefined();
+  });
+
+  it("drops a stale ANTHROPIC_API_KEY when injecting a stored subscription token", () => {
+    if (serverEnv.acpCommand) return;
+    // The crux fix: a stored token reaches the spawn env AND the inherited stale
+    // key is dropped — without passing claudeSubscriptionAuth, since the injected
+    // token is itself the subscription signal (the host probe can't see it).
+    setAgentCredentialCache({ "claude-code": { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-stored" } });
+    const launch = resolveAcpProcessLaunchById(
+      "claude-code",
+      {},
+      { ANTHROPIC_API_KEY: "stale-api-key", KEEP_ME: "yes" },
+      "/usr/bin",
+    );
+    expect(launch.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-stored");
+    expect(launch.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(launch.env.KEEP_ME).toBe("yes");
+  });
+});
+
+describe("ACP agent auth-failure hints", () => {
+  isolateAgentCredentials();
+
+  it("flags an agent as credential-less only when nothing is configured", () => {
+    expect(agentCredentialsMissing("claude-code")).toBe(true);
+    expect(agentCredentialsMissing("codex")).toBe(true);
+    setAgentCredentialCache({ "claude-code": { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-abc" } });
+    expect(agentCredentialsMissing("claude-code")).toBe(false);
+  });
+
+  it("never flags agents that declare no credentials", () => {
+    expect(agentCredentialsMissing("opencode")).toBe(false);
+  });
+
+  it("appends the connect hint to a credential-less agent's auth/connection error", () => {
+    const out = withAgentAuthHint("claude-code", "ACP connection closed");
+    expect(out).toContain("ACP connection closed");
+    expect(out).toContain("Claude Code");
+  });
+
+  it("leaves errors for credential-free agents untouched", () => {
+    expect(withAgentAuthHint("opencode", "boom")).toBe("boom");
+  });
+
+  it("does not append when creds are present and the error is unrelated", () => {
+    setAgentCredentialCache({ "claude-code": { CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-abc" } });
+    expect(withAgentAuthHint("claude-code", "some unrelated failure")).toBe(
+      "some unrelated failure",
+    );
   });
 });
 

--- a/apps/server/src/ai/acp/presets.ts
+++ b/apps/server/src/ai/acp/presets.ts
@@ -13,6 +13,7 @@ import {
   type ContextWindow,
   getAcpAgent,
   getAgentCapabilities,
+  getAgentCredentials,
   isAcpAgentId,
   type ThinkingEffort,
 } from "@revv/shared";
@@ -72,6 +73,73 @@ const CLAUDE_THINKING_TOKENS: Record<ThinkingEffort, number> = {
   ultrathink: 64_000,
 };
 
+// ── ACP agent credentials (agent-agnostic auth) ──────────────────────────────
+//
+// In-memory cache of per-agent credential env vars (`agentId → { ENV_VAR: value }`),
+// seeded from SQLite at boot by `SettingsServiceLive` and refreshed on every
+// connect/disconnect. SQLite stays authoritative (see the agent-subsystem
+// invariants); this is a reconstructible cache read synchronously at spawn time.
+// Each declared credential (see `ACP_AGENTS[].credentials`) is injected as its
+// env var into the subprocess so the packaged LaunchAgent — which runs with a
+// sparse env and can't reach the OS keychain where CLIs stash their interactive
+// login — can authenticate. Without it, chat 401s and generation dies with
+// "ACP connection closed".
+type AgentCredentialMap = Record<string, Record<string, string>>;
+let agentCredentialCache: AgentCredentialMap = {};
+
+/** Replace the cached credential map (called at boot and on every write). */
+export function setAgentCredentialCache(map: AgentCredentialMap): void {
+  agentCredentialCache = map;
+}
+
+/** The stored value for one agent credential env var, or null. */
+function storedCredential(agent: AcpAgentId, envVar: string): string | null {
+  const value = agentCredentialCache[agent]?.[envVar]?.trim();
+  return value && value.length > 0 ? value : null;
+}
+
+/**
+ * Whether the inherited environment already proves the agent is authenticated —
+ * its own env var, or any `alsoSatisfiedBy` var. Used ONLY for the missing/hint
+ * check, NOT to gate injection: an `alsoSatisfiedBy` var may be a hazard we want
+ * to override (see the field's doc), so injection keys off the own var alone.
+ */
+function credentialAuthedByEnv(cred: {
+  envVar: string;
+  alsoSatisfiedBy?: readonly string[];
+}): boolean {
+  return [cred.envVar, ...(cred.alsoSatisfiedBy ?? [])].some((v) => Boolean(process.env[v]));
+}
+
+/**
+ * True when the agent declares credentials but none are satisfied — neither a
+ * Revv-stored value nor a satisfying inherited env var for any of them. Used to
+ * turn an opaque 401 / "ACP connection closed" into an actionable "connect it"
+ * hint. Agents that declare no credentials (they self-authenticate) are never
+ * missing.
+ */
+export function agentCredentialsMissing(agent: AcpAgentId): boolean {
+  const creds = getAgentCredentials(agent);
+  if (creds.length === 0) return false;
+  return creds.every((c) => !storedCredential(agent, c.envVar) && !credentialAuthedByEnv(c));
+}
+
+/**
+ * Append an actionable connect hint to a raw ACP error when it's likely an auth
+ * failure — either the agent has no credential configured, or the message looks
+ * like an auth/connection error (401, "ACP connection closed", expired token).
+ */
+export function withAgentAuthHint(agent: AcpAgentId, rawMessage: string): string {
+  const creds = getAgentCredentials(agent);
+  if (creds.length === 0) return rawMessage;
+  const looksAuth = /401|unauthor|authenticat|invalid api key|oauth|connection closed/i.test(
+    rawMessage,
+  );
+  if (!agentCredentialsMissing(agent) && !looksAuth) return rawMessage;
+  const labels = creds.map((c) => c.label).join(" / ");
+  return `${rawMessage}\n\nConnect ${getAcpAgent(agent).label} in Settings (add the ${labels}), then retry.`;
+}
+
 /**
  * Apply the `REVV_ACP_AGENT` env override (a testing / power-user knob) over a
  * persisted agent id. Returns the override when it names a valid registry agent,
@@ -129,6 +197,19 @@ export function resolveAcpLaunchById(id: AcpAgentId, config: AcpLaunchConfig = {
     }
   }
 
+  // Inject each Revv-stored credential as its declared env var, unless that var
+  // is already inherited (leaves dev shells that export a key untouched, and
+  // avoids handing the agent two conflicting credentials). Agent-agnostic: the
+  // set of env vars comes entirely from the registry descriptor.
+  for (const cred of getAgentCredentials(id)) {
+    // Gate on the credential's OWN env var only — never `alsoSatisfiedBy`. A
+    // hazard like a stale ANTHROPIC_API_KEY must not suppress injecting the
+    // stored token; `buildAcpProcessEnv` then drops the hazard in its favor.
+    if (process.env[cred.envVar]) continue;
+    const value = storedCredential(id, cred.envVar);
+    if (value) env[cred.envVar] = value;
+  }
+
   return {
     command: def.command,
     args,
@@ -156,8 +237,16 @@ function buildAcpProcessEnv(
     if (value !== undefined) env[key] = value;
   }
 
+  // A Revv-injected OAuth token (in `launchEnv`) is itself proof of subscription
+  // auth — the host probe (`detectClaudeSubscriptionAuth`) can't see it, since it
+  // isn't in `process.env`. Treat it as subscription auth so the stale-key drop
+  // below still fires; otherwise an inherited ANTHROPIC_API_KEY would shadow the
+  // injected token and 401 (the exact failure this drop exists to prevent).
+  const injectsClaudeOauthToken =
+    id === "claude-code" && Boolean(launchEnv?.CLAUDE_CODE_OAUTH_TOKEN);
   const hasClaudeSubscriptionAuth =
-    options.claudeSubscriptionAuth ?? (id === "claude-code" && detectClaudeSubscriptionAuth());
+    options.claudeSubscriptionAuth ??
+    (id === "claude-code" && (injectsClaudeOauthToken || detectClaudeSubscriptionAuth()));
   if (id === "claude-code" && hasClaudeSubscriptionAuth) {
     delete env.ANTHROPIC_API_KEY;
     delete env.ANTHROPIC_AUTH_TOKEN;

--- a/apps/server/src/ai/providers/chat-acp.ts
+++ b/apps/server/src/ai/providers/chat-acp.ts
@@ -26,6 +26,7 @@ import { CLI_CHAT_TURN_TIMEOUT_MS } from "../../constants";
 import { AiGenerationError } from "../../domain/errors";
 import { debug, logError } from "../../logger";
 import { getAcpConnection } from "../acp/acp-connection";
+import { withAgentAuthHint } from "../acp/presets";
 import {
   buildActivity,
   decodeAcpSessionUpdate,
@@ -272,7 +273,10 @@ export function streamChatViaAcp(
             lastWasNonText = true;
           } else if (ev.kind === "error") {
             logError("chat-acp", "session.error:", ev.message);
-            controller.enqueue({ kind: "text", data: `\n\n_Error: ${ev.message}_` });
+            controller.enqueue({
+              kind: "text",
+              data: `\n\n_Error: ${withAgentAuthHint(opts.acpAgentId, ev.message)}_`,
+            });
             hasEmittedText = true;
             lastWasNonText = false;
           }
@@ -334,7 +338,9 @@ export function streamChatViaAcp(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         logError("chat-acp", "queryTask error:", msg);
-        controller.error(new AiGenerationError({ cause: err, message: msg }));
+        controller.error(
+          new AiGenerationError({ cause: err, message: withAgentAuthHint(opts.acpAgentId, msg) }),
+        );
       } finally {
         if (handle && sessionId) {
           handle.setListener(sessionId, null);

--- a/apps/server/src/ai/providers/recap-acp.ts
+++ b/apps/server/src/ai/providers/recap-acp.ts
@@ -29,6 +29,7 @@ import { serverEnv } from "../../config";
 import { CLI_WALKTHROUGH_TIMEOUT_MS } from "../../constants";
 import { debug, logError } from "../../logger";
 import { type AcpConnectionHandle, getAcpConnection } from "../acp/acp-connection";
+import { withAgentAuthHint } from "../acp/presets";
 import {
   decodeAcpSessionUpdate,
   makeAcpDecodeState,
@@ -209,7 +210,10 @@ export async function runRecapAgentViaAcp(params: RunRecapAgentAcpParams): Promi
   } catch (err) {
     // An abort fired by a successful `complete_recap` is success, not failure.
     if (validatedCompleteSeen) return {};
-    const message = err instanceof Error ? err.message : String(err);
+    const message = withAgentAuthHint(
+      params.acpAgentId,
+      err instanceof Error ? err.message : String(err),
+    );
     logError("recap-acp", "run failed:", message);
     return { error: message };
   } finally {

--- a/apps/server/src/ai/providers/walkthrough-acp.ts
+++ b/apps/server/src/ai/providers/walkthrough-acp.ts
@@ -48,6 +48,7 @@ import { walkthroughs as walkthroughsTable } from "../../db/schema/walkthroughs"
 import { debug, logError } from "../../logger";
 import type { PrFileMeta } from "../../services/GitHub";
 import { type AcpConnectionHandle, getAcpConnection } from "../acp/acp-connection";
+import { withAgentAuthHint } from "../acp/presets";
 import {
   buildActivity,
   decodeAcpSessionUpdate,
@@ -417,7 +418,10 @@ export function streamWalkthroughViaAcp(
         },
       });
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = withAgentAuthHint(
+        params.acpAgentId,
+        err instanceof Error ? err.message : String(err),
+      );
       logError("walkthrough-acp", "queryTask error:", message);
       if (!errorEmitted) {
         errorEmitted = true;

--- a/apps/server/src/db/migrations/0300_agent_credentials.sql
+++ b/apps/server/src/db/migrations/0300_agent_credentials.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `agent_credentials_json` text DEFAULT '{}' NOT NULL;

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1779635000000,
       "tag": "0290_chat_activity_results",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1779640000000,
+      "tag": "0300_agent_credentials",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/user-settings.ts
+++ b/apps/server/src/db/schema/user-settings.ts
@@ -70,5 +70,25 @@ export const userSettings = sqliteTable("user_settings", {
   cacheSigningKeyPath: text("cache_signing_key_path").notNull().default(""),
   /** JSON-encoded `string[]` of trusted GitHub hosts. */
   cacheTrustedSignerHosts: text("cache_trusted_signer_hosts").notNull().default("[]"),
+  // ── ACP agent credentials (agent-agnostic auth) ───────────────────────────
+  /**
+   * Per-agent credentials Revv injects into the ACP subprocess environment at
+   * spawn, as a JSON map `{ [agentId]: { [ENV_VAR]: value } }`. Which env vars
+   * apply is declared per agent in `ACP_AGENTS[].credentials` (`@revv/shared`) —
+   * e.g. `claude-code` → `CLAUDE_CODE_OAUTH_TOKEN`, `codex` → `OPENAI_API_KEY`.
+   *
+   * This is the deploy-safe path: the packaged LaunchAgent runs with a sparse
+   * environment and can't reach the OS keychain where CLIs stash their
+   * interactive login, so chat 401s and generation dies with "ACP connection
+   * closed". Injecting a stored value as an env var sidesteps the keychain.
+   *
+   * Deliberately kept OUT of the `UserSettings` type / round-trip (like
+   * `cacheCredentialsJson`) so secrets are never shipped to the web client —
+   * only per-credential `connected` booleans are exposed. Written via the
+   * dedicated `Settings.setAgentCredential` path, never `updateSettings`. V1
+   * stores plaintext; a future migration moves it into the OS keychain via
+   * `tauri-plugin-stronghold`.
+   */
+  agentCredentialsJson: text("agent_credentials_json").notNull().default("{}"),
   updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
 });

--- a/apps/server/src/routes/settings.ts
+++ b/apps/server/src/routes/settings.ts
@@ -1,7 +1,7 @@
-import { ACP_AGENT_IDS, type AcpAgentId, isAcpAgentId } from "@revv/shared";
+import { ACP_AGENT_IDS, type AcpAgentId, getAgentCredentials, isAcpAgentId } from "@revv/shared";
 import { Effect } from "effect";
 import { Elysia, t } from "elysia";
-import { listCliModels } from "../ai/providers/cli-agent";
+import { isCommandOnPath, listCliModels, resolveCliBin } from "../ai/providers/cli-agent";
 import { AppRuntime } from "../runtime";
 import { AiService } from "../services/Ai";
 import { BlobStore } from "../services/blob/BlobStore";
@@ -315,6 +315,124 @@ export const settingsRoutes = new Elysia({ prefix: "/api/settings" })
       return handleAppError(e, ctx);
     }
   })
+  // ── ACP agent credentials (agent-agnostic auth) ───────────────────────────
+  // The packaged app runs the server as a LaunchAgent with a sparse env, so a
+  // spawned ACP agent can't reach the OS keychain where its CLI stashes the
+  // interactive login — chat 401s and generation dies with "ACP connection
+  // closed". These endpoints capture (via a per-agent `setupCommand`) or accept
+  // a pasted credential and store it for injection at spawn. Which env vars
+  // apply is declared per agent in `ACP_AGENTS[].credentials`.
+  .get("/agent-credentials", async (ctx) => {
+    try {
+      const connections = await AppRuntime.runPromise(
+        Effect.flatMap(SettingsService, (s) => s.getAgentCredentialConnections()),
+      );
+      const items = ACP_AGENT_IDS.flatMap((agent) =>
+        getAgentCredentials(agent).map((cred) => ({
+          agent,
+          envVar: cred.envVar,
+          label: cred.label,
+          hint: cred.hint,
+          placeholder: cred.placeholder,
+          hasSetup: (cred.setupCommand?.length ?? 0) > 0,
+          connected: connections[agent]?.[cred.envVar] === true,
+        })),
+      );
+      return { credentials: items };
+    } catch (e) {
+      return handleAppError(e, ctx);
+    }
+  })
+  .post(
+    "/agent-credentials/connect",
+    async (ctx) => {
+      try {
+        const agent = ctx.body.agent as AcpAgentId;
+        const cred = getAgentCredentials(agent).find((c) => c.envVar === ctx.body.envVar);
+        if (!cred?.setupCommand || cred.setupCommand.length === 0 || !cred.tokenPattern) {
+          return { connected: false, error: "This credential has no automated connect flow." };
+        }
+        const [command, ...rest] = cred.setupCommand;
+        const bin =
+          command === "claude" || command === "codex" || command === "opencode"
+            ? resolveCliBin(command)
+            : (command ?? "");
+        if (!bin || !isCommandOnPath(command ?? "")) {
+          return {
+            connected: false,
+            error: `\`${command}\` CLI not found. Install it and retry, or paste the ${cred.label} manually.`,
+          };
+        }
+
+        // The setup command opens the browser for the OAuth flow, then prints the
+        // credential to stdout. Capture it, bounded by a timeout so an abandoned
+        // login doesn't wedge the request.
+        const proc = Bun.spawn([bin, ...rest], {
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const SETUP_TIMEOUT_MS = 180_000;
+        let timedOut = false;
+        const timer = setTimeout(() => {
+          timedOut = true;
+          try {
+            proc.kill();
+          } catch {
+            /* already gone */
+          }
+        }, SETUP_TIMEOUT_MS);
+
+        let stdout = "";
+        let stderr = "";
+        try {
+          [stdout, stderr] = await Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+          ]);
+          await proc.exited;
+        } finally {
+          clearTimeout(timer);
+        }
+
+        const token = `${stdout}\n${stderr}`.match(new RegExp(cred.tokenPattern))?.[0] ?? null;
+        if (!token) {
+          return {
+            connected: false,
+            error: timedOut
+              ? `Timed out waiting for \`${cred.setupCommand.join(" ")}\`. Complete the login and retry.`
+              : stderr.trim() ||
+                `No credential returned by \`${cred.setupCommand.join(" ")}\`. Complete the login and retry.`,
+          };
+        }
+
+        await AppRuntime.runPromise(
+          Effect.flatMap(SettingsService, (s) => s.setAgentCredential(agent, cred.envVar, token)),
+        );
+        return { connected: true };
+      } catch (e) {
+        return handleAppError(e, ctx);
+      }
+    },
+    { body: t.Object({ agent: aiAgentSchema, envVar: t.String() }) },
+  )
+  .post(
+    "/agent-credentials",
+    async (ctx) => {
+      try {
+        const value = ctx.body.value.trim();
+        await AppRuntime.runPromise(
+          Effect.flatMap(SettingsService, (s) =>
+            s.setAgentCredential(ctx.body.agent as AcpAgentId, ctx.body.envVar, value || null),
+          ),
+        );
+        return { connected: value.length > 0 };
+      } catch (e) {
+        return handleAppError(e, ctx);
+      }
+    },
+    { body: t.Object({ agent: aiAgentSchema, envVar: t.String(), value: t.String() }) },
+  )
   .get("/ai-status", async (ctx) => {
     try {
       return await AppRuntime.runPromise(

--- a/apps/server/src/services/Settings.ts
+++ b/apps/server/src/services/Settings.ts
@@ -16,7 +16,7 @@ import {
 } from "@revv/shared";
 import { eq } from "drizzle-orm";
 import { Context, Effect, Layer, Stream, SubscriptionRef } from "effect";
-import { applyAcpAgentOverride } from "../ai/acp/presets";
+import { applyAcpAgentOverride, setAgentCredentialCache } from "../ai/acp/presets";
 import type { Db } from "../db/index";
 import { userSettings } from "../db/schema/user-settings";
 import { ValidationError } from "../domain/errors";
@@ -229,6 +229,33 @@ function resolveRecapAgentFromSettings(
   });
 }
 
+// ── Agent credentials (agent-agnostic, kept off UserSettings) ────────────────
+// Stored as a JSON map `{ [agentId]: { [ENV_VAR]: value } }` in a dedicated
+// column, read/written directly (never through the UserSettings round-trip) so
+// secrets never reach the web client and `updateSettings` can't clobber them.
+
+type AgentCredentialMap = Record<string, Record<string, string>>;
+
+function parseAgentCredentials(json: string): AgentCredentialMap {
+  try {
+    const parsed = JSON.parse(json) as unknown;
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: AgentCredentialMap = {};
+    for (const [agent, vars] of Object.entries(parsed as Record<string, unknown>)) {
+      if (vars && typeof vars === "object") {
+        const entry: Record<string, string> = {};
+        for (const [envVar, value] of Object.entries(vars as Record<string, unknown>)) {
+          if (typeof value === "string" && value.trim().length > 0) entry[envVar] = value;
+        }
+        if (Object.keys(entry).length > 0) out[agent] = entry;
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
 // ── DB ↔ UserSettings mapping ────────────────────────────────────────────────
 
 function toSettings(row: typeof userSettings.$inferSelect): UserSettings {
@@ -388,6 +415,27 @@ export class SettingsService extends Context.Tag("SettingsService")<
      * foreign one.
      */
     resolveChatAgentId: () => Effect.Effect<AcpAgentId>;
+    /**
+     * Which agent credentials are stored, as `{ [agentId]: { [ENV_VAR]: true } }`.
+     * Only booleans are exposed — secret values never leave the server. Empty
+     * entries are omitted. See {@link setAgentCredential}.
+     */
+    getAgentCredentialConnections: () => Effect.Effect<
+      Record<string, Record<string, boolean>>,
+      ValidationError
+    >;
+    /**
+     * Store (or clear, with `null`) one agent credential env var. Writes the
+     * dedicated `agent_credentials_json` column directly — kept out of the
+     * `UserSettings` round-trip so secrets are never shipped to the client and
+     * `updateSettings` can't clobber them — and refreshes the in-memory spawn
+     * cache via `setAgentCredentialCache`.
+     */
+    setAgentCredential: (
+      agent: AcpAgentId,
+      envVar: string,
+      value: string | null,
+    ) => Effect.Effect<void, ValidationError>;
   }
 >() {}
 
@@ -405,6 +453,28 @@ export const SettingsServiceLive = Layer.effect(
         }),
     });
     const settingsRef = yield* SubscriptionRef.make(initial);
+
+    // Read the agent-credentials JSON column directly — it's intentionally not
+    // part of `UserSettings`, so it isn't carried on `initial`.
+    const readCredentialMap = (): Promise<AgentCredentialMap> =>
+      db
+        .select({ json: userSettings.agentCredentialsJson })
+        .from(userSettings)
+        .where(eq(userSettings.id, "default"))
+        .limit(1)
+        .then(([row]) => parseAgentCredentials(row?.json ?? "{}"));
+
+    // Seed the in-memory spawn cache from SQLite (authoritative).
+    yield* Effect.tryPromise({
+      try: async () => setAgentCredentialCache(await readCredentialMap()),
+      catch: (e) => new ValidationError({ message: e instanceof Error ? e.message : String(e) }),
+    }).pipe(
+      Effect.catchAll((e) =>
+        Effect.sync(() =>
+          logError("settings", "failed to seed agent-credential cache:", String(e)),
+        ),
+      ),
+    );
 
     return {
       getSettings: () =>
@@ -476,6 +546,44 @@ export const SettingsServiceLive = Layer.effect(
           ),
           Effect.orElseSucceed(() => applyAcpAgentOverride(DEFAULT_SETTINGS.aiAgent)),
         ),
+
+      getAgentCredentialConnections: () =>
+        Effect.tryPromise({
+          try: async () => {
+            const map = await readCredentialMap();
+            const out: Record<string, Record<string, boolean>> = {};
+            for (const [agent, vars] of Object.entries(map)) {
+              out[agent] = Object.fromEntries(Object.keys(vars).map((envVar) => [envVar, true]));
+            }
+            return out;
+          },
+          catch: (e) =>
+            new ValidationError({ message: e instanceof Error ? e.message : String(e) }),
+        }),
+
+      setAgentCredential: (agent, envVar, value) =>
+        Effect.gen(function* () {
+          const next = yield* Effect.tryPromise({
+            try: async () => {
+              const map = await readCredentialMap();
+              const normalized = typeof value === "string" ? value.trim() : "";
+              const entry = { ...(map[agent] ?? {}) };
+              if (normalized.length > 0) entry[envVar] = normalized;
+              else delete entry[envVar];
+              if (Object.keys(entry).length > 0) map[agent] = entry;
+              else delete map[agent];
+              await db
+                .update(userSettings)
+                .set({ agentCredentialsJson: JSON.stringify(map), updatedAt: new Date() })
+                .where(eq(userSettings.id, "default"));
+              return map;
+            },
+            catch: (e) =>
+              new ValidationError({ message: e instanceof Error ? e.message : String(e) }),
+          });
+          // Refresh the spawn cache so the next ACP launch picks it up.
+          setAgentCredentialCache(next);
+        }),
 
       resolveRecapAgent: () =>
         settingsRef.get.pipe(

--- a/apps/web/src/lib/components/settings/SettingsModal.svelte
+++ b/apps/web/src/lib/components/settings/SettingsModal.svelte
@@ -35,11 +35,15 @@ import { Switch } from "$lib/components/ui/switch";
 import { getUser, removeAccount, resetOnboarding, signOut } from "$lib/stores/auth.svelte";
 import { deleteRepo, getRepositories } from "$lib/stores/prs.svelte";
 import {
+  connectAgentCredential,
+  fetchAgentCredentials,
   fetchAgentStatus,
   fetchModels,
+  getAgentCredentialFields,
   getAgentStatus,
   getAvailableModels,
   getSettings,
+  saveAgentCredential,
   updateSettings,
 } from "$lib/stores/settings.svelte";
 import {
@@ -326,8 +330,45 @@ $effect(() => {
     // Populate the suggestions-model dropdown for the current agent (boot
     // prefetch usually covers this; this backstops a cold cache).
     void fetchModels(aiAgent);
+    void fetchAgentCredentials();
   }
 });
+
+// ── Agent credential connect state ──────────────────────────────────────────
+// Credential fields for the selected agent (registry-declared), plus per-field
+// connect/paste UI state. Agent-agnostic — the fields come from the server.
+let credentialFields = $derived(getAgentCredentialFields(aiAgent));
+let connectingEnvVar = $state<string | null>(null);
+let credentialError = $state<string | null>(null);
+let credentialDrafts = $state<Record<string, string>>({});
+
+async function handleConnectCredential(envVar: string): Promise<void> {
+  connectingEnvVar = envVar;
+  credentialError = null;
+  try {
+    const res = await connectAgentCredential(aiAgent, envVar);
+    if (!res.connected) credentialError = res.error ?? "Connection failed. Please try again.";
+  } finally {
+    connectingEnvVar = null;
+  }
+}
+
+async function handleSaveCredential(envVar: string): Promise<void> {
+  const value = (credentialDrafts[envVar] ?? "").trim();
+  if (!value) return;
+  credentialError = null;
+  const ok = await saveAgentCredential(aiAgent, envVar, value);
+  if (ok) {
+    credentialDrafts = { ...credentialDrafts, [envVar]: "" };
+  } else {
+    credentialError = "That value wasn't accepted. Check it and try again.";
+  }
+}
+
+async function handleDisconnectCredential(envVar: string): Promise<void> {
+  credentialError = null;
+  await saveAgentCredential(aiAgent, envVar, "");
+}
 
 async function fetchAiStatus(): Promise<void> {
   aiStatusLoading = true;
@@ -649,6 +690,90 @@ const themeOptions: { value: ThemePreference; label: string; icon: typeof Sun }[
 						</Select.Root>
 					</div>
 				</div>
+
+				<!-- Agent credentials (registry-declared; only for agents that need them) -->
+				{#if credentialFields.length > 0}
+					<div class="settings-subgroup">
+						<h3 class="settings-subgroup-heading">Credentials</h3>
+
+						{#each credentialFields as field (field.envVar)}
+							<div class="settings-row">
+								<div class="settings-row-info">
+									<p class="settings-row-label">{field.label}</p>
+									<p class="settings-row-hint">{field.hint}</p>
+								</div>
+								<div class="flex items-center gap-2">
+									{#if field.connected}
+										<span class="status-line-dot status-line-dot--success" aria-hidden="true"></span>
+										<span class="status-line-text">Connected</span>
+										<Button
+											variant="ghost"
+											size="sm"
+											class="text-xs"
+											onclick={() => handleDisconnectCredential(field.envVar)}
+										>
+											Disconnect
+										</Button>
+									{:else if field.hasSetup}
+										<Button
+											size="sm"
+											class="text-xs"
+											disabled={connectingEnvVar === field.envVar}
+											onclick={() => handleConnectCredential(field.envVar)}
+										>
+											{#if connectingEnvVar === field.envVar}
+												<Loader2 size={12} weight="regular" class="motion-essential-spin" />
+												Connecting…
+											{:else}
+												Connect
+											{/if}
+										</Button>
+									{/if}
+								</div>
+							</div>
+
+							{#if !field.connected}
+								<div class="settings-row">
+									<div class="settings-row-info">
+										<p class="settings-row-label">
+											{field.hasSetup ? 'Or paste manually' : 'Paste value'}
+										</p>
+										<p class="settings-row-hint">Stored locally and injected into the agent at launch.</p>
+									</div>
+									<div class="flex items-center gap-2">
+										<Input
+											type="password"
+											placeholder={field.placeholder}
+											class="w-48 text-xs"
+											value={credentialDrafts[field.envVar] ?? ''}
+											oninput={(e) =>
+												(credentialDrafts = {
+													...credentialDrafts,
+													[field.envVar]: (e.currentTarget as HTMLInputElement).value,
+												})}
+										/>
+										<Button
+											size="sm"
+											variant="secondary"
+											class="text-xs"
+											disabled={!(credentialDrafts[field.envVar] ?? '').trim()}
+											onclick={() => handleSaveCredential(field.envVar)}
+										>
+											Save
+										</Button>
+									</div>
+								</div>
+							{/if}
+						{/each}
+
+						{#if credentialError}
+							<div class="status-line">
+								<span class="status-line-dot status-line-dot--warning" aria-hidden="true"></span>
+								<span class="status-line-text">{credentialError}</span>
+							</div>
+						{/if}
+					</div>
+				{/if}
 
 				<!-- Limits -->
 				<div class="settings-subgroup">

--- a/apps/web/src/lib/stores/settings.svelte.ts
+++ b/apps/web/src/lib/stores/settings.svelte.ts
@@ -190,6 +190,7 @@ export function reset(): void {
   modelsLoadedByAgent = byAgent(() => false);
   modelsInFlight = {};
   agentStatus = null;
+  agentCredentials = [];
 }
 
 /**
@@ -290,5 +291,91 @@ export async function fetchAgentStatus(): Promise<AgentStatusReport | null> {
     return data;
   } catch {
     return agentStatus;
+  }
+}
+
+// ── ACP agent credentials (agent-agnostic auth) ─────────────────────────────
+// Per-agent credential fields declared in the shared registry, plus whether
+// each is currently stored server-side. Secret values never reach the client —
+// only the `connected` boolean and the field metadata do. Needed because the
+// packaged app can't inherit CLIs' keychain-stored logins.
+
+export interface AgentCredentialField {
+  agent: AcpAgentId;
+  envVar: string;
+  label: string;
+  hint: string;
+  placeholder: string;
+  /** Whether a one-click "Connect" flow (a `setupCommand`) exists for this credential. */
+  hasSetup: boolean;
+  connected: boolean;
+}
+
+let agentCredentials = $state<AgentCredentialField[]>([]);
+
+/** Declared credential fields for one agent (or all agents when omitted). */
+export function getAgentCredentialFields(agent?: AcpAgentId): AgentCredentialField[] {
+  return agent ? agentCredentials.filter((c) => c.agent === agent) : agentCredentials;
+}
+
+export async function fetchAgentCredentials(): Promise<AgentCredentialField[]> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/settings/agent-credentials`, {
+      headers: authHeaders(),
+    });
+    if (!res.ok) return agentCredentials;
+    const data = (await res.json()) as { credentials: AgentCredentialField[] };
+    agentCredentials = data.credentials ?? [];
+    return agentCredentials;
+  } catch {
+    return agentCredentials;
+  }
+}
+
+function markConnected(agent: AcpAgentId, envVar: string, connected: boolean): void {
+  agentCredentials = agentCredentials.map((c) =>
+    c.agent === agent && c.envVar === envVar ? { ...c, connected } : c,
+  );
+}
+
+/**
+ * Run the credential's server-side `setupCommand` (opens the browser OAuth flow)
+ * and store the captured value. On failure `error` carries an actionable message.
+ */
+export async function connectAgentCredential(
+  agent: AcpAgentId,
+  envVar: string,
+): Promise<{ connected: boolean; error?: string }> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/settings/agent-credentials/connect`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ agent, envVar }),
+    });
+    const data = (await res.json()) as { connected: boolean; error?: string };
+    if (data.connected) markConnected(agent, envVar, true);
+    return data;
+  } catch (e) {
+    return { connected: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Store (or clear, with an empty string) a manually-entered credential value. */
+export async function saveAgentCredential(
+  agent: AcpAgentId,
+  envVar: string,
+  value: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/settings/agent-credentials`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ agent, envVar, value }),
+    });
+    const data = (await res.json()) as { connected: boolean };
+    markConnected(agent, envVar, data.connected);
+    return data.connected;
+  } catch {
+    return false;
   }
 }

--- a/packages/shared/src/acp-agents.ts
+++ b/packages/shared/src/acp-agents.ts
@@ -48,6 +48,49 @@ export interface AcpAgentCapabilities {
   readonly planMode: boolean;
 }
 
+/**
+ * A credential the agent's subprocess needs in its environment to authenticate.
+ * ACP has no auth protocol, so — like model/effort/context — Revv can only hand
+ * the agent an environment. This descriptor is the agent-agnostic contract: the
+ * store, the injection at spawn, the settings UI, and the optional "Connect"
+ * flow are all driven off these entries, so covering another agent is one more
+ * registry entry.
+ *
+ * Why this exists: the packaged app runs the server as a background process with
+ * a sparse environment that can't reach the OS keychain where CLIs stash their
+ * interactive login. Injecting a stored value as an env var is the deploy-safe
+ * path. File-based logins (e.g. opencode) are reachable via `$HOME` and need no
+ * entry here.
+ */
+export interface AcpAgentCredential {
+  /** Env var injected into the agent subprocess at spawn (e.g. `CLAUDE_CODE_OAUTH_TOKEN`). */
+  readonly envVar: string;
+  /** Short label for the settings field (e.g. "Claude subscription"). */
+  readonly label: string;
+  /** Help text shown under the field. */
+  readonly hint: string;
+  /** Input placeholder / format hint. */
+  readonly placeholder: string;
+  /**
+   * Additional env vars whose presence means the agent is already authenticated,
+   * so Revv should not flag this credential as *missing* (used only for the
+   * "connect it" error hint). It deliberately does NOT gate injection: Revv still
+   * injects its stored value even when one of these is present, because some of
+   * them are hazards rather than substitutes — e.g. a stale `ANTHROPIC_API_KEY`
+   * can shadow a valid Claude subscription and 401, so `buildAcpProcessEnv`
+   * drops it in favor of the injected `CLAUDE_CODE_OAUTH_TOKEN`.
+   */
+  readonly alsoSatisfiedBy?: readonly string[];
+  /**
+   * Optional CLI that mints the credential non-interactively and prints it to
+   * stdout — drives the one-click "Connect" button. Omit for paste-only
+   * credentials (e.g. an API key the user copies from a dashboard).
+   */
+  readonly setupCommand?: readonly string[];
+  /** Regex (string form) matching the token in `setupCommand` stdout. */
+  readonly tokenPattern?: string;
+}
+
 export interface AcpAgentDescriptor {
   /** Stable id — persisted as the chat-agent setting and the connection-pool key. */
   readonly id: string;
@@ -63,6 +106,12 @@ export interface AcpAgentDescriptor {
   readonly args: readonly string[];
   /** Model / context-window / thinking-effort surface Revv exposes for this agent. */
   readonly capabilities: AcpAgentCapabilities;
+  /**
+   * Credentials Revv stores and injects into the subprocess env at spawn.
+   * Absent/empty = the agent authenticates entirely on its own (e.g. opencode's
+   * local file-based config, reachable via `$HOME`).
+   */
+  readonly credentials?: readonly AcpAgentCredential[];
 }
 
 // ⇩ Add a new ACP agent here — one entry is all it takes. ⇩
@@ -85,6 +134,17 @@ export const ACP_AGENTS = [
       // claude-agent-acp advertises a read-only plan mode.
       planMode: true,
     },
+    credentials: [
+      {
+        envVar: "CLAUDE_CODE_OAUTH_TOKEN",
+        label: "Claude subscription",
+        hint: "Connect your Claude subscription so the agent can authenticate. Runs `claude setup-token`.",
+        placeholder: "sk-ant-oat…",
+        alsoSatisfiedBy: ["ANTHROPIC_API_KEY"],
+        setupCommand: ["claude", "setup-token"],
+        tokenPattern: "sk-ant-oat\\d*-[A-Za-z0-9_-]+",
+      },
+    ],
   },
   {
     id: "opencode",
@@ -126,6 +186,14 @@ export const ACP_AGENTS = [
       // no enforceable read-only plan turn yet.
       planMode: false,
     },
+    credentials: [
+      {
+        envVar: "OPENAI_API_KEY",
+        label: "OpenAI API key",
+        hint: "Paste an OpenAI API key so Codex can authenticate without the system keychain (needed in the packaged app).",
+        placeholder: "sk-…",
+      },
+    ],
   },
   {
     id: "cursor",
@@ -174,6 +242,11 @@ export function getAcpAgent(id: AcpAgentId): AcpAgentDescriptor {
 /** The model / context-window / thinking-effort surface Revv exposes for an agent. */
 export function getAgentCapabilities(id: AcpAgentId): AcpAgentCapabilities {
   return getAcpAgent(id).capabilities;
+}
+
+/** Credentials Revv stores + injects for an agent (empty when it self-authenticates). */
+export function getAgentCredentials(id: AcpAgentId): readonly AcpAgentCredential[] {
+  return getAcpAgent(id).credentials ?? [];
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,6 @@
 export type {
   AcpAgentCapabilities,
+  AcpAgentCredential,
   AcpAgentDescriptor,
   AcpAgentIconKey,
   AcpAgentId,
@@ -12,6 +13,7 @@ export {
   ACP_AGENTS,
   getAcpAgent,
   getAgentCapabilities,
+  getAgentCredentials,
   isAcpAgentId,
 } from "./acp-agents";
 export type { Activity, ActivityKind, ActivityResult, ToolDiffOutput } from "./activity";

--- a/scripts/revv-claude-doctor.sh
+++ b/scripts/revv-claude-doctor.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# revv-claude-doctor.sh — diagnose why Revv's Claude Code agent fails to
+# authenticate (chat 401 / "ACP connection closed" during report generation).
+#
+# macOS only. Read-only: it reads settings, keychain metadata (never secrets),
+# the LaunchAgent environment, and the server log. Nothing is modified.
+#
+# Usage:  bash revv-claude-doctor.sh
+#
+# Send the full output back for interpretation.
+
+# Intentionally NOT `set -e`: every probe is best-effort and must not abort the
+# rest of the report if a tool is missing or a lookup fails.
+set -u
+
+mask() { sed -E 's/(sk-[A-Za-z0-9_-]{6})[A-Za-z0-9_-]+/\1…masked/g'; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+echo "──────── REVV CLAUDE DIAGNOSTIC ────────"
+echo "host: $(sw_vers -productVersion 2>/dev/null || uname -sr)   user: $(id -un)"
+echo
+
+# ── 1. Selected agent + whether a credential is stored by Revv ───────────────
+echo "## 1. Selected agent (prod DB)"
+DB="$HOME/Library/Application Support/Revv/revv.db"
+if [ ! -f "$DB" ]; then
+  DB=$(find "$HOME/Library/Application Support/Revv" "$HOME/Documents" \
+       -maxdepth 5 -name "revv.db" 2>/dev/null | head -1)
+fi
+echo "db: ${DB:-NOT FOUND}"
+if [ -n "${DB:-}" ] && [ -f "$DB" ] && have sqlite3; then
+  echo "agent: $(sqlite3 "$DB" 'select ai_agent from user_settings;' 2>/dev/null || echo '?')"
+  # agent_credentials_json only exists on builds that include the fix.
+  creds=$(sqlite3 "$DB" \
+    'select case when agent_credentials_json is null or agent_credentials_json="{}" then "NONE" else "present" end from user_settings;' \
+    2>/dev/null)
+  echo "stored agent creds: ${creds:-column absent (pre-fix build)}"
+elif ! have sqlite3; then
+  echo "(sqlite3 not available — skipping DB read)"
+fi
+
+# ── 2. Where is the Claude login, and is it keychain-only? ───────────────────
+echo
+echo "## 2. Claude login location"
+if [ -f "$HOME/.claude/.credentials.json" ]; then
+  echo "file login: ~/.claude/.credentials.json PRESENT (reachable by the background server)"
+else
+  echo "file login: ABSENT"
+fi
+if security find-generic-password -s "Claude Code-credentials" >/dev/null 2>&1; then
+  echo "keychain login: PRESENT (reachability depends on the item's Access Control)"
+else
+  echo "keychain login: absent"
+fi
+
+# ── 2b. Can the trusted `security` binary read it silently? ──────────────────
+# Claude Code reads the keychain by shelling out to /usr/bin/security, so the
+# item's Access Control usually trusts `security` (not the node/claude binary).
+# If `security` is trusted, this read is SILENT (exit 0) and the background
+# server succeeds the same way. If `security` is NOT trusted, macOS pops a
+# confirmation dialog here — that same block is why the background server 401s.
+#   • Silent exit 0            → keychain is readable by the trusted path (not the cause).
+#   • A GUI prompt appears     → not trusted; click Deny to observe (Always Allow would
+#                                fix it by adding `security`). This IS the failure cause.
+echo
+echo "## 2b. Silent keychain read via trusted 'security' binary"
+if security find-generic-password -s "Claude Code-credentials" >/dev/null 2>&1; then
+  security find-generic-password -w -s "Claude Code-credentials" >/dev/null 2>&1
+  rc=$?
+  if [ $rc -eq 0 ]; then
+    echo "silent read: OK (exit 0) — 'security' is trusted; background server can read it"
+  else
+    echo "silent read: FAILED/PROMPTED (exit $rc) — 'security' NOT trusted; this is the 401 cause"
+  fi
+else
+  echo "(no Claude keychain item to probe)"
+fi
+
+# ── 3. Does the subscription actually verify (interactive shell)? ────────────
+echo
+echo "## 3. Subscription verification (interactive shell)"
+if have claude; then
+  claude auth status 2>&1 | head -4
+else
+  echo "claude CLI not on PATH in this shell"
+fi
+
+# ── 4. What the background LaunchAgent server actually runs with ─────────────
+echo
+echo "## 4. Background server environment + state"
+launchctl print "gui/$(id -u)/com.revv.server" 2>/dev/null \
+  | grep -iE "state =|last exit|program =|CLAUDE_CODE_OAUTH|ANTHROPIC|OPENAI|REVV_CLAUDE_BIN|path =" \
+  | mask \
+  || echo "com.revv.server not loaded (is the app running?)"
+
+# ── 5. Stale API key that could shadow a valid subscription ──────────────────
+echo
+echo "## 5. Stale Anthropic API key in this shell?"
+if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "ANTHROPIC_API_KEY set (len=${#ANTHROPIC_API_KEY}) — can shadow a subscription and 401"
+elif [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+  echo "ANTHROPIC_AUTH_TOKEN set (len=${#ANTHROPIC_AUTH_TOKEN}) — can shadow a subscription and 401"
+else
+  echo "none in shell"
+fi
+
+# ── 6. The actual server error (smoking gun) ─────────────────────────────────
+echo
+echo "## 6. Recent Claude-relevant server errors"
+LOG="$HOME/Library/Logs/Revv/server.err.log"
+if [ -f "$LOG" ]; then
+  # Claude auth failures look like: 401 / unauthorized / oauth / "connection closed"
+  # from the chat/walkthrough/recap ACP drivers or suggestions.
+  tail -n 200 "$LOG" \
+    | grep -iE "401|unauthor|oauth|invalid authentication|connection closed|acp agent|walkthrough-acp|chat-acp|recap-acp|suggestions" \
+    | grep -viE "github|/repos/|org OAuth app policies|403" \
+    | tail -n 15 \
+    || echo "(no Claude-relevant error lines found)"
+  echo "  note: GitHub 401/403 lines were filtered out — those are GitHub sync, not Claude."
+else
+  echo "no $LOG"
+fi
+
+# ── Interpretation ───────────────────────────────────────────────────────────
+echo
+echo "──────── HOW TO READ THIS ────────"
+cat <<'EOF'
+Claude reads the keychain via the trusted /usr/bin/security binary, so the
+sharp signal is §2b, not "Allow all" vs "Confirm before allowing".
+
+Confirmed keychain-block pattern (the PR fixes this):
+  §1  agent = claude-code
+  §2  keychain login PRESENT (file login absent)
+  §2b silent read FAILED / PROMPTED   ← 'security' not trusted for their item
+  §3  loggedIn: true                  (subscription valid interactively)
+  §4  NO CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_* in the server env
+  §6  a Claude 401 / "ACP connection closed"
+→ Background server can't get a silent keychain read. Injecting a stored
+  CLAUDE_CODE_OAUTH_TOKEN (the fix) bypasses the keychain entirely.
+
+If §2b is "OK (exit 0)" — as on a working machine — the keychain is NOT the
+problem; look at §1 (right agent?), §4 (claude on PATH / REVV_CLAUDE_BIN),
+and §6 for the real error.
+
+Definitive GUI check + a remediation to try today:
+  Keychain Access → login → "Claude Code-credentials" → Access Control tab.
+  If `security` is missing from the allowed list, either add it, or set
+  "Allow all applications". If generation then works, that confirms the cause.
+
+Other outcomes:
+  §1 agent is cursor/opencode  → different story; not the keychain issue.
+  §5 shows an API key set      → the shadowing hazard; the fix drops it.
+EOF
+echo "──────────────────────────────────"


### PR DESCRIPTION
Packaged installs run the server with a sparse environment that can't reach the OS keychain where agent CLIs stash their interactive login, so Claude chat 401s and generation dies with "ACP connection closed". Improved detection (#154) doesn't help: there is still no way to supply a credential the background server can use.

Add a registry-driven, agent-agnostic credential system:
- Each ACP agent declares the env var(s) it needs (claude-code → CLAUDE_CODE_OAUTH_TOKEN, codex → OPENAI_API_KEY) in ACP_AGENTS.
- Values are stored per-agent in agent_credentials_json and injected into the subprocess env at spawn (survives buildAcpProcessEnv).
- A one-click Connect flow runs the agent's setupCommand (claude setup-token); a masked paste field covers paste-only creds.
- Injecting a Claude subscription token is itself treated as subscription auth, so a stale ANTHROPIC_API_KEY is dropped and can't shadow it / 401.
- Auth failures surface an actionable "connect in Settings" hint.