### PR TITLE
feat: set default model

### DIFF
--- a/apps/server/src/ai/acp/presets.test.ts
+++ b/apps/server/src/ai/acp/presets.test.ts
@@ -24,9 +24,15 @@ describe("ACP agent registry", () => {
       expect(typeof def.command).toBe("string");
       expect(Array.isArray(def.args)).toBe(true);
       expect(def.capabilities).toBeDefined();
+      expect(typeof def.capabilities.defaultModel).toBe("string");
       expect(def.capabilities.models === "dynamic" || Array.isArray(def.capabilities.models)).toBe(
         true,
       );
+      if (def.capabilities.models !== "dynamic") {
+        expect(
+          def.capabilities.models.some((model) => model.value === def.capabilities.defaultModel),
+        ).toBe(true);
+      }
     }
   });
 });
@@ -151,12 +157,13 @@ describe("resolveGenerationModel", () => {
 
   it("falls back to the agent default when the model belongs to another agent", () => {
     // A Cursor model id left in the shared setting must not reach Claude Code.
-    expect(resolveGenerationModel("claude-code", "sonnet-4.6")).toBe("claude-opus-4-8");
+    expect(resolveGenerationModel("claude-code", "sonnet-4.6")).toBe("claude-sonnet-5");
   });
 
   it("trusts opencode's dynamic catalog", () => {
     expect(resolveGenerationModel("opencode", "some-provider/some-model")).toBe(
       "some-provider/some-model",
     );
+    expect(resolveGenerationModel("opencode", null)).toBe("opencode/big-pickle");
   });
 });

--- a/apps/server/src/ai/acp/presets.ts
+++ b/apps/server/src/ai/acp/presets.ts
@@ -12,6 +12,7 @@ import {
   type AcpAgentId,
   type ContextWindow,
   getAcpAgent,
+  getAcpAgentDefaultModel,
   getAgentCapabilities,
   isAcpAgentId,
   type ThinkingEffort,
@@ -197,19 +198,19 @@ export function resolveAcpProcessLaunchById(
  * `aiModel` (written against the global agent's catalog) may not belong to the
  * resolved agent. Guard against that: if the configured id isn't in the agent's
  * catalog, fall back to that agent's default model. opencode's catalog is
- * dynamic, so its models are taken on trust. Returns `undefined` only when
- * there is no configured model and no static default (caller supplies its own
- * fallback).
+ * dynamic, so configured opencode models are taken on trust.
  */
 export function resolveGenerationModel(
   agent: AcpAgentId,
   configuredModel: string | null | undefined,
 ): string | undefined {
   const caps = getAgentCapabilities(agent);
-  if (caps.models === "dynamic") return configuredModel ?? undefined;
+  if (caps.models === "dynamic") return configuredModel ?? getAcpAgentDefaultModel(agent);
   if (configuredModel && caps.models.some((m) => m.value === configuredModel)) {
     return configuredModel;
   }
+  const defaultModel = getAcpAgentDefaultModel(agent);
+  if (caps.models.some((m) => m.value === defaultModel)) return defaultModel;
   return caps.models[0]?.value;
 }
 

--- a/apps/web/src/lib/constants/models.ts
+++ b/apps/web/src/lib/constants/models.ts
@@ -1,4 +1,4 @@
-import type { AcpAgentId, ThinkingEffort } from "@revv/shared";
+import { type AcpAgentId, getAcpAgentDefaultModel, type ThinkingEffort } from "@revv/shared";
 
 export type ModelOption = { label: string; value: string };
 
@@ -14,15 +14,8 @@ export const THINKING_EFFORT_OPTIONS: { label: string; value: ThinkingEffort }[]
   { label: "Low", value: "low" },
 ];
 
-const DEFAULT_MODEL_BY_AGENT: Record<AcpAgentId, string> = {
-  opencode: "opencode/big-pickle",
-  "claude-code": "claude-sonnet-4-6",
-  codex: "gpt-5.5",
-  cursor: "auto",
-};
-
 export function getDefaultModel(agent: AcpAgentId): string {
-  return DEFAULT_MODEL_BY_AGENT[agent];
+  return getAcpAgentDefaultModel(agent);
 }
 
 // Low-cost defaults for the right-panel suggestions feature. Pinned to the

--- a/apps/web/src/lib/stores/settings.svelte.ts
+++ b/apps/web/src/lib/stores/settings.svelte.ts
@@ -251,8 +251,13 @@ export function cascadeChatAgentChange(acpId: AcpAgentId): SettingsUpdate {
     const cached = getAvailableModels(acpId);
     update.aiModel = cached[0]?.value ?? getDefaultModel(acpId);
   } else {
-    const first = caps.models[0];
-    if (first) update.aiModel = first.value;
+    const defaultModel = getDefaultModel(acpId);
+    const fallback = caps.models[0]?.value;
+    if (caps.models.some((m) => m.value === defaultModel)) {
+      update.aiModel = defaultModel;
+    } else if (fallback) {
+      update.aiModel = fallback;
+    }
   }
 
   if (caps.thinkingEfforts.length > 0) {

--- a/packages/shared/src/acp-agents.ts
+++ b/packages/shared/src/acp-agents.ts
@@ -29,6 +29,8 @@ export interface AcpAgentModel {
  * default the persisted model. Anything not represented here is owned agent-side.
  */
 export interface AcpAgentCapabilities {
+  /** Revv's default model for this agent when no user-specific model is saved. */
+  readonly defaultModel: string;
   /**
    * Static model catalog (label + id), or the literal `"dynamic"` when the list
    * must be fetched live from the server (opencode runs `opencode models`). ACP
@@ -96,6 +98,7 @@ export const ACP_AGENTS = [
     command: "npx",
     args: ["-y", "@agentclientprotocol/claude-agent-acp"],
     capabilities: {
+      defaultModel: "claude-sonnet-5",
       models: [
         { label: "Claude Fable 5", value: "claude-fable-5" },
         { label: "Claude Opus 4.8", value: "claude-opus-4-8" },
@@ -125,6 +128,7 @@ export const ACP_AGENTS = [
     command: "opencode",
     args: ["acp"],
     capabilities: {
+      defaultModel: "opencode/big-pickle",
       // opencode exposes 75+ models across providers; fetched live via the
       // server's `opencode models` parse rather than curated here.
       models: "dynamic",
@@ -143,6 +147,7 @@ export const ACP_AGENTS = [
     command: "npx",
     args: ["-y", "@zed-industries/codex-acp"],
     capabilities: {
+      defaultModel: "gpt-5.5",
       models: [
         { label: "GPT-5.5", value: "gpt-5.5" },
         { label: "GPT-5.4", value: "gpt-5.4" },
@@ -166,6 +171,7 @@ export const ACP_AGENTS = [
     command: "npx",
     args: ["-y", "cursor-agent-acp"],
     capabilities: {
+      defaultModel: "auto",
       // Curated from Cursor's CLI model roster (`cursor-agent --list-models`).
       // Re-verify when Cursor ships/retires models.
       models: [
@@ -205,6 +211,11 @@ export function getAcpAgent(id: AcpAgentId): AcpAgentDescriptor {
 /** The model / context-window / thinking-effort surface Revv exposes for an agent. */
 export function getAgentCapabilities(id: AcpAgentId): AcpAgentCapabilities {
   return getAcpAgent(id).capabilities;
+}
+
+/** Revv's persisted-model default for an ACP agent. */
+export function getAcpAgentDefaultModel(id: AcpAgentId): string {
+  return getAcpAgent(id).capabilities.defaultModel;
 }
 
 /** Keychain-login details for an agent, or `undefined` when it isn't keychain-backed. */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,6 +12,7 @@ export {
   ACP_AGENT_IDS,
   ACP_AGENTS,
   getAcpAgent,
+  getAcpAgentDefaultModel,
   getAgentCapabilities,
   getAgentKeychainAuth,
   isAcpAgentId,


### PR DESCRIPTION
## Summary
- Add an explicit per-agent default model to the shared ACP registry
- Set Claude Code's default model to Claude Sonnet 5
- Use the shared default in the web agent cascade and server generation fallback

## Verification
- bun run typecheck && bun run lint && bun run knip && bun run build
- bun test apps/server/src/ai/acp/presets.test.ts