### PR TITLE
fix: add Claude Sonnet 5 and Fable 5 model choices

### DIFF
--- a/packages/shared/src/acp-agents.ts
+++ b/packages/shared/src/acp-agents.ts
@@ -97,7 +97,9 @@ export const ACP_AGENTS = [
     args: ["-y", "@agentclientprotocol/claude-agent-acp"],
     capabilities: {
       models: [
+        { label: "Claude Fable 5", value: "claude-fable-5" },
         { label: "Claude Opus 4.8", value: "claude-opus-4-8" },
+        { label: "Claude Sonnet 5", value: "claude-sonnet-5" },
         { label: "Claude Sonnet 4.6", value: "claude-sonnet-4-6" },
         { label: "Claude Haiku 4.5", value: "claude-haiku-4-5-20251001" },
       ],


### PR DESCRIPTION
## Summary
Adds Claude Fable 5 and Claude Sonnet 5 to the Claude Code model catalog so they appear in Revv model selection.

## Verification
- bun run typecheck && bun run lint && bun run knip && bun run build