### PR TITLE
chore: Skip welcome for connected accounts

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/web/src/lib/components/onboarding/OnboardingGate.svelte
+++ b/apps/web/src/lib/components/onboarding/OnboardingGate.svelte
@@ -7,6 +7,7 @@ import {
   getIsAuthenticated,
   getIsOnboarded,
   getLocalAccounts,
+  getLocalAccountsLoaded,
   getToken,
   getUser,
   resetForceOnboardingFlow,
@@ -35,20 +36,23 @@ const authed = $derived(getIsAuthenticated());
 const onboarded = $derived(getIsOnboarded());
 const hasUser = $derived(getUser() !== null);
 const localAccounts = $derived(getLocalAccounts());
+const localAccountsLoaded = $derived(getLocalAccountsLoaded());
+const hasLocalConnectedAccount = $derived(localAccounts.some((la) => la.accounts.length > 0));
 
 // During a fresh page load with a stored token but no user payload yet,
 // `authed` is true but `onboarded` is false because the identity request
 // hasn't returned. Showing onboarding in that window would flash the
 // welcome screen for an already-onboarded user. Hold the gate's decision
-// until either the user payload lands OR we can confirm there's no token.
-const ready = $derived(getToken() === null || hasUser);
+// until either the user payload lands OR, for signed-out boots, local
+// account detection has resolved so returning users go straight to picker.
+const ready = $derived(getToken() === null ? localAccountsLoaded : hasUser);
 
 let showApp = $derived(authed && onboarded);
 const forceFlow = $derived(getForceOnboardingFlow());
 // Show the account picker when: not authenticated, but local accounts exist on this machine
 // Suppress picker when the account was just removed or force flag is set — fall through to OnboardingFlow instead
 let showPicker = $derived(
-  !authed && localAccounts.length > 0 && !getAccountJustRemoved() && !forceFlow,
+  !authed && hasLocalConnectedAccount && !getAccountJustRemoved() && !forceFlow,
 );
 
 // User can dismiss the picker to reach the full onboarding flow

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -61,6 +61,7 @@ export type LocalAccount = {
 
 let _connectedAccounts = $state<ConnectedAccount[]>([]);
 let localAccounts = $state<LocalAccount[]>([]);
+let localAccountsLoaded = $state(typeof localStorage === "undefined");
 let accountJustRemoved = $state(false);
 
 /**
@@ -88,6 +89,10 @@ export function clearReauthRequired(): void {
 
 export function getLocalAccounts(): LocalAccount[] {
   return localAccounts;
+}
+
+export function getLocalAccountsLoaded(): boolean {
+  return localAccountsLoaded;
 }
 
 export function getAccountJustRemoved(): boolean {
@@ -508,6 +513,8 @@ export async function fetchLocalAccounts(): Promise<void> {
     }
   } catch {
     // best-effort
+  } finally {
+    localAccountsLoaded = true;
   }
 }
 


### PR DESCRIPTION
Fixes returning-user onboarding by exposing a local-account loaded flag and holding OnboardingGate until the first lookup completes.

When signed out with a connected account, the gate now sends users straight to the account picker instead of briefly showing the welcome Begin flow. It also requires an actual connected host entry before showing the picker, preserving first-run setup. Validated with `bun run typecheck && bun run lint && bun run knip && bun run build`.