### PR TITLE
fix(auth): never apply a BYO GHE client_id to github.com

### DIFF
--- a/apps/server/src/github-oauth.test.ts
+++ b/apps/server/src/github-oauth.test.ts
@@ -15,3 +15,21 @@ describe("GitHub client ID validation", () => {
     );
   });
 });
+
+describe("clientIdForHost host resolution", () => {
+  // Regression: a stale BYO GHE client_id left in settings after switching back
+  // to a github.com account must NOT be applied to github.com — it 404s on
+  // github.com's device-code endpoint. github.com always uses the bundled id.
+  it("ignores a custom (GHE) client id on github.com and uses the bundled id", () => {
+    const bundled = clientIdForHost("github.com", null);
+    const leakedGheId = "Iv23g4k6FNfeW0S9tUca";
+    expect(clientIdForHost("github.com", leakedGheId)).toBe(bundled);
+    expect(clientIdForHost("github.com", leakedGheId)).not.toBe(leakedGheId);
+    expect(bundled.length).toBeGreaterThan(0);
+  });
+
+  it("uses the supplied custom client id for a GHE host", () => {
+    const gheId = "Iv23li1234567890";
+    expect(clientIdForHost("ghe.example.com", gheId)).toBe(gheId);
+  });
+});

--- a/apps/server/src/github-oauth.ts
+++ b/apps/server/src/github-oauth.ts
@@ -69,12 +69,20 @@ export class InvalidGitHubClientIdError extends Error {
  * Client_id for a host.
  *
  * - **Pro on github.com** → the bundled GitHub App id.
+ * - **github.com (OSS)** → the bundled public OAuth App id.
  * - **A user-added GHE host** → `customClientId`, the GitHub App/OAuth App id
  *   the user registered on their own instance (passed from settings). There is
  *   no bundled registration on a customer's host.
- * - **github.com (OSS)** → the bundled public OAuth App id.
  * - **A GHE host configured via env** → the `GITHUB_CLIENT_ID` override (for a
  *   fixed self-hosted deployment).
+ *
+ * github.com ALWAYS resolves to Revv's bundled registration, and the public
+ * paths are checked BEFORE `customClientId` — a `customClientId` is bound to a
+ * GHE host and must never be applied to github.com. Otherwise a stale GHE id
+ * left in settings after switching back to a github.com account (the switch
+ * updates only the host) would be POSTed to github.com's device-code endpoint,
+ * which 404s. See the `settings.githubHost==='github.com'` clamp in
+ * `SettingsService.updateSettings` and the guard in `resolveGithubUrls`.
  *
  * Throws a clear error when github.com lacks `GITHUB_CLIENT_ID_PUBLIC`, or when
  * a GHE host has no client ID at all, so the user gets a diagnosable message
@@ -82,16 +90,6 @@ export class InvalidGitHubClientIdError extends Error {
  */
 export function clientIdForHost(host: string, customClientId?: string | null): string {
   if (usesGitHubApp(host)) return serverEnv.githubAppClientId;
-  const custom = customClientId?.trim();
-  if (custom) {
-    if (!isLikelyGitHubClientId(custom)) {
-      throw new InvalidGitHubClientIdError(
-        host,
-        `The GitHub App or OAuth App client ID for ${host} is not valid. ${GITHUB_CLIENT_ID_HINT}`,
-      );
-    }
-    return custom;
-  }
   if (isPublicGitHub(host)) {
     if (!serverEnv.githubClientIdPublic) {
       throw new MissingGitHubClientIdError(
@@ -101,6 +99,16 @@ export function clientIdForHost(host: string, customClientId?: string | null): s
       );
     }
     return serverEnv.githubClientIdPublic;
+  }
+  const custom = customClientId?.trim();
+  if (custom) {
+    if (!isLikelyGitHubClientId(custom)) {
+      throw new InvalidGitHubClientIdError(
+        host,
+        `The GitHub App or OAuth App client ID for ${host} is not valid. ${GITHUB_CLIENT_ID_HINT}`,
+      );
+    }
+    return custom;
   }
   if (serverEnv.githubClientId) return serverEnv.githubClientId;
   throw new MissingGitHubClientIdError(

--- a/apps/server/src/routes/device-auth.ts
+++ b/apps/server/src/routes/device-auth.ts
@@ -69,8 +69,9 @@ async function resolveGithubUrls(hostOverride?: string): Promise<{
   const host = hostOverride?.trim() || settings?.githubHost?.trim() || serverEnv.githubHost;
   const githubBase = `https://${host}`;
   const apiBase = isPublicGitHub(host) ? "https://api.github.com" : `https://api.${host}`;
-  // The BYO client ID applies only to the host it was saved with. For
-  // github.com it's empty and the resolver falls back to server config.
+  // The BYO client ID applies only to the host it was saved with. github.com
+  // ignores it regardless (see `clientIdForHost`), so no github.com-specific
+  // guard is needed here.
   const customClientId = settings?.githubHost?.trim() === host ? settings?.githubClientId : null;
   return {
     host,


### PR DESCRIPTION
## Problem

A production install hit an inescapable **"GitHub session expired"** reauth modal:

> Failed to start sign-in: Sign-in request failed (502): GitHub device flow failed for github.com (404 Not Found: Not Found). Check that the client ID belongs to this GitHub host and that Device Flow is enabled.

**Root cause:** the `user_settings` row had `github_host=github.com` but `github_client_id=Iv23…` — a stale **GitHub Enterprise** App id. Switching from a GHE account back to a github.com account updates only `githubHost`, never clearing `githubClientId`. That GHE id was then sent to `github.com/login/device/code`, which doesn't recognize it → `404 {"error":"Not Found"}` → wrapped as 502.

Verified directly against GitHub: the leaked `Iv23g4k6FNfeW0S9tUca` → **404**, the bundled public id `Ov23…` → **200**.

The prior guard (`settings.githubHost === host`) didn't catch this because the host *does* match (`github.com`) — only the client id is stale. And `clientIdForHost` checked a valid custom id *before* the bundled public fallback.

## Fix

One change, at the single choke point: **`clientIdForHost`** now resolves github.com's bundled id (GitHub App in Pro, public OAuth App otherwise) **before** consulting `customClientId`. Both `resolveGithubUrls` (device sign-in) and `TokenProvider` (refresh) call this function, so a custom id — which is only ever bound to a GHE host — can never reach github.com.

(device-auth gets a one-line comment noting no github.com guard is needed there anymore.)

## Tests

`github-oauth.test.ts`: github.com ignores a custom (GHE) id and returns the bundled id; a GHE host still uses its supplied id.

## Verification

`bun run typecheck && bun run lint && bun run knip && bun run build` all pass; `bun test src/github-oauth.test.ts` → 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)