### PR TITLE
fix: duplicate diff cache writes

### DIFF
--- a/apps/server/src/services/DiffCache.test.ts
+++ b/apps/server/src/services/DiffCache.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "bun:test";
+import { eq } from "drizzle-orm";
+import { Effect, Layer } from "effect";
+import { createDb, type Db } from "../db";
+import { prDiffFiles } from "../db/schema";
 import { GitHubAuthError, GitHubRateLimitError } from "../domain/errors";
+import { DbService } from "./Db";
 import {
   type CachedDiffFile,
+  DiffCacheService,
+  DiffCacheServiceLive,
   hasCompleteCachedFiles,
   shouldServeCachedFilesOnFetchError,
 } from "./DiffCache";
@@ -17,6 +24,15 @@ function cachedFile(path: string): CachedDiffFile {
     patch: null,
     fetchedAt: "2026-01-01T00:00:00.000Z",
   };
+}
+
+async function cacheFiles(db: Db, prId: string, files: CachedDiffFile[]): Promise<void> {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const service = yield* DiffCacheService;
+      yield* service.cacheFiles(prId, files);
+    }).pipe(Effect.provide(DiffCacheServiceLive), Effect.provide(Layer.succeed(DbService, { db }))),
+  );
 }
 
 describe("hasCompleteCachedFiles", () => {
@@ -59,5 +75,32 @@ describe("shouldServeCachedFilesOnFetchError", () => {
     const error = new GitHubAuthError({ message: "Invalid or expired GitHub token" });
 
     expect(shouldServeCachedFilesOnFetchError(cached, error)).toBe(false);
+  });
+});
+
+describe("cacheFiles", () => {
+  it("is idempotent for duplicate rows with the same deterministic id", async () => {
+    const db = createDb(":memory:");
+    const sqlite = (db as unknown as { session: { client: { run: (sql: string) => void } } })
+      .session.client;
+    sqlite.run("PRAGMA foreign_keys = OFF");
+
+    const first = cachedFile("src/a.ts");
+    const second: CachedDiffFile = {
+      ...first,
+      oldPath: "src/old-a.ts",
+      additions: 3,
+      patch: "@@ second",
+      fetchedAt: "2026-01-01T00:01:00.000Z",
+    };
+
+    await cacheFiles(db, "pr-1", [first, second]);
+
+    const rows = db.select().from(prDiffFiles).where(eq(prDiffFiles.prId, "pr-1")).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.path).toBe("src/a.ts");
+    expect(rows[0]?.oldPath).toBe("src/old-a.ts");
+    expect(rows[0]?.additions).toBe(3);
+    expect(rows[0]?.patch).toBe("@@ second");
   });
 });

--- a/apps/server/src/services/DiffCache.ts
+++ b/apps/server/src/services/DiffCache.ts
@@ -1,4 +1,4 @@
-import { eq, inArray } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import { Context, Effect, Layer } from "effect";
 import { prDiffFiles } from "../db/schema/index";
 import { type GitHubError, GitHubRateLimitError } from "../domain/errors";
@@ -60,23 +60,36 @@ export const DiffCacheServiceLive = Layer.succeed(DiffCacheService, {
   cacheFiles: (prId, files) =>
     Effect.gen(function* () {
       const { db } = yield* DbService;
-      db.transaction(() => {
-        db.delete(prDiffFiles).where(eq(prDiffFiles.prId, prId)).run();
+      db.transaction((tx) => {
+        tx.delete(prDiffFiles).where(eq(prDiffFiles.prId, prId)).run();
         if (files.length > 0) {
-          db.insert(prDiffFiles)
+          tx.insert(prDiffFiles)
             .values(
               files.map((f) => ({
                 id: `${prId}\0${f.path}`,
                 prId,
                 path: f.path,
-                ...(f.oldPath !== null ? { oldPath: f.oldPath } : {}),
+                oldPath: f.oldPath,
                 status: f.status,
                 additions: f.additions,
                 deletions: f.deletions,
-                ...(f.patch !== null ? { patch: f.patch } : {}),
+                patch: f.patch,
                 fetchedAt: f.fetchedAt,
               })),
             )
+            .onConflictDoUpdate({
+              target: prDiffFiles.id,
+              set: {
+                prId: sql`excluded.pr_id`,
+                path: sql`excluded.path`,
+                oldPath: sql`excluded.old_path`,
+                status: sql`excluded.status`,
+                additions: sql`excluded.additions`,
+                deletions: sql`excluded.deletions`,
+                patch: sql`excluded.patch`,
+                fetchedAt: sql`excluded.fetched_at`,
+              },
+            })
             .run();
         }
       });


### PR DESCRIPTION
Fixes report startup failures caused by duplicate deterministic IDs in the PR diff-file cache. Diff cache writes now upsert on pr_diff_files.id inside the transaction, so duplicate file rows update the existing cache row instead of aborting walkthrough startup. Adds a regression test covering duplicate rows with the same deterministic id.