### PR TITLE
perf(server): make walkthrough rounds endpoint DB-only

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.16.1"
+version = "0.17.1"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/routes/reviews.ts
+++ b/apps/server/src/routes/reviews.ts
@@ -280,14 +280,13 @@ export const reviewRoutes = new Elysia({ prefix: "/api/reviews" })
           const prContext = yield* PrContextService;
           const walkthroughService = yield* WalkthroughService;
           const mode = coerceWalkthroughMode(ctx.query.mode);
-          const { pr, repo, token } = yield* prContext.resolveBasic(
-            ctx.params.id,
-            ctx.session.user.id,
-          );
-          const commits = yield* prContext
-            .prCommits(repo.fullName, pr.externalId, token)
-            .pipe(Effect.catchAll(() => Effect.succeed([])));
-          return yield* walkthroughService.listReviewRounds(pr.id, pr.headSha, commits, mode);
+          const { pr } = yield* prContext.resolveBasic(ctx.params.id, ctx.session.user.id);
+          // No live GitHub commit fetch here: round focus titles derive from the
+          // commit list persisted per walkthrough (`walkthroughs.prCommits`), so
+          // this high-frequency endpoint stays DB-only. The client refreshes it
+          // for every active PR on each `prs:updated`, so an uncached paginated
+          // GitHub call here would add avoidable rate-limit pressure.
+          return yield* walkthroughService.listReviewRounds(pr.id, pr.headSha, mode);
         }),
       );
     } catch (e) {

--- a/apps/server/src/services/PrContext.ts
+++ b/apps/server/src/services/PrContext.ts
@@ -88,11 +88,6 @@ export class PrContextService extends Context.Tag("PrContextService")<
       externalId: number,
       token: string,
     ) => Effect.Effect<PrFileMeta[], GitHubError, DbService | GitHubEtagCache | SettingsService>;
-    readonly prCommits: (
-      repoFullName: string,
-      externalId: number,
-      token: string,
-    ) => Effect.Effect<PrCommit[], GitHubError, SettingsService>;
     /**
      * Full PR fetch by number. Thin forward to the GitHub gateway. Used by
      * the recap backfill path to hydrate PRs that never landed in the local
@@ -249,8 +244,6 @@ export const PrContextServiceLive = Layer.effect(
       github.prs.meta(repoFullName, externalId, token);
     const prFiles = (repoFullName: string, externalId: number, token: string) =>
       github.prs.files(repoFullName, externalId, token);
-    const prCommits = (repoFullName: string, externalId: number, token: string) =>
-      github.prs.commits(repoFullName, externalId, token);
     const fetchPr = (repoFullName: string, externalId: number, token: string) =>
       github.prs.get(repoFullName, externalId, token);
     const searchClosedPrs = (
@@ -280,7 +273,6 @@ export const PrContextServiceLive = Layer.effect(
       resolveWithDiff,
       prMeta,
       prFiles,
-      prCommits,
       fetchPr,
       searchClosedPrs,
       resolveRepoToken,

--- a/apps/server/src/services/Walkthrough.test.ts
+++ b/apps/server/src/services/Walkthrough.test.ts
@@ -53,6 +53,10 @@ describe("commitsInRoundRange", () => {
 });
 
 describe("deriveRoundFocusTitle", () => {
+  it("returns null when persisted commits are unavailable", () => {
+    expect(__walkthroughTest.deriveRoundFocusTitle(null, "b", "d")).toBeNull();
+  });
+
   it("uses the newest non-low-signal commit in the selected round", () => {
     const commits = [
       commit("a", "feat: base"),

--- a/apps/server/src/services/Walkthrough.test.ts
+++ b/apps/server/src/services/Walkthrough.test.ts
@@ -61,7 +61,7 @@ describe("deriveRoundFocusTitle", () => {
       commit("d", "test: add query coverage"),
     ];
 
-    expect(__walkthroughTest.deriveRoundFocusTitle(null, "b", "d", commits)).toBe(
+    expect(__walkthroughTest.deriveRoundFocusTitle(JSON.stringify(commits), "b", "d")).toBe(
       "add range indexes",
     );
   });

--- a/apps/server/src/services/Walkthrough.ts
+++ b/apps/server/src/services/Walkthrough.ts
@@ -281,11 +281,8 @@ function deriveRoundFocusTitle(
   rawCommits: string | null,
   fromSha: string | null,
   toSha: string,
-  fallbackCommits: readonly PrCommit[] = [],
 ): string | null {
-  const persistedCommits = parsePrCommits(rawCommits);
-  const sourceCommits = persistedCommits.length > 0 ? persistedCommits : fallbackCommits;
-  const commits = commitsInRoundRange(sourceCommits, fromSha, toSha);
+  const commits = commitsInRoundRange(parsePrCommits(rawCommits), fromSha, toSha);
   const subjects = commits
     .map((commit) => subjectFromCommitMessage(commit.message))
     .filter((subject) => subject.length > 0);
@@ -624,7 +621,6 @@ export class WalkthroughService extends Context.Tag("WalkthroughService")<
     readonly listReviewRounds: (
       prId: string,
       currentHeadSha: string | null,
-      fallbackCommits?: readonly PrCommit[],
       mode?: WalkthroughMode,
     ) => Effect.Effect<WalkthroughReviewRoundsResponse, never, DbService>;
   }
@@ -1316,7 +1312,7 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
       };
     }).pipe(Effect.catchAll(() => Effect.succeed(null))),
 
-  listReviewRounds: (prId, currentHeadSha, fallbackCommits = [], mode = "reviewer") =>
+  listReviewRounds: (prId, currentHeadSha, mode = "reviewer") =>
     Effect.gen(function* () {
       const { db } = yield* DbService;
       const rows = db
@@ -1358,12 +1354,7 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
         createdAt: row.createdAt,
         completedAt: row.completedAt ?? null,
         summary: row.summary.trim() ? row.summary : null,
-        focusTitle: deriveRoundFocusTitle(
-          row.prCommits,
-          row.fromSha ?? null,
-          row.toSha,
-          fallbackCommits,
-        ),
+        focusTitle: deriveRoundFocusTitle(row.prCommits, row.fromSha ?? null, row.toSha),
         prHeadSha: row.prHeadSha,
       }));
 
@@ -1402,12 +1393,7 @@ export const WalkthroughServiceLive = Layer.succeed(WalkthroughService, {
           createdAt: row.generatedAt,
           completedAt: row.completedAt ?? null,
           summary: row.summary.trim() ? row.summary : null,
-          focusTitle: deriveRoundFocusTitle(
-            row.prCommits,
-            row.baseHeadSha ?? null,
-            row.prHeadSha,
-            fallbackCommits,
-          ),
+          focusTitle: deriveRoundFocusTitle(row.prCommits, row.baseHeadSha ?? null, row.prHeadSha),
           prHeadSha: row.prHeadSha,
         }));
       }


### PR DESCRIPTION
The `GET /api/reviews/:prId/walkthrough/rounds` endpoint made an uncached, paginated GitHub commits fetch on every call, and the web client fires it for every active PR on each `prs:updated` SSE — adding avoidable GitHub rate-limit pressure introduced in #141. Those commits were only a fallback for round focus titles, which already derive from the commit list persisted per walkthrough (`walkthroughs.prCommits`), so the live fetch was redundant. This PR drops the fetch to make the high-frequency endpoint DB-only, and removes the now-dead `prCommits` passthrough on `PrContext` and the `fallbackCommits` parameter on `listReviewRounds`/`deriveRoundFocusTitle`. Focus titles for walkthroughs generated post-#141 are unchanged; only legacy rows predating the persisted column lose a best-effort fallback (already degrading gracefully to none). Verified with typecheck, lint, build, and the Walkthrough test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)