### PR TITLE
fix: repo relink upsert

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/services/Repository.test.ts
+++ b/apps/server/src/services/Repository.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Layer } from "effect";
+import { createDb, type Db } from "../db/index";
+import { account, repositories, user } from "../db/schema";
+import { DbService } from "./Db";
+import { RepositoryService, RepositoryServiceLive } from "./Repository";
+
+const ACCOUNT_ID = "acc-1";
+
+function seedAccount(db: Db): void {
+  const now = new Date();
+  db.insert(user)
+    .values({
+      id: "user-1",
+      name: "Test",
+      email: "test@example.com",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(account)
+    .values({
+      id: ACCOUNT_ID,
+      accountId: "gh-1",
+      providerId: "github:github.com",
+      userId: "user-1",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function addRepo(
+  db: Db,
+  data: {
+    readonly managed?: boolean;
+    readonly clonePath?: string | null;
+    readonly defaultBranch?: string;
+    readonly avatarUrl?: string | null;
+  } = {},
+) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const svc = yield* RepositoryService;
+      return yield* svc.addRepo(
+        {
+          provider: "github",
+          owner: "acme",
+          name: "web",
+          fullName: "acme/web",
+          defaultBranch: data.defaultBranch ?? "main",
+          avatarUrl: data.avatarUrl ?? null,
+          githubHost: "github.com",
+          ...(data.managed !== undefined ? { managed: data.managed } : {}),
+          ...(data.clonePath !== undefined ? { clonePath: data.clonePath } : {}),
+        },
+        ACCOUNT_ID,
+      );
+    }).pipe(
+      Effect.provide(RepositoryServiceLive),
+      Effect.provide(Layer.succeed(DbService, { db })),
+    ),
+  );
+}
+
+describe("RepositoryService.addRepo", () => {
+  it("upserts an existing repository and returns the persisted row id", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db);
+
+    const first = await addRepo(db);
+    const relinked = await addRepo(db, {
+      managed: false,
+      clonePath: "/tmp/acme-web",
+      defaultBranch: "develop",
+      avatarUrl: "https://example.com/avatar.png",
+    });
+
+    expect(relinked.id).toBe(first.id);
+    expect(relinked.managed).toBe(false);
+    expect(relinked.cloneStatus).toBe("pending");
+    expect(relinked.clonePath).toBe("/tmp/acme-web");
+    expect(relinked.cloneError).toBeNull();
+    expect(relinked.defaultBranch).toBe("develop");
+    expect(relinked.avatarUrl).toBe("https://example.com/avatar.png");
+
+    const rows = db.select().from(repositories).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe(first.id);
+  });
+
+  it("clears linked checkout state when re-added as a managed clone", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db);
+
+    const linked = await addRepo(db, { managed: false, clonePath: "/tmp/acme-web" });
+    db.update(repositories).set({ cloneStatus: "ready", cloneError: "stale error" }).run();
+
+    const managed = await addRepo(db, { managed: true });
+
+    expect(managed.id).toBe(linked.id);
+    expect(managed.managed).toBe(true);
+    expect(managed.cloneStatus).toBe("pending");
+    expect(managed.clonePath).toBeNull();
+    expect(managed.cloneError).toBeNull();
+  });
+});

--- a/apps/server/src/services/Repository.test.ts
+++ b/apps/server/src/services/Repository.test.ts
@@ -104,4 +104,18 @@ describe("RepositoryService.addRepo", () => {
     expect(managed.clonePath).toBeNull();
     expect(managed.cloneError).toBeNull();
   });
+
+  it("clears stale cached avatar content when the avatar URL changes", async () => {
+    const db = createDb(":memory:");
+    seedAccount(db);
+
+    const first = await addRepo(db, { avatarUrl: "https://example.com/old.png" });
+    db.update(repositories).set({ avatarContent: "data:image/png;base64,old" }).run();
+
+    const updated = await addRepo(db, { avatarUrl: "https://example.com/new.png" });
+
+    expect(updated.id).toBe(first.id);
+    expect(updated.avatarUrl).toBe("https://example.com/new.png");
+    expect(db.select().from(repositories).get()?.avatarContent).toBeNull();
+  });
 });

--- a/apps/server/src/services/Repository.ts
+++ b/apps/server/src/services/Repository.ts
@@ -1,5 +1,5 @@
 import type { Repository } from "@revv/shared";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { Context, Effect, Layer } from "effect";
 import { repositories } from "../db/schema/index";
 import { NotFoundError, ValidationError } from "../domain/errors";
@@ -106,34 +106,41 @@ export const RepositoryServiceLive = Layer.succeed(RepositoryService, {
         name: data.name,
         fullName: data.fullName,
         defaultBranch: data.defaultBranch,
-        ...(data.avatarUrl !== null ? { avatarUrl: data.avatarUrl } : {}),
+        avatarUrl: data.avatarUrl,
         addedAt,
         githubHost: data.githubHost,
         managed: data.managed ?? true,
-        ...(data.clonePath !== undefined ? { clonePath: data.clonePath } : {}),
-        accountId,
-      } satisfies typeof repositories.$inferInsert;
-      yield* Effect.tryPromise({
-        try: () => Promise.resolve(db.insert(repositories).values(row).run()),
-        catch: (e) => new ValidationError({ message: String(e) }),
-      });
-      return rowToRepo({
-        id,
-        provider: data.provider,
-        owner: data.owner,
-        name: data.name,
-        fullName: data.fullName,
-        defaultBranch: data.defaultBranch,
-        avatarUrl: data.avatarUrl ?? null,
-        avatarContent: null,
-        addedAt,
         cloneStatus: "pending",
         clonePath: data.clonePath ?? null,
         cloneError: null,
-        managed: data.managed ?? true,
-        githubHost: data.githubHost,
         accountId,
+      } satisfies typeof repositories.$inferInsert;
+      const saved = yield* Effect.try({
+        try: () =>
+          db
+            .insert(repositories)
+            .values(row)
+            .onConflictDoUpdate({
+              target: [repositories.fullName, repositories.accountId],
+              set: {
+                provider: sql`excluded.provider`,
+                owner: sql`excluded.owner`,
+                name: sql`excluded.name`,
+                defaultBranch: sql`excluded.default_branch`,
+                avatarUrl: sql`excluded.avatar_url`,
+                addedAt: sql`excluded.added_at`,
+                githubHost: sql`excluded.github_host`,
+                managed: sql`excluded.managed`,
+                cloneStatus: sql`excluded.clone_status`,
+                clonePath: sql`excluded.clone_path`,
+                cloneError: sql`excluded.clone_error`,
+              },
+            })
+            .returning()
+            .get(),
+        catch: (e) => new ValidationError({ message: String(e) }),
       });
+      return rowToRepo(saved);
     }),
 
   deleteRepo: (id, accountId) =>

--- a/apps/server/src/services/Repository.ts
+++ b/apps/server/src/services/Repository.ts
@@ -128,6 +128,7 @@ export const RepositoryServiceLive = Layer.succeed(RepositoryService, {
                 name: sql`excluded.name`,
                 defaultBranch: sql`excluded.default_branch`,
                 avatarUrl: sql`excluded.avatar_url`,
+                avatarContent: sql`CASE WHEN ${repositories.avatarUrl} IS NOT excluded.avatar_url THEN NULL ELSE ${repositories.avatarContent} END`,
                 addedAt: sql`excluded.added_at`,
                 githubHost: sql`excluded.github_host`,
                 managed: sql`excluded.managed`,

--- a/apps/web/src/lib/components/settings/SettingsModal.svelte
+++ b/apps/web/src/lib/components/settings/SettingsModal.svelte
@@ -550,6 +550,8 @@ async function handleDeleteRepo(id: string): Promise<void> {
   try {
     await deleteRepo(id);
     repoPendingDelete = null;
+  } catch {
+    // The store restores optimistic state and shows the failure toast.
   } finally {
     removingRepoId = null;
   }

--- a/apps/web/src/lib/stores/prs.svelte.ts
+++ b/apps/web/src/lib/stores/prs.svelte.ts
@@ -690,7 +690,7 @@ export async function addRepo(input: AddRepoInput): Promise<void> {
   await fetchPrs();
 }
 
-export function deleteRepo(id: string): Promise<void> {
+export async function deleteRepo(id: string): Promise<void> {
   const snapshot = snapshotRepoState();
   const repo = repositories.find((r) => r.id === id);
   const toastOptions = repo ? { description: repo.fullName } : undefined;
@@ -698,30 +698,24 @@ export function deleteRepo(id: string): Promise<void> {
 
   removeRepoLocally(id);
 
-  void api.api
-    .repos({ id })
-    .delete()
-    .then(({ error }) => {
-      toast.dismiss(toastId);
-      if (error) {
-        restoreRepoState(snapshot);
-        const value = error.value as { error?: string; message?: string } | undefined;
-        toast.error(
-          value?.error ?? value?.message ?? `Failed to remove repository (HTTP ${error.status})`,
-        );
-        return;
-      }
+  try {
+    const { error } = await api.api.repos({ id }).delete();
+    if (error) {
+      const value = error.value as { error?: string; message?: string } | undefined;
+      throw new Error(
+        value?.error ?? value?.message ?? `Failed to remove repository (HTTP ${error.status})`,
+      );
+    }
+  } catch (e) {
+    toast.dismiss(toastId);
+    restoreRepoState(snapshot);
+    toast.error(e instanceof Error ? e.message : "Failed to remove repository");
+    throw e;
+  }
 
-      toast.success("Repository removed", toastOptions);
-      void Promise.all([fetchRepos(), fetchPrs()]);
-    })
-    .catch((e) => {
-      toast.dismiss(toastId);
-      restoreRepoState(snapshot);
-      toast.error(e instanceof Error ? e.message : "Failed to remove repository");
-    });
-
-  return Promise.resolve();
+  toast.dismiss(toastId);
+  toast.success("Repository removed", toastOptions);
+  void Promise.all([fetchRepos(), fetchPrs()]);
 }
 
 /**


### PR DESCRIPTION
## Summary
- make RepositoryService.addRepo upsert on the repository full_name/account_id unique key
- return the persisted row so relink flows reuse the existing repository id
- make the web deleteRepo action await the server delete instead of resolving immediately after optimistic local removal
- reset stale clone/link state and add service coverage for relinking/re-adding behavior

## Verification
- bun test apps/server/src/services/Repository.test.ts
- bun run typecheck
- bun run lint
- bun run knip
- bun run build