### PR TITLE
chore(security): add 3-day minimumReleaseAge to bunfig.toml

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,9 @@
 [install]
 peer = false
+
+# Supply-chain hardening: refuse package versions published less than 3 days
+# ago. Recent npm worms (Shai-Hulud / Miasma) propagate through freshly
+# published versions and are usually pulled within hours, so a short cooldown
+# blocks the attack window before IOCs are public. Mirrors the Merkl monorepo.
+# See https://bun.com/docs/pm/cli/install#minimum-release-age
+minimumReleaseAge = 259200 # 3 days, in seconds


### PR DESCRIPTION
Adds `minimumReleaseAge = 259200` (3 days) under `[install]` in the root `bunfig.toml`, so Bun refuses any dependency version published less than 3 days ago during resolution. This closes the propagation window that recent npm worms (Shai-Hulud / Miasma) exploit — they spread through freshly published versions and are typically yanked within hours, well before a 3-day cooldown expires and before package names reach public IOC lists. Mirrors the Merkl monorepo's setting, but placed under `[install]` (where Bun actually reads it) rather than under `[install.cache]`. CI is unaffected since it installs from the frozen lockfile; the gate protects developers who add or bump dependencies. If an urgent freshly-released version is ever needed, whitelist it via `minimumReleaseAgeExcludes` under `[install]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)