### PR TITLE
fix: ACP launch without npx

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.19.0"
+version = "0.19.2"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/ai/acp/presets.test.ts
+++ b/apps/server/src/ai/acp/presets.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ACP_AGENTS, getAcpAgent } from "@revv/shared";
 import { serverEnv } from "../../config";
 import { ACP_LOGIN_COMMAND } from "../providers/cli-agent";
@@ -7,6 +10,18 @@ import {
   resolveAcpProcessLaunchById,
   resolveGenerationModel,
 } from "./presets";
+
+function withPathExecutable(command: string, fn: (path: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), "revv-acp-preset-"));
+  try {
+    const bin = join(dir, command);
+    writeFileSync(bin, "#!/bin/sh\nexit 0\n");
+    chmodSync(bin, 0o755);
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 describe("ACP agent registry", () => {
   it("is the single source of truth — adding an agent is one registry entry", () => {
@@ -120,6 +135,37 @@ describe("ACP launch presets", () => {
     expect(launch.env.ANTHROPIC_MODEL).toBe("claude-sonnet-4-6");
     expect(launch.env.KEEP_ME).toBe("yes");
     expect(launch.env.PATH).toBe("/usr/bin");
+  });
+
+  it("keeps npx when the selected PATH provides it", () => {
+    withPathExecutable("npx", (path) => {
+      const launch = resolveAcpProcessLaunchById("claude-code", {}, {}, path, {
+        claudeSubscriptionAuth: false,
+      });
+
+      expect(launch.command).toBe("npx");
+      expect(launch.args).toEqual(["-y", "@agentclientprotocol/claude-agent-acp"]);
+    });
+  });
+
+  it("falls back from npx to bunx and removes npx's yes flag", () => {
+    withPathExecutable("bunx", (path) => {
+      const launch = resolveAcpProcessLaunchById("claude-code", {}, {}, path, {
+        claudeSubscriptionAuth: false,
+      });
+
+      expect(launch.command).toBe("bunx");
+      expect(launch.args).toEqual(["@agentclientprotocol/claude-agent-acp"]);
+    });
+  });
+
+  it("falls back from npx to bun x when only bun is available", () => {
+    withPathExecutable("bun", (path) => {
+      const launch = resolveAcpProcessLaunchById("codex", { model: "gpt-5.5" }, {}, path);
+
+      expect(launch.command).toBe("bun");
+      expect(launch.args).toEqual(["x", "@zed-industries/codex-acp", "-c", 'model="gpt-5.5"']);
+    });
   });
 
   it("keeps Anthropic API credentials when no Claude subscription auth exists", () => {

--- a/apps/server/src/ai/acp/presets.ts
+++ b/apps/server/src/ai/acp/presets.ts
@@ -8,6 +8,8 @@
 // model protocol — per-adapter injection of the selected model / thinking-effort
 // / context-window at launch time (args for Codex/opencode, env for Claude Code).
 
+import { accessSync, constants } from "node:fs";
+import { delimiter, isAbsolute, join } from "node:path";
 import {
   type AcpAgentId,
   type ContextWindow,
@@ -72,6 +74,50 @@ const CLAUDE_THINKING_TOKENS: Record<ThinkingEffort, number> = {
   max: 48_000,
   ultrathink: 64_000,
 };
+
+function executableExists(command: string, path: string): boolean {
+  const candidates = isAbsolute(command)
+    ? [command]
+    : path
+        .split(delimiter)
+        .filter(Boolean)
+        .map((dir) => join(dir, command));
+
+  return candidates.some((candidate) => {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function stripNpxYes(args: readonly string[]): readonly string[] {
+  return args[0] === "-y" || args[0] === "--yes" ? args.slice(1) : args;
+}
+
+function resolvePackageRunner(
+  launch: AcpLaunch,
+  path: string,
+): Pick<AcpLaunch, "command" | "args"> {
+  if (launch.command !== "npx") {
+    return { command: launch.command, args: launch.args };
+  }
+  if (executableExists("npx", path)) {
+    return { command: launch.command, args: launch.args };
+  }
+
+  const args = stripNpxYes(launch.args);
+  if (executableExists("bunx", path)) {
+    return { command: "bunx", args };
+  }
+  if (executableExists("bun", path)) {
+    return { command: "bun", args: ["x", ...args] };
+  }
+
+  return { command: launch.command, args: launch.args };
+}
 
 /**
  * Apply the `REVV_ACP_AGENT` env override (a testing / power-user knob) over a
@@ -189,9 +235,10 @@ export function resolveAcpProcessLaunchById(
   options: AcpProcessEnvOptions = {},
 ): AcpProcessLaunch {
   const launch = resolveAcpLaunchById(id, config);
+  const runner = resolvePackageRunner(launch, path);
   return {
-    command: launch.command,
-    args: launch.args,
+    command: runner.command,
+    args: runner.args,
     env: buildAcpProcessEnv(id, inheritedEnv, launch.env, path, options),
   };
 }
@@ -226,6 +273,9 @@ export function resolveGenerationModel(
  */
 export function isAcpAgentAvailable(id: AcpAgentId): boolean {
   const { command } = resolveAcpLaunchById(id);
-  if (command === "npx" || command === "bunx") return true;
+  if (command === "npx") {
+    return isCommandOnPath("npx") || isCommandOnPath("bunx") || isCommandOnPath("bun");
+  }
+  if (command === "bunx") return isCommandOnPath("bunx") || isCommandOnPath("bun");
   return isCommandOnPath(command);
 }


### PR DESCRIPTION
## Summary
- Falls back from npx to bunx or bun x when launching npx-based ACP adapters, including Claude Code.
- Updates ACP availability checks so Bun satisfies package-runner availability.
- Adds tests for npx, bunx, and bun x launch resolution.

## Verification
- bun test apps/server/src/ai/acp/presets.test.ts
- bun run typecheck && bun run lint && bun run knip && bun run build