### PR TITLE
feat: Worktree filter closed prs by creator

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.14.1"
+version = "0.15.1"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/routes/prs.ts
+++ b/apps/server/src/routes/prs.ts
@@ -130,6 +130,7 @@ export const prRoutes = new Elysia({ prefix: "/api/prs" })
           until?: string;
           cursor?: string;
           limit?: number;
+          authorLogins?: string[];
         } = {};
         if (ctx.query.repo !== undefined) params.repoId = ctx.query.repo;
         if (ctx.query.since !== undefined) params.since = ctx.query.since;
@@ -138,6 +139,13 @@ export const prRoutes = new Elysia({ prefix: "/api/prs" })
         if (ctx.query.limit !== undefined) {
           const n = Number(ctx.query.limit);
           if (Number.isFinite(n) && n > 0) params.limit = Math.floor(n);
+        }
+        if (ctx.query.authors !== undefined) {
+          // Comma-separated author logins. GitHub logins never contain commas,
+          // so a plain split is safe. Empty segments (e.g. trailing comma) are
+          // dropped so an all-empty value behaves as "no author filter".
+          const logins = ctx.query.authors.split(",").filter((s) => s.length > 0);
+          if (logins.length > 0) params.authorLogins = logins;
         }
         return await AppRuntime.runPromise(
           Effect.gen(function* () {
@@ -157,6 +165,7 @@ export const prRoutes = new Elysia({ prefix: "/api/prs" })
         until: t.Optional(t.String()),
         cursor: t.Optional(t.String()),
         limit: t.Optional(t.String()),
+        authors: t.Optional(t.String()),
       }),
     },
   )

--- a/apps/server/src/services/PollScheduler.ts
+++ b/apps/server/src/services/PollScheduler.ts
@@ -79,7 +79,12 @@ export const PollSchedulerLive = Layer.effect(
     // cached avatar bytes (`repositories.avatar_content`) right after boot,
     // instead of leaving stale/blank icons for up to an hour.
     let lastMetadataRefreshAt = 0;
-    let lastArchiveBackfillAt = Date.now();
+    // Seed to 0 (not `Date.now()`) so the archive backfill runs on the first
+    // poll after boot rather than waiting a full interval. Without this a fresh
+    // mirror shows no closed/merged PRs for the first hour, and in dev — where
+    // the server restarts more often than once an hour — the backfill would
+    // never run at all, leaving the archive populated only by live closures.
+    let lastArchiveBackfillAt = 0;
 
     // Bind the captured db handle for convenience
     const withDb = <A, E>(eff: Effect.Effect<A, E, DbService>) => withDbHelper(db, eff);
@@ -710,7 +715,14 @@ export const PollSchedulerLive = Layer.effect(
           if (shouldRunArchiveBackfill) {
             lastArchiveBackfillAt = Date.now();
             const ARCHIVE_BACKFILL_DAYS = 7;
-            const ARCHIVE_BACKFILL_MAX_FETCHES_PER_REPO = 25;
+            // Sized to cover the full backfill window in a single cycle for an
+            // active repo (~13 closed PRs/day × 7 days ≈ 90, with headroom).
+            // The search returns the whole window; this caps how many missing
+            // rows we individually fetch per repo per cycle. At 25 a busy repo
+            // only imported ~2 days per cycle, so a fresh mirror never showed
+            // the whole week. Only ever fetches PRs not already mirrored, so
+            // the cost is a bounded one-time burst that converges to near-zero.
+            const ARCHIVE_BACKFILL_MAX_FETCHES_PER_REPO = 150;
             const backfillSinceIso = new Date(
               Date.now() - ARCHIVE_BACKFILL_DAYS * 24 * 60 * 60 * 1000,
             ).toISOString();

--- a/apps/server/src/services/PullRequest.test.ts
+++ b/apps/server/src/services/PullRequest.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import { createDb, type Db } from "../db/index";
+import { account, pullRequests, repositories, user } from "../db/schema";
+import { DbService } from "./Db";
+import {
+  type ListArchivedPrsParams,
+  PullRequestService,
+  PullRequestServiceLive,
+} from "./PullRequest";
+
+const ACCOUNT_ID = "acc-1";
+const REPO_ID = "repo-1";
+
+// Seed one account/repo and a spread of PRs across statuses and authors.
+// closedAt values are deliberately out of insertion order so tests also
+// assert the `closedAt DESC` ordering, not just membership.
+function seed(db: Db): void {
+  const now = new Date();
+  db.insert(user)
+    .values({
+      id: "user-1",
+      name: "Test",
+      email: "test@example.com",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(account)
+    .values({
+      id: ACCOUNT_ID,
+      accountId: "gh-1",
+      providerId: "github:github.com",
+      userId: "user-1",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(repositories)
+    .values({
+      id: REPO_ID,
+      owner: "acme",
+      name: "web",
+      fullName: "acme/web",
+      addedAt: now.toISOString(),
+      accountId: ACCOUNT_ID,
+    })
+    .run();
+
+  const base = {
+    repositoryId: REPO_ID,
+    title: "t",
+    sourceBranch: "feature",
+    targetBranch: "main",
+    url: "https://example.com",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    fetchedAt: "2026-01-01T00:00:00Z",
+  };
+  db.insert(pullRequests)
+    .values([
+      {
+        ...base,
+        id: "pr-open-alice",
+        externalId: 1,
+        authorLogin: "alice",
+        status: "open",
+        closedAt: null,
+      },
+      {
+        ...base,
+        id: "pr-closed-alice",
+        externalId: 2,
+        authorLogin: "alice",
+        status: "closed",
+        closedAt: "2026-07-03T00:00:00Z",
+      },
+      {
+        ...base,
+        id: "pr-merged-bob",
+        externalId: 3,
+        authorLogin: "bob",
+        status: "merged",
+        closedAt: "2026-07-05T00:00:00Z",
+      },
+      {
+        ...base,
+        id: "pr-closed-carol",
+        externalId: 4,
+        authorLogin: "carol",
+        status: "closed",
+        closedAt: "2026-07-01T00:00:00Z",
+      },
+    ])
+    .run();
+}
+
+function listArchived(db: Db, params?: ListArchivedPrsParams) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const svc = yield* PullRequestService;
+      return yield* svc.listArchivedPrs(ACCOUNT_ID, params);
+    }).pipe(
+      Effect.provide(PullRequestServiceLive),
+      Effect.provide(Layer.succeed(DbService, { db })),
+    ),
+  );
+}
+
+describe("listArchivedPrs author filter", () => {
+  it("returns all closed/merged PRs (never open) ordered by closedAt desc when unfiltered", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    const { prs } = await listArchived(db);
+    expect(prs.map((p) => p.id)).toEqual(["pr-merged-bob", "pr-closed-alice", "pr-closed-carol"]);
+  });
+
+  it("restricts to a single author", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    const { prs } = await listArchived(db, { authorLogins: ["alice"] });
+    expect(prs.map((p) => p.id)).toEqual(["pr-closed-alice"]);
+    expect(prs.every((p) => p.authorLogin === "alice")).toBe(true);
+  });
+
+  it("restricts to multiple authors, still ordered by closedAt desc", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    const { prs } = await listArchived(db, { authorLogins: ["alice", "bob"] });
+    expect(prs.map((p) => p.id)).toEqual(["pr-merged-bob", "pr-closed-alice"]);
+  });
+
+  it("never surfaces an open PR, even when its author is in the filter", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    const { prs } = await listArchived(db, { authorLogins: ["alice"] });
+    expect(prs.some((p) => p.id === "pr-open-alice")).toBe(false);
+  });
+
+  it("returns nothing when the filtered author has no closed PRs", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    const { prs } = await listArchived(db, { authorLogins: ["nobody"] });
+    expect(prs).toEqual([]);
+  });
+
+  it("treats an empty author list as no filter", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    const { prs } = await listArchived(db, { authorLogins: [] });
+    expect(prs.map((p) => p.id)).toEqual(["pr-merged-bob", "pr-closed-alice", "pr-closed-carol"]);
+  });
+});

--- a/apps/server/src/services/PullRequest.ts
+++ b/apps/server/src/services/PullRequest.ts
@@ -56,6 +56,12 @@ export interface ListArchivedPrsParams {
   readonly cursor?: string;
   /** Page size. Clamped to `[1, MAX_ARCHIVE_PAGE_LIMIT]`. */
   readonly limit?: number;
+  /**
+   * Restrict results to PRs authored by these logins. Empty/omitted means no
+   * author restriction. Mirrors the sidebar's creator/team filter so the
+   * closed list narrows the same way the open list does.
+   */
+  readonly authorLogins?: readonly string[];
 }
 
 export interface ListArchivedPrsResult {
@@ -415,6 +421,9 @@ export const PullRequestServiceLive = Layer.succeed(PullRequestService, {
           }
           if (params?.repoId !== undefined) {
             conditions.push(eq(pullRequests.repositoryId, params.repoId));
+          }
+          if (params?.authorLogins && params.authorLogins.length > 0) {
+            conditions.push(inArray(pullRequests.authorLogin, [...params.authorLogins]));
           }
           if (params?.since !== undefined) {
             conditions.push(gte(pullRequests.closedAt, params.since));

--- a/apps/web/src/lib/stores/prs.svelte.ts
+++ b/apps/web/src/lib/stores/prs.svelte.ts
@@ -378,9 +378,31 @@ export async function fetchPrs(): Promise<void> {
   }
 }
 
+/**
+ * Serialize the active creator/team filter into the `authors` query param the
+ * archived endpoint expects (comma-separated logins). Returns `undefined` when
+ * no filter is active so the server applies no author restriction. Keeps
+ * `selectedAuthorLogins` the single source of truth for both the open and
+ * closed lists.
+ */
+function archivedAuthorsParam(): string | undefined {
+  if (selectedAuthorLogins.size === 0) return undefined;
+  return [...selectedAuthorLogins].join(",");
+}
+
+// Guards against out-of-order archived reloads: rapid filter toggles can fire
+// overlapping `fetchArchivedPrs` calls, and only the latest one's result should
+// win. Each call captures the token; a stale response is discarded.
+let archivedFetchToken = 0;
+
 export async function fetchArchivedPrs(): Promise<void> {
+  const token = ++archivedFetchToken;
   try {
-    const { data } = await api.api.prs.archived.get({ query: {} });
+    const authors = archivedAuthorsParam();
+    const { data } = await api.api.prs.archived.get({
+      query: authors === undefined ? {} : { authors },
+    });
+    if (token !== archivedFetchToken) return; // superseded by a newer reload
     if (data) {
       const page = data as { prs: PullRequest[]; nextCursor: string | null };
       archivedPrs = page.prs;
@@ -402,8 +424,12 @@ export async function fetchMoreArchived(): Promise<void> {
   if (archivedLoadingMore) return;
   archivedLoadingMore = true;
   try {
+    const authors = archivedAuthorsParam();
     const { data } = await api.api.prs.archived.get({
-      query: { cursor: archivedNextCursor },
+      query:
+        authors === undefined
+          ? { cursor: archivedNextCursor }
+          : { cursor: archivedNextCursor, authors },
     });
     if (data) {
       const page = data as { prs: PullRequest[]; nextCursor: string | null };
@@ -503,7 +529,12 @@ export function onPrArchived(data: {
     if (!existing) return;
     const archived = { ...existing, status: data.status, closedAt: data.closedAt };
     pullRequests = [...pullRequests.slice(0, openIdx), ...pullRequests.slice(openIdx + 1)];
-    archivedPrs = [archived, ...archivedPrs];
+    // Respect the active creator/team filter: the archived list is a
+    // server-filtered view, so a newly-closed PR whose author is filtered out
+    // must not pop into it. It's already gone from the open list above.
+    if (selectedAuthorLogins.size === 0 || selectedAuthorLogins.has(archived.authorLogin)) {
+      archivedPrs = [archived, ...archivedPrs];
+    }
   }
   // PR not known locally — wait for the `prs:updated` reconcile.
 }
@@ -547,6 +578,7 @@ export function toggleAuthorFilter(login: string): void {
   if (next.has(login)) next.delete(login);
   else next.add(login);
   selectedAuthorLogins = next;
+  void fetchArchivedPrs();
 }
 
 /**
@@ -563,11 +595,13 @@ export function setAuthorFilters(logins: readonly string[], selected: boolean): 
     else next.delete(login);
   }
   selectedAuthorLogins = next;
+  void fetchArchivedPrs();
 }
 
 export function clearAuthorFilters(): void {
   if (selectedAuthorLogins.size === 0) return;
   selectedAuthorLogins = new Set();
+  void fetchArchivedPrs();
 }
 
 export function getTeamsForOrg(owner: string): Team[] {

--- a/apps/web/src/lib/stores/prs.svelte.ts
+++ b/apps/web/src/lib/stores/prs.svelte.ts
@@ -423,6 +423,11 @@ export async function fetchMoreArchived(): Promise<void> {
   if (archivedNextCursor === null) return;
   if (archivedLoadingMore) return;
   archivedLoadingMore = true;
+  // Capture the current filter generation (do not bump it — this is a
+  // continuation of the same feed, not a new reload). If a `fetchArchivedPrs`
+  // filter reload lands mid-flight, discard this page: appending it would mix
+  // stale-filter rows in and clobber the new cursor.
+  const token = archivedFetchToken;
   try {
     const authors = archivedAuthorsParam();
     const { data } = await api.api.prs.archived.get({
@@ -431,6 +436,7 @@ export async function fetchMoreArchived(): Promise<void> {
           ? { cursor: archivedNextCursor }
           : { cursor: archivedNextCursor, authors },
     });
+    if (token !== archivedFetchToken) return; // superseded by a filter reload
     if (data) {
       const page = data as { prs: PullRequest[]; nextCursor: string | null };
       // Deduplicate against existing rows in case a `pr:archived` patch
@@ -764,20 +770,21 @@ export async function markPrReadyForReview(prId: string): Promise<void> {
 }
 
 /**
- * Restore a PR from the archive back into the open list with prior status
- * and closedAt. Used by the `closePr` / `mergePr` rollback path — the
- * reverse of `onPrArchived`'s forward move. Touches only the one PR so
- * concurrent `prs:updated` reshuffles of other entries are preserved.
+ * Restore a PR back into the open list from the caller's pre-close snapshot.
+ * Used by the `closePr` / `mergePr` rollback path — the reverse of
+ * `onPrArchived`'s forward move.
+ *
+ * Restores from the passed snapshot rather than looking the PR up in
+ * `archivedPrs`, because the forward move may have skipped adding it there:
+ * when an author filter is active, `onPrArchived` filters out non-matching
+ * PRs, so a lookup would find nothing and the PR would be lost from both
+ * lists. Idempotent — no-ops the open-list insert if a concurrent
+ * `prs:updated` reconcile already restored it.
  */
-function restorePrFromArchive(
-  prId: string,
-  prevStatus: PullRequest["status"],
-  prevClosedAt: string | null,
-): void {
-  const archived = archivedPrs.find((p) => p.id === prId);
-  if (!archived) return;
-  archivedPrs = archivedPrs.filter((p) => p.id !== prId);
-  pullRequests = [{ ...archived, status: prevStatus, closedAt: prevClosedAt }, ...pullRequests];
+function restorePrFromArchive(snapshot: PullRequest): void {
+  archivedPrs = archivedPrs.filter((p) => p.id !== snapshot.id);
+  if (pullRequests.some((p) => p.id === snapshot.id)) return;
+  pullRequests = [snapshot, ...pullRequests];
 }
 
 export async function closePr(prId: string): Promise<void> {
@@ -792,8 +799,9 @@ export async function closePr(prId: string): Promise<void> {
     return;
   }
 
-  const prevStatus = pr.status;
-  const prevClosedAt = pr.closedAt;
+  // Snapshot the pre-close PR for rollback. `onPrArchived` never mutates this
+  // object (it builds a new one), so it stays a faithful `status:"open"` copy.
+  const snapshot = pr;
 
   onPrArchived({
     prId,
@@ -806,7 +814,7 @@ export async function closePr(prId: string): Promise<void> {
     const { error } = await api.api.prs({ id: prId }).close.post();
     if (error) throw new Error(`HTTP ${error.status}`);
   } catch (e) {
-    restorePrFromArchive(prId, prevStatus, prevClosedAt);
+    restorePrFromArchive(snapshot);
     toast.error(e instanceof Error ? e.message : "Failed to close PR");
     throw e;
   }
@@ -836,8 +844,8 @@ export async function mergePr(prId: string, mergeMethod: MergeMethod): Promise<v
     return;
   }
 
-  const prevStatus = pr.status;
-  const prevClosedAt = pr.closedAt;
+  // Snapshot the pre-merge PR for rollback (see closePr for why this is safe).
+  const snapshot = pr;
 
   onPrArchived({
     prId,
@@ -851,7 +859,7 @@ export async function mergePr(prId: string, mergeMethod: MergeMethod): Promise<v
     if (error) throw new Error(`HTTP ${error.status}`);
     toast.success("Pull request merged successfully");
   } catch (e) {
-    restorePrFromArchive(prId, prevStatus, prevClosedAt);
+    restorePrFromArchive(snapshot);
     toast.error(e instanceof Error ? e.message : "Failed to merge pull request");
     throw e;
   }


### PR DESCRIPTION
## What

Extends the sidebar creator/team filter so it also narrows the **closed/merged (archived)** list, not just the open list.

## How

- **Server** — `listArchivedPrs` accepts `authorLogins` and adds an `author_login IN (…)` condition; `GET /api/prs/archived` parses a comma-separated `authors` query param. Filtering is done server-side so it composes correctly with cursor pagination (client-side filtering would break "Load more").
- **Web store** — `fetchArchivedPrs` / `fetchMoreArchived` send the active filter; the filter mutators trigger an archived refetch; a request-token guard discards out-of-order reloads (including on `fetchMoreArchived`, so a "Load more" in flight can't mix stale-filter rows or clobber the cursor). `onPrArchived` respects the active filter before prepending a newly-closed PR, and the optimistic close/merge rollback restores from a snapshot so a filtered-out PR can't be lost from both lists.

## Archive backfill fixes (required for the feature to be usable)

The closed-PR archive is populated by a bounded backfill (GitHub search over a rolling 7-day window, pruned by the retention sweep). Two issues made it effectively empty:

- **`lastArchiveBackfillAt` was seeded to `Date.now()`** → the backfill was skipped for the first hour after every boot, so in dev (frequent restarts) it never ran. Now seeded to `0` (matching `lastMetadataRefreshAt`) so it runs on the first poll after boot.
- **Per-repo fetch cap was 25/cycle** → an active repo only imported ~2 days of the 7-day window per cycle. Raised to **150** so one cycle covers the whole window for a typical active repo.

## ⚠️ Ops note — boot-time GitHub API volume

The two backfill fixes change first-sync API-call volume: on a fresh mirror the backfill now runs immediately at boot and may issue up to **150 individual `getPr` calls per active repo** (concurrency 3) to fill the 7-day window. This is a **bounded, one-time** cost — subsequent cycles only fetch PRs not already mirrored, converging to ~0. No change to steady-state polling.

## Tests

- `apps/server/src/services/PullRequest.test.ts` — covers `listArchivedPrs` author filtering: single/multiple authors, `closedAt DESC` ordering, open PRs never surfacing, empty result for an unknown author, and empty-list = no filter.

## Verification

`bun run typecheck && bun run lint && bun run knip && bun run build` all pass; new tests green.
