### PR TITLE
feat: (server) reap stale PR review worktrees and branches

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -240,6 +240,17 @@ AppRuntime.runPromise(Effect.flatMap(RepoCloneService, (svc) => svc.resumePendin
   },
 );
 
+// Reap Revv-owned review worktrees + `revv/pr-N` branches for PRs that are
+// closed/merged (or no longer tracked), left behind by prior runs. Bounds
+// accumulation in the user's clone so VSCode isn't overwhelmed. Runs after
+// `resumePending` so any in-flight generation's worktree is protected by
+// `pruneWorktree`'s `generating` guard. Best-effort; never crashes boot.
+AppRuntime.runPromise(Effect.flatMap(RepoCloneService, (svc) => svc.sweepStaleWorktrees())).catch(
+  (err) => {
+    logError("repo-clone", "sweepStaleWorktrees failed on boot:", err);
+  },
+);
+
 // Start DB maintenance scheduler: sweeps expired cache rows and checkpoints
 // the WAL every 6 hours to prevent unbounded disk growth.
 AppRuntime.runPromise(Effect.flatMap(DbMaintenance, (svc) => svc.start())).catch((err) => {

--- a/apps/server/src/services/AppLayer.ts
+++ b/apps/server/src/services/AppLayer.ts
@@ -156,7 +156,14 @@ const WalkthroughJobsWithDeps = WalkthroughJobsLive.pipe(
 // PollScheduler depends on BaseLayers + SyncService (for thread polling) +
 // WalkthroughJobs (for superseding walkthroughs when a new head SHA arrives).
 const PollSchedulerWithDeps = PollSchedulerLive.pipe(
-  Layer.provide(Layer.mergeAll(BaseLayers, SyncServiceWithDeps, WalkthroughJobsWithDeps)),
+  Layer.provide(
+    Layer.mergeAll(
+      BaseLayers,
+      SyncServiceWithDeps,
+      WalkthroughJobsWithDeps,
+      RepoCloneServiceWithDeps,
+    ),
+  ),
 );
 
 // ProjectRecapJobs is the recap orchestrator. Mirrors WalkthroughJobs but

--- a/apps/server/src/services/PollScheduler.ts
+++ b/apps/server/src/services/PollScheduler.ts
@@ -15,6 +15,7 @@ import { GitHubEtagCache } from "./GitHubEtagCache";
 import { githubFetch } from "./github-rest";
 import { PullRequestService } from "./PullRequest";
 import { RemoteUserService } from "./RemoteUser";
+import { RepoCloneService } from "./RepoClone";
 import { RepositoryService } from "./Repository";
 import { SettingsService } from "./Settings";
 import { SyncService } from "./Sync";
@@ -59,6 +60,7 @@ export const PollSchedulerLive = Layer.effect(
     const syncService = yield* SyncService;
     const etagCache = yield* GitHubEtagCache;
     const walkthroughJobs = yield* WalkthroughJobs;
+    const repoClone = yield* RepoCloneService;
     const walkthroughService = yield* WalkthroughService;
     const tokenProvider = yield* TokenProvider;
     const { db } = yield* DbService;
@@ -611,6 +613,22 @@ export const PollSchedulerLive = Layer.effect(
 
             yield* withDb(prService.markPrsClosed(updates)).pipe(
               Effect.orElseSucceed(() => undefined),
+            );
+
+            // Reap the review worktree + `revv/pr-N` branch for each PR that
+            // just went terminal, so they stop accumulating in the user's
+            // clone (and cluttering VSCode). `pruneWorktree` self-guards
+            // against in-flight generations and un-pushed review commits, so
+            // this is safe to fire-and-forget; it must not block the sync loop.
+            yield* Effect.forkDaemon(
+              Effect.forEach(
+                closedPrObjects,
+                (pr) =>
+                  repoClone
+                    .pruneWorktree({ repoId: pr.repositoryId, prNumber: pr.externalId })
+                    .pipe(Effect.catchAll(() => Effect.void)),
+                { concurrency: 3, discard: true },
+              ),
             );
 
             // Targeted `pr:archived` envelopes for each transition. The full

--- a/apps/server/src/services/RepoClone.ts
+++ b/apps/server/src/services/RepoClone.ts
@@ -7,7 +7,7 @@ import { and, eq, or } from "drizzle-orm";
 import { Context, Effect, Layer } from "effect";
 import { serverEnv } from "../config";
 import { CLONE_TIMEOUT_MS } from "../constants";
-import { repositories } from "../db/schema/index";
+import { pullRequests, repositories, walkthroughs } from "../db/schema/index";
 import {
   CloneError,
   CloneNotReadyError,
@@ -56,6 +56,18 @@ const MAX_FILE_CONTENT_BYTES = 5 * 1024 * 1024;
 const BINARY_SNIFF_SAMPLE_BYTES = 8 * 1024;
 
 // ── Service definition ────────────────────────────────────────────────────────
+
+/**
+ * Result of a single-PR worktree reap. `pruned:false` means the teardown was
+ * intentionally skipped to avoid destroying live or unsaved work — the caller
+ * can surface `reason` (e.g. "you have N reviews with unpushed changes").
+ */
+export type PruneWorktreeOutcome =
+  | { readonly pruned: true }
+  | {
+      readonly pruned: false;
+      readonly reason: "unpushed-commits" | "generating" | "not-found";
+    };
 
 export class RepoCloneService extends Context.Tag("RepoCloneService")<
   RepoCloneService,
@@ -172,6 +184,31 @@ export class RepoCloneService extends Context.Tag("RepoCloneService")<
     }) => Effect.Effect<
       { readonly worktreePath: string; readonly branchName: string },
       CloneError | CloneNotReadyError | WorktreeBlockedByUnpushedCommits
+    >;
+    /**
+     * Reap a single PR's review worktree + `revv/pr-N` branch + fetch refs.
+     *
+     * Idempotent and best-effort. Refuses (returns `pruned:false`) when the
+     * teardown would lose work — unpushed commits on `revv/pr-N` beyond the
+     * recorded PR head — or when a walkthrough is still `generating` for the
+     * PR, unless `force` is set. Callers own the *policy* (which PRs are
+     * eligible, e.g. closed/merged); this owns the safe *teardown*. Handles
+     * both worktree-backed branches and orphan branches (no worktree dir).
+     */
+    readonly pruneWorktree: (params: {
+      readonly repoId: string;
+      readonly prNumber: number;
+      readonly force?: boolean;
+    }) => Effect.Effect<PruneWorktreeOutcome, CloneError>;
+    /**
+     * Sweep every ready repo for Revv-owned `revv/pr-N` branches/worktrees
+     * whose PR is closed/merged (or no longer tracked) and reap them via
+     * {@link pruneWorktree}. Bounds worktree/branch accumulation in the
+     * user's clone. Run on boot and periodically. Best-effort.
+     */
+    readonly sweepStaleWorktrees: () => Effect.Effect<
+      { readonly scanned: number; readonly pruned: number; readonly keptUnpushed: number },
+      CloneError
     >;
   }
 >() {}
@@ -606,8 +643,173 @@ export const RepoCloneServiceLive = Layer.effect(
           }),
       });
 
+    const pruneWorktree = ({
+      repoId,
+      prNumber,
+      force = false,
+    }: {
+      repoId: string;
+      prNumber: number;
+      force?: boolean;
+    }): Effect.Effect<PruneWorktreeOutcome, CloneError> =>
+      Effect.tryPromise({
+        try: async (): Promise<PruneWorktreeOutcome> => {
+          const row = db.select().from(repositories).where(eq(repositories.id, repoId)).get();
+          if (!row || row.cloneStatus !== "ready" || !row.clonePath) {
+            return { pruned: false, reason: "not-found" };
+          }
+          const clonePath = row.clonePath;
+          const branchName = `revv/pr-${prNumber}`;
+          const worktreePath = join(worktreeHolderPath(row.owner, row.name), `pr-${prNumber}`);
+          const worktreeExists = existsSync(worktreePath);
+
+          const prRow = db
+            .select()
+            .from(pullRequests)
+            .where(
+              and(eq(pullRequests.repositoryId, repoId), eq(pullRequests.externalId, prNumber)),
+            )
+            .get();
+
+          if (!force) {
+            // Never reap out from under an in-flight generation.
+            if (prRow) {
+              const generating = db
+                .select({ id: walkthroughs.id })
+                .from(walkthroughs)
+                .where(
+                  and(
+                    eq(walkthroughs.pullRequestId, prRow.id),
+                    eq(walkthroughs.status, "generating"),
+                  ),
+                )
+                .get();
+              if (generating) return { pruned: false, reason: "generating" };
+            }
+
+            // Never reap a branch carrying commits not yet on the PR head —
+            // that's un-pushed review/agent work. `<headSha>..<branch>` counts
+            // commits reachable from the branch but not the recorded PR head.
+            const headSha = prRow?.headSha ?? null;
+            if (headSha) {
+              const cwd = worktreeExists ? worktreePath : clonePath;
+              const aheadOut = await runGitCapture(
+                ["rev-list", "--count", `${headSha}..${branchName}`],
+                cwd,
+                15_000,
+              ).catch(() => "0");
+              if (Number.parseInt(aheadOut.trim(), 10) > 0) {
+                return { pruned: false, reason: "unpushed-commits" };
+              }
+            }
+          }
+
+          // Teardown — mirrors `deleteClone`, scoped to one PR. Best-effort:
+          // each step is idempotent and a no-op when its target is already gone.
+          if (worktreeExists) {
+            await runGitBestEffort(
+              ["worktree", "remove", "--force", worktreePath],
+              clonePath,
+              15_000,
+            );
+            if (existsSync(worktreePath)) {
+              await rm(worktreePath, { recursive: true, force: true });
+            }
+          }
+          await runGitBestEffort(["worktree", "prune"], clonePath, 15_000);
+          await runGitBestEffort(["branch", "-D", branchName], clonePath, 15_000);
+          await runGitBestEffort(
+            ["update-ref", "-d", `refs/revv-pull/${prNumber}`],
+            clonePath,
+            15_000,
+          );
+          await runGitBestEffort(
+            ["update-ref", "-d", `refs/revv/pr-${prNumber}`],
+            clonePath,
+            15_000,
+          );
+          return { pruned: true };
+        },
+        catch: (err) =>
+          new CloneError({
+            message: err instanceof Error ? err.message : String(err),
+            cause: err,
+          }),
+      });
+
+    const sweepStaleWorktrees = (): Effect.Effect<
+      { scanned: number; pruned: number; keptUnpushed: number },
+      CloneError
+    > =>
+      Effect.gen(function* () {
+        const repos = db
+          .select()
+          .from(repositories)
+          .where(eq(repositories.cloneStatus, "ready"))
+          .all();
+
+        let scanned = 0;
+        let pruned = 0;
+        let keptUnpushed = 0;
+
+        for (const repo of repos) {
+          if (!repo.clonePath) continue;
+          const clonePath = repo.clonePath;
+
+          // Enumerate by branch ref — covers both worktree-backed branches and
+          // orphan `revv/pr-N` branches whose worktree was already removed (the
+          // latter still clutter the user's VSCode branch list).
+          const out = yield* Effect.promise(() =>
+            runGitCapture(
+              ["for-each-ref", "--format=%(refname:short)", "refs/heads/revv/"],
+              clonePath,
+              15_000,
+            ).catch(() => ""),
+          );
+
+          const prNumbers = out
+            .split("\n")
+            .map((line) => /^revv\/pr-(\d+)$/.exec(line.trim())?.[1])
+            .filter((n): n is string => Boolean(n))
+            .map((n) => Number.parseInt(n, 10));
+
+          for (const prNumber of prNumbers) {
+            scanned++;
+            const prRow = db
+              .select({ status: pullRequests.status })
+              .from(pullRequests)
+              .where(
+                and(eq(pullRequests.repositoryId, repo.id), eq(pullRequests.externalId, prNumber)),
+              )
+              .get();
+            // Reapable when the PR is gone from our mirror or terminal.
+            const terminal = !prRow || prRow.status === "closed" || prRow.status === "merged";
+            if (!terminal) continue;
+
+            const outcome = yield* pruneWorktree({ repoId: repo.id, prNumber }).pipe(
+              Effect.catchAll(() =>
+                Effect.succeed<PruneWorktreeOutcome>({ pruned: false, reason: "not-found" }),
+              ),
+            );
+            if (outcome.pruned) pruned++;
+            else if (outcome.reason === "unpushed-commits") keptUnpushed++;
+          }
+        }
+
+        if (pruned > 0 || keptUnpushed > 0) {
+          debug(
+            "repo-clone",
+            `worktree sweep: pruned ${pruned}, kept ${keptUnpushed} with unpushed commits (scanned ${scanned})`,
+          );
+        }
+
+        return { scanned, pruned, keptUnpushed };
+      });
+
     return {
       cloneRepo,
+      pruneWorktree,
+      sweepStaleWorktrees,
       linkExisting,
 
       inspectLocal: (localPath, gitHost) =>


### PR DESCRIPTION
Review worktrees (`revv/pr-N`) and their branches are created per review-requested PR and never reaped, so they accumulate unbounded in the user's linked clone and overwhelm editors like VSCode. This adds a guarded reaper that keeps the worktree-in-clone model but bounds it to active reviews: `RepoClone.pruneWorktree` safely tears down a single PR's worktree + branch + fetch refs, refusing when a walkthrough is still generating or the branch carries unpushed commits so in-flight and unsaved review work is never destroyed. `RepoClone.sweepStaleWorktrees` scans every ready repo and reaps worktrees and orphan branches whose PR is closed/merged or no longer tracked. The sweep runs on boot and the poller reaps on each close/merge transition (with `RepoCloneService` wired into `PollScheduler`'s layer). No schema change — pure DB reads plus git ops; TTL/LRU backstop and a manual cleanup UI are intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)