### PR TITLE
fix(server): bind API to loopback only + loopback request guard

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -23,6 +23,10 @@ import { Config, Effect } from "effect";
  */
 export const ServerConfig = Config.all({
   port: Config.integer("PORT").pipe(Config.withDefault(API_PORT)),
+  // Bind interface. Loopback-only by default so the API is unreachable off-box.
+  // `REVV_HOST` is the escape hatch for self-hosting; a non-loopback value also
+  // disables the loopback request guard (an explicit opt-in to off-box exposure).
+  host: Config.string("REVV_HOST").pipe(Config.withDefault("127.0.0.1")),
   channel: Config.string("REVV_CHANNEL").pipe(Config.withDefault(DEFAULT_APP_CHANNEL)),
   // SQLite location. Empty (the default) means "auto-resolve to the per-user
   // app-data dir" (`<appDataDir>/revv.db`) — the same durable tree as

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -7,6 +7,7 @@ import { serverEnv } from "./config";
 import { resolveDbPath } from "./db/index";
 import { CORS_ORIGINS } from "./http-origins";
 import { logError } from "./logger";
+import { isLoopbackAddress } from "./net";
 import { recordSpan } from "./observability/tracer";
 import { chatRoute } from "./routes/chat";
 import { debugRoutes } from "./routes/debug";
@@ -57,6 +58,18 @@ const app = new Elysia()
       methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     }),
   )
+  .onRequest(({ request, server, set }) => {
+    // Defense-in-depth: reject non-loopback peers so a future bind-widening
+    // can't silently re-expose the API. Skipped when bound to a non-loopback
+    // host; fails open when the peer IP is undeterminable.
+    if (isLoopbackAddress(serverEnv.host)) {
+      const peer = server?.requestIP(request)?.address;
+      if (peer && !isLoopbackAddress(peer)) {
+        set.status = 403;
+        return "Forbidden: this server only accepts loopback connections";
+      }
+    }
+  })
   .onRequest((ctx) => {
     // Stamp request start time for the post-hoc http.request span.
     (ctx.store as { _revvStartMs?: number })._revvStartMs = performance.now();
@@ -119,12 +132,14 @@ const app = new Elysia()
   }))
   .listen({
     port,
+    // Loopback only — without a hostname Bun binds to 0.0.0.0 (every interface).
+    hostname: serverEnv.host,
     // Prevent Bun's default idle timeout from killing long-running SSE streams
     // (e.g. agent chat turns that go quiet for >10 s during tool execution).
     idleTimeout: 255,
   });
 
-logError("server", `listening on http://localhost:${port}`);
+logError("server", `listening on http://${serverEnv.host}:${port}`);
 
 // Migrate any plaintext GitHub tokens left in the `account` table into the OS
 // secure store, then null the columns. Awaited before the sync scheduler boots

--- a/apps/server/src/net.test.ts
+++ b/apps/server/src/net.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { isLoopbackAddress } from "./net";
+
+describe("isLoopbackAddress", () => {
+  it("treats every loopback form as local", () => {
+    expect(isLoopbackAddress("127.0.0.1")).toBe(true);
+    expect(isLoopbackAddress("127.0.0.53")).toBe(true);
+    expect(isLoopbackAddress("::1")).toBe(true);
+    expect(isLoopbackAddress("::ffff:127.0.0.1")).toBe(true);
+    expect(isLoopbackAddress("localhost")).toBe(true);
+    expect(isLoopbackAddress(" 127.0.0.1 ")).toBe(true);
+    expect(isLoopbackAddress("::FFFF:127.0.0.1")).toBe(true);
+  });
+
+  it("rejects bind-to-all and LAN addresses", () => {
+    expect(isLoopbackAddress("0.0.0.0")).toBe(false);
+    expect(isLoopbackAddress("::")).toBe(false);
+    expect(isLoopbackAddress("192.168.1.20")).toBe(false);
+    expect(isLoopbackAddress("10.0.0.5")).toBe(false);
+    expect(isLoopbackAddress("172.16.4.9")).toBe(false);
+    expect(isLoopbackAddress("::ffff:192.168.1.20")).toBe(false);
+    expect(isLoopbackAddress("128.0.0.1")).toBe(false);
+    expect(isLoopbackAddress("")).toBe(false);
+  });
+});

--- a/apps/server/src/net.ts
+++ b/apps/server/src/net.ts
@@ -1,0 +1,14 @@
+const IPV4_MAPPED_PREFIX = "::ffff:";
+const IPV4_LOOPBACK = /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+
+/**
+ * True when `address` is a loopback interface: `localhost`, `::1`, the IPv4
+ * `127.0.0.0/8` block, or IPv4-mapped IPv6 (`::ffff:127.0.0.1`). `0.0.0.0`/`::`
+ * (bind-to-all) are deliberately NOT loopback.
+ */
+export function isLoopbackAddress(address: string): boolean {
+  const a = address.trim().toLowerCase();
+  if (a === "localhost" || a === "::1") return true;
+  const bare = a.startsWith(IPV4_MAPPED_PREFIX) ? a.slice(IPV4_MAPPED_PREFIX.length) : a;
+  return IPV4_LOOPBACK.test(bare);
+}


### PR DESCRIPTION
Server bound to `0.0.0.0`, exposing the whole API to the LAN. Unauthenticated `GET /api/auth/local-accounts` + `POST /api/auth/switch` let any device on the network mint a session token and drive the GitHub proxy as the victim.

Fix: bind to loopback (`REVV_HOST`, default `127.0.0.1`) + `onRequest` guard rejecting non-loopback peers. Includes `isLoopbackAddress` + tests.

Point 1 of the ticket. Point 2 (local-process vector) is a follow-up.