### PR TITLE
fix: Recover missing GHE client ID during reauth

### DIFF
--- a/apps/server/src/github-oauth.test.ts
+++ b/apps/server/src/github-oauth.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { isLikelyGitHubClientId } from "@revv/shared";
+import { clientIdForHost, InvalidGitHubClientIdError } from "./github-oauth";
+
+describe("GitHub client ID validation", () => {
+  it("accepts GitHub App and OAuth App client ID shapes", () => {
+    expect(isLikelyGitHubClientId("Iv23li1234567890")).toBe(true);
+    expect(isLikelyGitHubClientId("Ov23li1234567890")).toBe(true);
+  });
+
+  it("rejects malformed client IDs before starting device flow", () => {
+    expect(isLikelyGitHubClientId("not-a-client-id")).toBe(false);
+    expect(() => clientIdForHost("ghe.example.com", "not-a-client-id")).toThrow(
+      InvalidGitHubClientIdError,
+    );
+  });
+});

--- a/apps/server/src/github-oauth.ts
+++ b/apps/server/src/github-oauth.ts
@@ -1,3 +1,4 @@
+import { GITHUB_CLIENT_ID_HINT, isLikelyGitHubClientId } from "@revv/shared";
 import { serverEnv } from "./config";
 
 /**
@@ -52,6 +53,18 @@ export class MissingGitHubClientIdError extends Error {
   }
 }
 
+export class InvalidGitHubClientIdError extends Error {
+  readonly code = "invalid_github_client_id";
+
+  constructor(
+    readonly host: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "InvalidGitHubClientIdError";
+  }
+}
+
 /**
  * Client_id for a host.
  *
@@ -70,7 +83,15 @@ export class MissingGitHubClientIdError extends Error {
 export function clientIdForHost(host: string, customClientId?: string | null): string {
   if (usesGitHubApp(host)) return serverEnv.githubAppClientId;
   const custom = customClientId?.trim();
-  if (custom) return custom;
+  if (custom) {
+    if (!isLikelyGitHubClientId(custom)) {
+      throw new InvalidGitHubClientIdError(
+        host,
+        `The GitHub App or OAuth App client ID for ${host} is not valid. ${GITHUB_CLIENT_ID_HINT}`,
+      );
+    }
+    return custom;
+  }
   if (isPublicGitHub(host)) {
     if (!serverEnv.githubClientIdPublic) {
       throw new MissingGitHubClientIdError(

--- a/apps/server/src/github-oauth.ts
+++ b/apps/server/src/github-oauth.ts
@@ -40,6 +40,18 @@ export function clientIdIsGitHubApp(clientId: string): boolean {
   return clientId.startsWith("Iv");
 }
 
+export class MissingGitHubClientIdError extends Error {
+  readonly code = "missing_github_client_id";
+
+  constructor(
+    readonly host: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "MissingGitHubClientIdError";
+  }
+}
+
 /**
  * Client_id for a host.
  *
@@ -61,7 +73,8 @@ export function clientIdForHost(host: string, customClientId?: string | null): s
   if (custom) return custom;
   if (isPublicGitHub(host)) {
     if (!serverEnv.githubClientIdPublic) {
-      throw new Error(
+      throw new MissingGitHubClientIdError(
+        host,
         "Public GitHub sign-in requires GITHUB_CLIENT_ID_PUBLIC to be set. " +
           "Register an OAuth App on github.com and add GITHUB_CLIENT_ID_PUBLIC=<id> to your .env file.",
       );
@@ -69,7 +82,8 @@ export function clientIdForHost(host: string, customClientId?: string | null): s
     return serverEnv.githubClientIdPublic;
   }
   if (serverEnv.githubClientId) return serverEnv.githubClientId;
-  throw new Error(
+  throw new MissingGitHubClientIdError(
+    host,
     `Signing in to ${host} requires a GitHub App or OAuth App client ID. ` +
       "Add one during onboarding (GitHub Enterprise → client ID), or set GITHUB_CLIENT_ID for a fixed deployment.",
   );

--- a/apps/server/src/routes/device-auth.ts
+++ b/apps/server/src/routes/device-auth.ts
@@ -9,6 +9,7 @@ import {
   clientIdForHost,
   clientIdIsGitHubApp,
   isPublicGitHub,
+  MissingGitHubClientIdError,
   tokenUrlForHost,
 } from "../github-oauth";
 import { logError } from "../logger";
@@ -495,7 +496,15 @@ const publicAuthRoutes = new Elysia()
   .post(
     "/api/auth/device/init",
     async ({ body, status }) => {
-      const urls = await resolveGithubUrls(body?.host);
+      let urls: Awaited<ReturnType<typeof resolveGithubUrls>>;
+      try {
+        urls = await resolveGithubUrls(body?.host);
+      } catch (e) {
+        if (e instanceof MissingGitHubClientIdError) {
+          return status(400, { error: e.message, code: e.code, host: e.host });
+        }
+        throw e;
+      }
       const res = await fetch(urls.deviceCodeUrl, {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
@@ -545,7 +554,15 @@ const publicAuthRoutes = new Elysia()
         }
       }
 
-      const urls = await resolveGithubUrls(body.host);
+      let urls: Awaited<ReturnType<typeof resolveGithubUrls>>;
+      try {
+        urls = await resolveGithubUrls(body.host);
+      } catch (e) {
+        if (e instanceof MissingGitHubClientIdError) {
+          return status(400, { error: e.message, code: e.code, host: e.host });
+        }
+        throw e;
+      }
       // Per GitHub's docs, device-flow token exchange does not take a
       // client_secret — only client_id, device_code, and grant_type.
       const res = await fetch(urls.tokenUrl, {

--- a/apps/server/src/routes/device-auth.ts
+++ b/apps/server/src/routes/device-auth.ts
@@ -8,6 +8,7 @@ import { remoteUsers } from "../db/schema/remote-users";
 import {
   clientIdForHost,
   clientIdIsGitHubApp,
+  InvalidGitHubClientIdError,
   isPublicGitHub,
   MissingGitHubClientIdError,
   tokenUrlForHost,
@@ -78,6 +79,56 @@ async function resolveGithubUrls(hostOverride?: string): Promise<{
     tokenUrl: tokenUrlForHost(host),
     userUrl: `${apiBase}/user`,
     emailsUrl: `${apiBase}/user/emails`,
+  };
+}
+
+type GitHubClientIdErrorCode =
+  | MissingGitHubClientIdError["code"]
+  | InvalidGitHubClientIdError["code"];
+
+function isGitHubClientIdError(
+  e: unknown,
+): e is MissingGitHubClientIdError | InvalidGitHubClientIdError {
+  return e instanceof MissingGitHubClientIdError || e instanceof InvalidGitHubClientIdError;
+}
+
+function githubClientIdErrorBody(e: MissingGitHubClientIdError | InvalidGitHubClientIdError): {
+  error: string;
+  code: GitHubClientIdErrorCode;
+  host: string;
+} {
+  return { error: e.message, code: e.code, host: e.host };
+}
+
+async function resolveGithubUrlsForDeviceAuth(
+  hostOverride: string | undefined,
+  status: (
+    code: 400,
+    body: { error: string; code: GitHubClientIdErrorCode; host: string },
+  ) => unknown,
+): Promise<
+  | { ok: true; urls: Awaited<ReturnType<typeof resolveGithubUrls>> }
+  | { ok: false; response: unknown }
+> {
+  try {
+    return { ok: true, urls: await resolveGithubUrls(hostOverride) };
+  } catch (e) {
+    if (isGitHubClientIdError(e)) {
+      return { ok: false, response: status(400, githubClientIdErrorBody(e)) };
+    }
+    throw e;
+  }
+}
+
+function rejectedClientIdBody(host: string): {
+  error: string;
+  code: InvalidGitHubClientIdError["code"];
+  host: string;
+} {
+  return {
+    error: `GitHub rejected the client ID for ${host}. Check that it was copied from the GitHub App or OAuth App registered on that host.`,
+    code: "invalid_github_client_id",
+    host,
   };
 }
 
@@ -496,15 +547,9 @@ const publicAuthRoutes = new Elysia()
   .post(
     "/api/auth/device/init",
     async ({ body, status }) => {
-      let urls: Awaited<ReturnType<typeof resolveGithubUrls>>;
-      try {
-        urls = await resolveGithubUrls(body?.host);
-      } catch (e) {
-        if (e instanceof MissingGitHubClientIdError) {
-          return status(400, { error: e.message, code: e.code, host: e.host });
-        }
-        throw e;
-      }
+      const resolved = await resolveGithubUrlsForDeviceAuth(body?.host, status);
+      if (!resolved.ok) return resolved.response;
+      const { urls } = resolved;
       const res = await fetch(urls.deviceCodeUrl, {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
@@ -523,6 +568,9 @@ const publicAuthRoutes = new Elysia()
           `GitHub device code request failed: ${res.status} ${res.statusText}`,
           text,
         );
+        if (res.status === 400 || res.status === 401) {
+          return status(400, rejectedClientIdBody(urls.host));
+        }
         return status(502, { error: "Failed to initiate device flow" });
       }
 
@@ -554,15 +602,9 @@ const publicAuthRoutes = new Elysia()
         }
       }
 
-      let urls: Awaited<ReturnType<typeof resolveGithubUrls>>;
-      try {
-        urls = await resolveGithubUrls(body.host);
-      } catch (e) {
-        if (e instanceof MissingGitHubClientIdError) {
-          return status(400, { error: e.message, code: e.code, host: e.host });
-        }
-        throw e;
-      }
+      const resolved = await resolveGithubUrlsForDeviceAuth(body.host, status);
+      if (!resolved.ok) return resolved.response;
+      const { urls } = resolved;
       // Per GitHub's docs, device-flow token exchange does not take a
       // client_secret — only client_id, device_code, and grant_type.
       const res = await fetch(urls.tokenUrl, {

--- a/apps/web/src/lib/components/auth/ReauthModal.svelte
+++ b/apps/web/src/lib/components/auth/ReauthModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { GITHUB_CLIENT_ID_HINT, isLikelyGitHubClientId } from "@revv/shared";
 import { GithubLogo, WarningCircle } from "phosphor-svelte";
 import { gsapFade, gsapFadeY, tokens } from "$lib/motion";
 import {
@@ -27,7 +28,9 @@ const needsClientId = $derived(
   Boolean(
     reauth?.host &&
       reauth.host !== "github.com" &&
-      (signInErrorCode === "missing_github_client_id" || clientIdError),
+      (signInErrorCode === "missing_github_client_id" ||
+        signInErrorCode === "invalid_github_client_id" ||
+        clientIdError),
   ),
 );
 
@@ -50,6 +53,11 @@ async function saveClientIdAndRetry(): Promise<void> {
   if (!host || !trimmed || isSavingClientId) return;
 
   clientIdError = null;
+  if (!isLikelyGitHubClientId(trimmed)) {
+    clientIdError = GITHUB_CLIENT_ID_HINT;
+    return;
+  }
+
   isSavingClientId = true;
   try {
     await setGithubConfigStrict(host, trimmed);

--- a/apps/web/src/lib/components/auth/ReauthModal.svelte
+++ b/apps/web/src/lib/components/auth/ReauthModal.svelte
@@ -7,6 +7,7 @@ import {
   getError,
   getIsLoading,
   getReauthRequired,
+  getSignInErrorCode,
   signIn,
 } from "$lib/stores/auth.svelte";
 import { setGithubConfigStrict } from "$lib/stores/settings.svelte";
@@ -14,6 +15,7 @@ import { setGithubConfigStrict } from "$lib/stores/settings.svelte";
 const reauth = $derived(getReauthRequired());
 const deviceFlow = $derived(getDeviceFlow());
 const error = $derived(getError());
+const signInErrorCode = $derived(getSignInErrorCode());
 const isLoading = $derived(getIsLoading());
 
 let copied = $state(false);
@@ -25,7 +27,7 @@ const needsClientId = $derived(
   Boolean(
     reauth?.host &&
       reauth.host !== "github.com" &&
-      error?.includes("requires a GitHub App or OAuth App client ID"),
+      (signInErrorCode === "missing_github_client_id" || clientIdError),
   ),
 );
 
@@ -51,7 +53,10 @@ async function saveClientIdAndRetry(): Promise<void> {
   isSavingClientId = true;
   try {
     await setGithubConfigStrict(host, trimmed);
-    await signIn(host);
+    const started = await signIn(host);
+    if (!started) {
+      clientIdError = getError() ?? "Failed to start sign-in. Check the client ID and try again.";
+    }
   } catch (e) {
     clientIdError = e instanceof Error ? e.message : String(e);
   } finally {
@@ -125,7 +130,7 @@ async function saveClientIdAndRetry(): Promise<void> {
 					</button>
 				</div>
 			{:else}
-				{#if error}
+				{#if error && !clientIdError}
 					<p class="text-sm text-danger">{error}</p>
 				{/if}
 				{#if needsClientId}

--- a/apps/web/src/lib/components/auth/ReauthModal.svelte
+++ b/apps/web/src/lib/components/auth/ReauthModal.svelte
@@ -9,6 +9,7 @@ import {
   getReauthRequired,
   signIn,
 } from "$lib/stores/auth.svelte";
+import { setGithubConfigStrict } from "$lib/stores/settings.svelte";
 
 const reauth = $derived(getReauthRequired());
 const deviceFlow = $derived(getDeviceFlow());
@@ -16,6 +17,17 @@ const error = $derived(getError());
 const isLoading = $derived(getIsLoading());
 
 let copied = $state(false);
+let clientId = $state("");
+let clientIdError = $state<string | null>(null);
+let isSavingClientId = $state(false);
+
+const needsClientId = $derived(
+  Boolean(
+    reauth?.host &&
+      reauth.host !== "github.com" &&
+      error?.includes("requires a GitHub App or OAuth App client ID"),
+  ),
+);
 
 async function copyCode(): Promise<void> {
   if (!deviceFlow) return;
@@ -28,6 +40,23 @@ function startReauth(): void {
   // Re-auth against the same GitHub host the expired account belongs to so
   // GHE accounts land on the right instance.
   void signIn(reauth?.host ?? undefined);
+}
+
+async function saveClientIdAndRetry(): Promise<void> {
+  const host = reauth?.host;
+  const trimmed = clientId.trim();
+  if (!host || !trimmed || isSavingClientId) return;
+
+  clientIdError = null;
+  isSavingClientId = true;
+  try {
+    await setGithubConfigStrict(host, trimmed);
+    await signIn(host);
+  } catch (e) {
+    clientIdError = e instanceof Error ? e.message : String(e);
+  } finally {
+    isSavingClientId = false;
+  }
 }
 </script>
 
@@ -99,14 +128,48 @@ function startReauth(): void {
 				{#if error}
 					<p class="text-sm text-danger">{error}</p>
 				{/if}
-				<button
-					class="flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-bg-tertiary px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
-					onclick={startReauth}
-					disabled={isLoading}
-				>
-					<GithubLogo size={18} weight="fill" />
-					Sign in again
-				</button>
+				{#if needsClientId}
+					<form
+						class="flex w-full flex-col gap-3 text-left"
+						onsubmit={(e) => {
+							e.preventDefault();
+							void saveClientIdAndRetry();
+						}}
+					>
+						<label class="flex flex-col gap-1.5 text-xs font-medium text-text-secondary">
+							GitHub App client ID for {reauth.host}
+							<input
+								class="h-10 rounded-lg border border-border bg-bg-tertiary px-3 text-sm text-text-primary outline-none focus:border-accent"
+								type="text"
+								autocapitalize="off"
+								autocorrect="off"
+								spellcheck="false"
+								placeholder="Iv23xxxxxxxxxxxxxxxx"
+								bind:value={clientId}
+							/>
+						</label>
+						{#if clientIdError}
+							<p class="text-sm text-danger">{clientIdError}</p>
+						{/if}
+						<button
+							class="flex cursor-pointer items-center justify-center gap-2 rounded-lg border border-border bg-bg-tertiary px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+							type="submit"
+							disabled={isSavingClientId || clientId.trim().length === 0}
+						>
+							<GithubLogo size={18} weight="fill" />
+							Save and sign in
+						</button>
+					</form>
+				{:else}
+					<button
+						class="flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-bg-tertiary px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+						onclick={startReauth}
+						disabled={isLoading}
+					>
+						<GithubLogo size={18} weight="fill" />
+						Sign in again
+					</button>
+				{/if}
 			{/if}
 		</div>
 	</div>

--- a/apps/web/src/lib/components/auth/SignInButton.svelte
+++ b/apps/web/src/lib/components/auth/SignInButton.svelte
@@ -86,7 +86,7 @@ async function copyCode() {
 		{/if}
 		<button
 			class="flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-bg-elevated px-4 py-2.5 text-sm font-medium text-text-primary transition-colors hover:bg-bg-tertiary disabled:cursor-not-allowed disabled:opacity-50"
-			onclick={() => signIn()}
+			onclick={() => void signIn()}
 			disabled={isLoading}
 		>
 			{#if isLoading}

--- a/apps/web/src/lib/components/onboarding/StepSignIn.svelte
+++ b/apps/web/src/lib/components/onboarding/StepSignIn.svelte
@@ -104,7 +104,11 @@ async function copyCode() {
 			</p>
 
 			<div class="actions">
-				<button class="primary" onclick={() => signIn(isGhe ? githubHost : undefined)} disabled={isLoading}>
+				<button
+					class="primary"
+					onclick={() => void signIn(isGhe ? githubHost : undefined)}
+					disabled={isLoading}
+				>
 					<span>{isLoading ? `Opening ${hostLabel}…` : `Sign in with ${hostLabel}`}</span>
 					{#if !isLoading}
 						<svg

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -27,7 +27,7 @@ let isLoading = $state(false);
 let isSwitching = $state(false);
 let error = $state<string | null>(null);
 
-export type SignInErrorCode = "missing_github_client_id";
+export type SignInErrorCode = "invalid_github_client_id" | "missing_github_client_id";
 let signInErrorCode = $state<SignInErrorCode | null>(null);
 
 let deviceFlow = $state<{
@@ -167,7 +167,9 @@ export function clearToken(): void {
 }
 
 function parseSignInErrorCode(value: unknown): SignInErrorCode | null {
-  return value === "missing_github_client_id" ? value : null;
+  return value === "missing_github_client_id" || value === "invalid_github_client_id"
+    ? value
+    : null;
 }
 
 export async function signIn(host?: string): Promise<boolean> {

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -27,6 +27,9 @@ let isLoading = $state(false);
 let isSwitching = $state(false);
 let error = $state<string | null>(null);
 
+export type SignInErrorCode = "missing_github_client_id";
+let signInErrorCode = $state<SignInErrorCode | null>(null);
+
 let deviceFlow = $state<{
   userCode: string;
   verificationUri: string;
@@ -133,6 +136,10 @@ export function getError(): string | null {
   return error;
 }
 
+export function getSignInErrorCode(): SignInErrorCode | null {
+  return signInErrorCode;
+}
+
 export function getDeviceFlow(): typeof deviceFlow {
   return deviceFlow;
 }
@@ -153,13 +160,19 @@ export function clearToken(): void {
   // a dead session strands the modal with no account behind it.
   reauthRequired = null;
   error = null;
+  signInErrorCode = null;
   if (typeof localStorage !== "undefined") {
     localStorage.removeItem("rev_session_token");
   }
 }
 
-export async function signIn(host?: string): Promise<void> {
+function parseSignInErrorCode(value: unknown): SignInErrorCode | null {
+  return value === "missing_github_client_id" ? value : null;
+}
+
+export async function signIn(host?: string): Promise<boolean> {
   error = null;
+  signInErrorCode = null;
   isLoading = true;
   try {
     const res = await fetch(`${API_BASE_URL}/api/auth/device/init`, {
@@ -175,8 +188,9 @@ export async function signIn(host?: string): Promise<void> {
       const body = await res.text().catch(() => "");
       let detail = body.trim();
       try {
-        const parsed = JSON.parse(body) as { error?: string };
+        const parsed = JSON.parse(body) as { error?: string; code?: unknown };
         if (parsed?.error) detail = parsed.error;
+        signInErrorCode = parseSignInErrorCode(parsed?.code);
       } catch {
         /* plain-text body — use as-is */
       }
@@ -209,8 +223,10 @@ export async function signIn(host?: string): Promise<void> {
       // Opening browser is best-effort
     }
     startPolling();
+    return true;
   } catch (e) {
     error = `Failed to start sign-in: ${e instanceof Error ? e.message : String(e)}`;
+    return false;
   } finally {
     isLoading = false;
   }
@@ -231,6 +247,7 @@ async function poll(): Promise<void> {
 
   if (Date.now() > deviceFlow.expiresAt) {
     error = "Sign-in timed out. Please try again.";
+    signInErrorCode = null;
     cancelSignIn();
     return;
   }
@@ -305,6 +322,7 @@ async function poll(): Promise<void> {
           : data.error
             ? `Sign-in failed: ${data.error}`
             : "Sign-in failed. Please try again.";
+    signInErrorCode = null;
     cancelSignIn();
   } catch {
     // Network error — retry after current interval
@@ -321,6 +339,7 @@ export function cancelSignIn(): void {
 
 export function clearError(): void {
   error = null;
+  signInErrorCode = null;
 }
 
 export async function loadUser(): Promise<void> {

--- a/apps/web/src/lib/stores/settings.svelte.ts
+++ b/apps/web/src/lib/stores/settings.svelte.ts
@@ -64,6 +64,28 @@ export async function setGithubConfig(host: string, clientId: string): Promise<v
 }
 
 /**
+ * Persist GitHub host/client ID and surface failures to callers that need a
+ * hard recovery path, such as reauth after an upgrade. Most settings controls
+ * intentionally use `updateSettings`, which remains best-effort/optimistic.
+ */
+export async function setGithubConfigStrict(host: string, clientId: string): Promise<void> {
+  const partial = { githubHost: host, githubClientId: clientId };
+  const previous = settings;
+  if (settings) settings = { ...settings, ...partial };
+
+  const res = await fetch(`${API_BASE_URL}/api/settings`, {
+    method: "PUT",
+    headers: { ...authHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify(partial),
+  });
+  if (!res.ok) {
+    settings = previous;
+    const detail = await res.text().catch(() => "");
+    throw new Error(detail.trim() || `Failed to save GitHub settings (HTTP ${res.status})`);
+  }
+}
+
+/**
  * Read the cached model list for a given agent (or the currently selected
  * agent when `agent` is omitted). Returns an empty array if models have not
  * been fetched yet — callers can use `areModelsLoaded` to disambiguate

--- a/apps/web/src/lib/stores/settings.svelte.ts
+++ b/apps/web/src/lib/stores/settings.svelte.ts
@@ -63,26 +63,8 @@ export async function setGithubConfig(host: string, clientId: string): Promise<v
   await updateSettings({ githubHost: host, githubClientId: clientId });
 }
 
-/**
- * Persist GitHub host/client ID and surface failures to callers that need a
- * hard recovery path, such as reauth after an upgrade. Most settings controls
- * intentionally use `updateSettings`, which remains best-effort/optimistic.
- */
 export async function setGithubConfigStrict(host: string, clientId: string): Promise<void> {
-  const partial = { githubHost: host, githubClientId: clientId };
-  const previous = settings;
-  if (settings) settings = { ...settings, ...partial };
-
-  const res = await fetch(`${API_BASE_URL}/api/settings`, {
-    method: "PUT",
-    headers: { ...authHeaders(), "Content-Type": "application/json" },
-    body: JSON.stringify(partial),
-  });
-  if (!res.ok) {
-    settings = previous;
-    const detail = await res.text().catch(() => "");
-    throw new Error(detail.trim() || `Failed to save GitHub settings (HTTP ${res.status})`);
-  }
+  await updateSettings({ githubHost: host, githubClientId: clientId }, { strict: true });
 }
 
 /**
@@ -126,7 +108,36 @@ export type SettingsUpdate = Partial<Omit<UserSettings, "id" | "recap" | "cache"
   };
 };
 
-export async function updateSettings(partial: SettingsUpdate): Promise<void> {
+type UpdateSettingsOptions = {
+  /**
+   * Most settings controls are optimistic/best-effort. Recovery flows can opt
+   * into strict mode to rollback local state and surface persistence failures.
+   */
+  strict?: boolean;
+};
+
+function settingsErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === "object") {
+    const value = "value" in error ? (error as { value?: unknown }).value : error;
+    if (value && typeof value === "object" && "message" in value) {
+      const message = (value as { message?: unknown }).message;
+      if (typeof message === "string") return message;
+    }
+    try {
+      return JSON.stringify(value);
+    } catch {
+      // fall through
+    }
+  }
+  return String(error);
+}
+
+export async function updateSettings(
+  partial: SettingsUpdate,
+  options: UpdateSettingsOptions = {},
+): Promise<void> {
+  const previous = settings;
   // Optimistic local merge — apply the partial immediately so concurrent calls
   // (e.g. model + context-window in the same popover session) don't clobber each
   // other when server responses arrive out of order. `recap` and `cache` are
@@ -159,11 +170,16 @@ export async function updateSettings(partial: SettingsUpdate): Promise<void> {
     invalidateSuggestions();
   }
   try {
-    await api.api.settings.put(partial as Record<string, unknown>);
+    const result = await api.api.settings.put(partial as Record<string, unknown>);
+    if (result.error) throw new Error(settingsErrorMessage(result.error));
     // Intentionally ignore the response body: merging a full settings object
     // here would reintroduce the race described above.
-  } catch {
-    // handle silently
+  } catch (e) {
+    if (options.strict) {
+      settings = previous;
+      throw e instanceof Error ? e : new Error(settingsErrorMessage(e));
+    }
+    // Non-strict settings controls are best-effort.
   }
 }
 

--- a/packages/shared/src/github-client-id.ts
+++ b/packages/shared/src/github-client-id.ts
@@ -1,0 +1,11 @@
+export const GITHUB_CLIENT_ID_HINT =
+  "GitHub client IDs start with Iv for GitHub Apps or Ov for OAuth Apps.";
+
+/**
+ * GitHub App client IDs currently start with `Iv`; classic OAuth App client
+ * IDs start with `Ov`. Keep this as a shape check only: GitHub remains the
+ * authority for whether the id exists on a given host.
+ */
+export function isLikelyGitHubClientId(value: string): boolean {
+  return /^(Iv|Ov)[A-Za-z0-9]{8,}$/.test(value.trim());
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -78,6 +78,7 @@ export {
 } from "./constants";
 export type { ServerEventMessage, WalkthroughEventEnvelope } from "./events";
 export * from "./events";
+export { GITHUB_CLIENT_ID_HINT, isLikelyGitHubClientId } from "./github-client-id";
 export { guessImageContentType, isImagePath } from "./images";
 export { isMaintainerLogin, MAINTAINER_LOGINS } from "./maintainers";
 export { detectMentionTrigger, extractMentionTokens, type MentionTrigger } from "./mentions";


### PR DESCRIPTION
Adds a recovery path to the desktop-rendered reauth modal when a GitHub Enterprise account exists but its saved OAuth/GitHub App client ID is missing or invalid after an update. The modal now relies on structured auth error codes, validates pasted GitHub App/OAuth App client ID shapes before saving, persists through the shared settings update path in strict mode, and keeps the recovery form open if retry fails or GitHub rejects the ID. This fixes the confusing state where Revv can show a connected GHE account but cannot start reauth after the token expires. Validation: bun run typecheck && bun run lint && bun run knip && bun run build; bun --filter @revv/server test.