### PR TITLE
fix(server): zero-touch acquirePrWorktree fast path

### DIFF
--- a/apps/server/src/services/RepoClone.test.ts
+++ b/apps/server/src/services/RepoClone.test.ts
@@ -82,20 +82,34 @@ describe("isWorktreeHealthy", () => {
     await rm(base, { recursive: true, force: true });
   });
 
-  it("reports a healthy worktree without touching .git on disk", async () => {
-    const refsBefore = await snapshotMtimes(join(clonePath, ".git", "refs"));
-    const worktreeGitdirBefore = await snapshotMtimes(
-      join(clonePath, ".git", "worktrees", prDirName),
-    );
-
-    const healthy = await isWorktreeHealthy({
+  /** Common healthy-baseline params — tests override just what they're probing. */
+  function healthyParams(): {
+    clonePath: string;
+    prDirName: string;
+    branchName: string;
+    worktreePath: string;
+    prHeadSha: string;
+    exactHead: true;
+    prNumber: number;
+  } {
+    return {
       clonePath,
       prDirName,
       branchName,
       worktreePath,
       prHeadSha: headSha,
       exactHead: true,
-    });
+      prNumber,
+    };
+  }
+
+  it("reports a healthy worktree without touching .git on disk", async () => {
+    const refsBefore = await snapshotMtimes(join(clonePath, ".git", "refs"));
+    const worktreeGitdirBefore = await snapshotMtimes(
+      join(clonePath, ".git", "worktrees", prDirName),
+    );
+
+    const healthy = await isWorktreeHealthy(healthyParams());
 
     expect(healthy).toBe(true);
     expect(await snapshotMtimes(join(clonePath, ".git", "refs"))).toEqual(refsBefore);
@@ -107,30 +121,38 @@ describe("isWorktreeHealthy", () => {
   it("refuses a worktree with an in-progress merge (MERGE_HEAD present)", async () => {
     writeFileSync(join(clonePath, ".git", "worktrees", prDirName, "MERGE_HEAD"), `${headSha}\n`);
 
-    const healthy = await isWorktreeHealthy({
-      clonePath,
-      prDirName,
-      branchName,
-      worktreePath,
-      prHeadSha: headSha,
-      exactHead: true,
-    });
-
-    expect(healthy).toBe(false);
+    expect(await isWorktreeHealthy(healthyParams())).toBe(false);
   });
 
   it("refuses a worktree with a stale index.lock", async () => {
     writeFileSync(join(clonePath, ".git", "worktrees", prDirName, "index.lock"), "");
 
-    const healthy = await isWorktreeHealthy({
-      clonePath,
-      prDirName,
-      branchName,
-      worktreePath,
-      prHeadSha: headSha,
-      exactHead: true,
+    expect(await isWorktreeHealthy(healthyParams())).toBe(false);
+  });
+
+  describe("legacy refs/revv/pr-N ref", () => {
+    const legacyRef = `refs/revv/pr-${prNumber}`;
+
+    it("refuses an otherwise-healthy worktree while the legacy ref still exists", async () => {
+      git(clonePath, ["update-ref", legacyRef, headSha]);
+
+      expect(await isWorktreeHealthy(healthyParams())).toBe(false);
     });
 
-    expect(healthy).toBe(false);
+    it("reports healthy again once the legacy ref is deleted", async () => {
+      git(clonePath, ["update-ref", legacyRef, headSha]);
+      expect(await isWorktreeHealthy(healthyParams())).toBe(false);
+
+      git(clonePath, ["update-ref", "-d", legacyRef]);
+
+      expect(await isWorktreeHealthy(healthyParams())).toBe(true);
+    });
+
+    it("sees the legacy ref even when packed (not just loose)", async () => {
+      git(clonePath, ["update-ref", legacyRef, headSha]);
+      git(clonePath, ["pack-refs", "--all"]);
+
+      expect(await isWorktreeHealthy(healthyParams())).toBe(false);
+    });
   });
 });

--- a/apps/server/src/services/RepoClone.test.ts
+++ b/apps/server/src/services/RepoClone.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isWorktreeHealthy } from "./RepoClone";
+
+// ── isWorktreeHealthy ────────────────────────────────────────────────────────
+//
+// `isWorktreeHealthy` is the read-only gate `acquirePrWorktree` consults
+// before falling through to its cold path (lock cleanup, ref deletion,
+// merge/rebase abort — all writes under `.git`). These tests build a real
+// git repo + worktree on disk (no mocks — the whole point is verifying
+// nothing on disk changes) and assert both the boolean result and, for the
+// healthy case, that not a single file under `.git` was touched.
+
+const GIT_ENV: Record<string, string> = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Revv Test",
+  GIT_AUTHOR_EMAIL: "revv-test@example.com",
+  GIT_COMMITTER_NAME: "Revv Test",
+  GIT_COMMITTER_EMAIL: "revv-test@example.com",
+  GIT_TERMINAL_PROMPT: "0",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: GIT_ENV, stdio: ["ignore", "pipe", "pipe"] })
+    .toString()
+    .trim();
+}
+
+/** Recursively snapshots mtimes of every entry under `dir`, keyed by path relative to `dir`. */
+async function snapshotMtimes(dir: string): Promise<Map<string, number>> {
+  const snapshot = new Map<string, number>();
+  const walk = async (current: string, prefix: string): Promise<void> => {
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = join(current, entry.name);
+      const rel = join(prefix, entry.name);
+      snapshot.set(rel, statSync(abs).mtimeMs);
+      if (entry.isDirectory()) await walk(abs, rel);
+    }
+  };
+  await walk(dir, "");
+  return snapshot;
+}
+
+describe("isWorktreeHealthy", () => {
+  const prNumber = 42;
+  const prDirName = `pr-${prNumber}`;
+  const branchName = `revv/pr-${prNumber}`;
+
+  let base: string;
+  let clonePath: string;
+  let worktreePath: string;
+  let headSha: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "revv-worktree-health-"));
+    clonePath = join(base, "clone");
+    worktreePath = join(base, "worktrees", prDirName);
+
+    mkdirSync(clonePath, { recursive: true });
+    mkdirSync(join(base, "worktrees"), { recursive: true });
+
+    git(clonePath, ["init", "--quiet", "--initial-branch=main"]);
+    // The user's global config may force commit signing (`commit.gpgsign`),
+    // which hangs/fails in a sandboxed test env with no signing agent.
+    // Scope the override to this throwaway repo only.
+    git(clonePath, ["config", "commit.gpgsign", "false"]);
+    git(clonePath, ["config", "tag.gpgsign", "false"]);
+    writeFileSync(join(clonePath, "README.md"), "hello\n");
+    git(clonePath, ["add", "README.md"]);
+    git(clonePath, ["commit", "--quiet", "-m", "initial commit"]);
+    headSha = git(clonePath, ["rev-parse", "HEAD"]);
+
+    git(clonePath, ["worktree", "add", "-B", branchName, worktreePath, headSha]);
+  });
+
+  afterEach(async () => {
+    await rm(base, { recursive: true, force: true });
+  });
+
+  it("reports a healthy worktree without touching .git on disk", async () => {
+    const refsBefore = await snapshotMtimes(join(clonePath, ".git", "refs"));
+    const worktreeGitdirBefore = await snapshotMtimes(
+      join(clonePath, ".git", "worktrees", prDirName),
+    );
+
+    const healthy = await isWorktreeHealthy({
+      clonePath,
+      prDirName,
+      branchName,
+      worktreePath,
+      prHeadSha: headSha,
+      exactHead: true,
+    });
+
+    expect(healthy).toBe(true);
+    expect(await snapshotMtimes(join(clonePath, ".git", "refs"))).toEqual(refsBefore);
+    expect(await snapshotMtimes(join(clonePath, ".git", "worktrees", prDirName))).toEqual(
+      worktreeGitdirBefore,
+    );
+  });
+
+  it("refuses a worktree with an in-progress merge (MERGE_HEAD present)", async () => {
+    writeFileSync(join(clonePath, ".git", "worktrees", prDirName, "MERGE_HEAD"), `${headSha}\n`);
+
+    const healthy = await isWorktreeHealthy({
+      clonePath,
+      prDirName,
+      branchName,
+      worktreePath,
+      prHeadSha: headSha,
+      exactHead: true,
+    });
+
+    expect(healthy).toBe(false);
+  });
+
+  it("refuses a worktree with a stale index.lock", async () => {
+    writeFileSync(join(clonePath, ".git", "worktrees", prDirName, "index.lock"), "");
+
+    const healthy = await isWorktreeHealthy({
+      clonePath,
+      prDirName,
+      branchName,
+      worktreePath,
+      prHeadSha: headSha,
+      exactHead: true,
+    });
+
+    expect(healthy).toBe(false);
+  });
+});

--- a/apps/server/src/services/RepoClone.ts
+++ b/apps/server/src/services/RepoClone.ts
@@ -288,6 +288,16 @@ function prWorktreeGitdir(clonePath: string, prDirName: string): string {
 }
 
 /**
+ * The legacy PR-head fetch ref from the old (pre `refs/revv-pull/N`) scheme.
+ * Shared so every reader/writer of this ref name — the cold path's heal step,
+ * the reap/prune teardown, and `isWorktreeHealthy`'s health check — can never
+ * drift apart.
+ */
+function legacyPrRef(prNumber: number): string {
+  return `refs/revv/pr-${prNumber}`;
+}
+
+/**
  * The fixed set of lock file paths tied to a single PR's worktree gitdir and
  * its branch ref. Shared by `clearStalePrWorktreeLocks` (which deletes them)
  * and `isWorktreeHealthy` (which only checks whether any exist), so the two
@@ -338,8 +348,12 @@ async function clearStalePrWorktreeLocks(
  *
  * Mirrors the conditions the cold path below would otherwise repair:
  * directory exists, no lock files, no in-progress merge/rebase, checked out
- * on the expected branch, and at (or, unless `exactHead`, an ancestor of)
- * `prHeadSha`.
+ * on the expected branch, at (or, unless `exactHead`, an ancestor of)
+ * `prHeadSha`, AND no legacy `refs/revv/pr-N` ref shadowing the branch (see
+ * the cold path's heal step below for why that ref is unsafe to leave in
+ * place). `rev-parse --verify --quiet` is a pure read — unlike `existsSync`,
+ * it also sees a ref folded into `packed-refs`, and it writes nothing so it
+ * can't trigger a file-watcher event either.
  */
 export async function isWorktreeHealthy(params: {
   clonePath: string;
@@ -348,8 +362,9 @@ export async function isWorktreeHealthy(params: {
   worktreePath: string;
   prHeadSha: string;
   exactHead: boolean;
+  prNumber: number;
 }): Promise<boolean> {
-  const { clonePath, prDirName, branchName, worktreePath, prHeadSha, exactHead } = params;
+  const { clonePath, prDirName, branchName, worktreePath, prHeadSha, exactHead, prNumber } = params;
 
   if (!existsSync(worktreePath)) return false;
 
@@ -363,6 +378,18 @@ export async function isWorktreeHealthy(params: {
 
   if (
     prWorktreeLockPaths(clonePath, prDirName, branchName).some((lockPath) => existsSync(lockPath))
+  ) {
+    return false;
+  }
+
+  // The legacy `refs/revv/pr-N` ref (see the cold path below) makes the bare
+  // name `revv/pr-N` ambiguous with the branch `refs/heads/revv/pr-N` — git
+  // resolves `refs/<name>` before `refs/heads/<name>`, so its mere presence
+  // silently breaks bare-name git ops even when everything else here checks
+  // out healthy. A worktree seeded before the heal step existed must fall
+  // through to the cold path so that heal actually runs.
+  if (
+    await runGitBestEffort(["rev-parse", "--verify", "--quiet", legacyPrRef(prNumber)], clonePath)
   ) {
     return false;
   }
@@ -827,11 +854,7 @@ export const RepoCloneServiceLive = Layer.effect(
             clonePath,
             15_000,
           );
-          await runGitBestEffort(
-            ["update-ref", "-d", `refs/revv/pr-${prNumber}`],
-            clonePath,
-            15_000,
-          );
+          await runGitBestEffort(["update-ref", "-d", legacyPrRef(prNumber)], clonePath, 15_000);
           return { pruned: true };
         },
         catch: (err) =>
@@ -1000,14 +1023,17 @@ export const RepoCloneServiceLive = Layer.effect(
 
                   // Zero-touch fast path: if the worktree is already checked
                   // out on the right branch, at (or ahead of) `prHeadSha`,
-                  // with no lock files or in-progress merge/rebase, return
+                  // with no lock files, no in-progress merge/rebase, and no
+                  // legacy `refs/revv/pr-N` ref shadowing the branch, return
                   // immediately. Nothing below this point may run — every
                   // statement in the cold path that follows writes to
                   // `.git` (lock cleanup, ref deletion, merge/rebase abort),
                   // and those writes fire file-watcher events in any editor
                   // that has the linked user repo open, on every chat turn
                   // and composer warm-up. Only an unhealthy worktree should
-                  // ever pay that cost.
+                  // ever pay that cost — and a worktree still carrying the
+                  // legacy ref counts as unhealthy specifically so the heal
+                  // step just below actually runs for it.
                   if (
                     await isWorktreeHealthy({
                       clonePath,
@@ -1016,6 +1042,7 @@ export const RepoCloneServiceLive = Layer.effect(
                       worktreePath,
                       prHeadSha,
                       exactHead,
+                      prNumber,
                     })
                   ) {
                     return { worktreePath, branchName };
@@ -1038,7 +1065,7 @@ export const RepoCloneServiceLive = Layer.effect(
                   // an already-checked-out worktree is fixed in place without a
                   // teardown, preserving any unpushed agent commits.
                   await runGitBestEffort(
-                    ["update-ref", "-d", `refs/revv/pr-${prNumber}`],
+                    ["update-ref", "-d", legacyPrRef(prNumber)],
                     clonePath,
                     10_000,
                   );

--- a/apps/server/src/services/RepoClone.ts
+++ b/apps/server/src/services/RepoClone.ts
@@ -282,18 +282,32 @@ async function readGitHead(worktreePath: string): Promise<string | null> {
  * walkthrough job for a different PR could be holding them legitimately —
  * `MAX_CONCURRENT_JOBS = 5` allows that concurrency.
  */
+/** Absolute path to a PR worktree's own `.git/worktrees/<name>` gitdir. */
+function prWorktreeGitdir(clonePath: string, prDirName: string): string {
+  return join(clonePath, ".git", "worktrees", prDirName);
+}
+
+/**
+ * The fixed set of lock file paths tied to a single PR's worktree gitdir and
+ * its branch ref. Shared by `clearStalePrWorktreeLocks` (which deletes them)
+ * and `isWorktreeHealthy` (which only checks whether any exist), so the two
+ * lists can never drift apart.
+ */
+function prWorktreeLockPaths(clonePath: string, prDirName: string, branchName: string): string[] {
+  const worktreeGitdir = prWorktreeGitdir(clonePath, prDirName);
+  return [
+    join(worktreeGitdir, "index.lock"),
+    join(worktreeGitdir, "HEAD.lock"),
+    join(clonePath, ".git", "refs", "heads", `${branchName}.lock`),
+  ];
+}
+
 async function clearStalePrWorktreeLocks(
   clonePath: string,
   prDirName: string,
   branchName: string,
 ): Promise<void> {
-  const worktreeGitdir = join(clonePath, ".git", "worktrees", prDirName);
-  const candidates = [
-    join(worktreeGitdir, "index.lock"),
-    join(worktreeGitdir, "HEAD.lock"),
-    join(clonePath, ".git", "refs", "heads", `${branchName}.lock`),
-  ];
-  for (const lockPath of candidates) {
+  for (const lockPath of prWorktreeLockPaths(clonePath, prDirName, branchName)) {
     try {
       if (!existsSync(lockPath)) continue;
       await rm(lockPath, { force: true });
@@ -307,6 +321,65 @@ async function clearStalePrWorktreeLocks(
       );
     }
   }
+}
+
+/**
+ * Read-only health check for an existing PR worktree: true when it can be
+ * reused exactly as-is, with zero filesystem writes.
+ *
+ * Why this exists: `acquirePrWorktree` fires on every chat turn and every
+ * composer warm-up. Its cold path clears lock files, deletes a legacy ref,
+ * and aborts any in-progress merge/rebase — all writes under `.git`. When a
+ * user has the linked repo open in an editor, those writes fire a
+ * file-watcher event on *every single call* even though nothing was actually
+ * wrong. This check lets `acquirePrWorktree` skip straight to the existing
+ * early-return when the worktree is already healthy, so the common case
+ * (repeated acquires against a worktree nobody touched) never touches disk.
+ *
+ * Mirrors the conditions the cold path below would otherwise repair:
+ * directory exists, no lock files, no in-progress merge/rebase, checked out
+ * on the expected branch, and at (or, unless `exactHead`, an ancestor of)
+ * `prHeadSha`.
+ */
+export async function isWorktreeHealthy(params: {
+  clonePath: string;
+  prDirName: string;
+  branchName: string;
+  worktreePath: string;
+  prHeadSha: string;
+  exactHead: boolean;
+}): Promise<boolean> {
+  const { clonePath, prDirName, branchName, worktreePath, prHeadSha, exactHead } = params;
+
+  if (!existsSync(worktreePath)) return false;
+
+  const worktreeGitdir = prWorktreeGitdir(clonePath, prDirName);
+  const inProgressMarkers = [
+    join(worktreeGitdir, "MERGE_HEAD"),
+    join(worktreeGitdir, "rebase-merge"),
+    join(worktreeGitdir, "rebase-apply"),
+  ];
+  if (inProgressMarkers.some((marker) => existsSync(marker))) return false;
+
+  if (
+    prWorktreeLockPaths(clonePath, prDirName, branchName).some((lockPath) => existsSync(lockPath))
+  ) {
+    return false;
+  }
+
+  const headRef = await readGitHead(worktreePath);
+  if (headRef !== `refs/heads/${branchName}`) return false;
+
+  let currentSha: string;
+  try {
+    currentSha = (await runGitCapture(["rev-parse", "HEAD"], worktreePath)).trim();
+  } catch {
+    return false;
+  }
+  if (currentSha === prHeadSha) return true;
+  if (exactHead) return false;
+
+  return runGitBestEffort(["merge-base", "--is-ancestor", prHeadSha, currentSha], worktreePath);
 }
 
 /**
@@ -924,6 +997,29 @@ export const RepoCloneServiceLive = Layer.effect(
                   const prFetchRef = `refs/revv-pull/${prNumber}`;
                   const holderBase = worktreeHolderPath(row.owner, row.name);
                   const worktreePath = join(holderBase, prDirName);
+
+                  // Zero-touch fast path: if the worktree is already checked
+                  // out on the right branch, at (or ahead of) `prHeadSha`,
+                  // with no lock files or in-progress merge/rebase, return
+                  // immediately. Nothing below this point may run — every
+                  // statement in the cold path that follows writes to
+                  // `.git` (lock cleanup, ref deletion, merge/rebase abort),
+                  // and those writes fire file-watcher events in any editor
+                  // that has the linked user repo open, on every chat turn
+                  // and composer warm-up. Only an unhealthy worktree should
+                  // ever pay that cost.
+                  if (
+                    await isWorktreeHealthy({
+                      clonePath,
+                      prDirName,
+                      branchName,
+                      worktreePath,
+                      prHeadSha,
+                      exactHead,
+                    })
+                  ) {
+                    return { worktreePath, branchName };
+                  }
 
                   const authedUrl = `https://x-access-token:${githubToken}@${gitHost}/${row.fullName}.git`;
 


### PR DESCRIPTION
## Summary
Every acquire of a PR worktree (fired on each chat turn and composer warm-up) wrote into the linked user repo's `.git` — stale-lock cleanup, `update-ref -d refs/revv/pr-N`, best-effort merge/rebase aborts — even when the worktree was already healthy. For users with the linked repo open in an editor, this fired file-watchers constantly (SCM refresh churn, window reloads).

This adds a read-only fast path: if the worktree exists, has no merge/rebase in progress, no stale locks, is on the expected branch and at the expected SHA (or ahead when `!exactHead`), acquire returns immediately with **zero `.git` writes**. The full cleanup path is unchanged and still runs for cold/broken worktrees.

- `isWorktreeHealthy()` extracted as a pure, exported check; lock paths factored into a helper shared with `clearStalePrWorktreeLocks` so the two can't drift.

## Test plan
- `apps/server/src/services/RepoClone.test.ts` (real git fixtures, no mocks):
  - healthy worktree → fast path taken, recursive mtime snapshot of `.git/refs` + `.git/worktrees/<name>` byte-identical before/after
  - `MERGE_HEAD` present → fast path refused
  - stale `index.lock` → fast path refused
- `make typecheck` / `make lint` clean; full server suite passes (1 pre-existing unrelated failure in `GitHub.test.ts`).
- Manual: `fswatch <linked-repo>/.git` while chatting on a PR — silent on this branch, writes on every turn on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)