### PR TITLE
fix(updater): publish signed release manifests and honour the channel

### DIFF
--- a/.github/workflows/_build-tauri.yml
+++ b/.github/workflows/_build-tauri.yml
@@ -2,16 +2,27 @@ name: Build Tauri (reusable)
 
 # Shared macOS Tauri build matrix (Apple Silicon + Intel). Invoked by:
 #   - release.yml     (per-version stable releases, prerelease=false)
-#   - nightly.yml     (moving `nightly` tag, prerelease=true)
+#   - nightly.yml     (per-SHA `nightly-<sha>` tags, prerelease=true)
 #
 # Inputs are intentionally minimal — the matrix, build steps, and attestation
 # logic are identical across both pipelines; only the release metadata differs.
+#
+# ── Updater artifacts ────────────────────────────────────────────────────────
+# `bundle.createUpdaterArtifacts` is on in `tauri.conf.json`, so every build
+# emits `<name>.app.tar.gz` plus a minisign `.sig` alongside the `.dmg`. Those
+# three, and the `latest.json` manifest composed by the `manifest` job below,
+# are what `tauri-plugin-updater` needs. Without them the in-app check fails
+# with "Could not fetch a valid release JSON from the remote".
+#
+# Signing requires the `TAURI_SIGNING_PRIVATE_KEY` repo secret; its public half
+# is pinned in `tauri.conf.json` → `plugins.updater.pubkey`. See
+# `docs/updater-setup.md`.
 
 on:
   workflow_call:
     inputs:
       tag_name:
-        description: "Git tag to upload artifacts under (e.g. v1.2.3 or nightly)"
+        description: "Git tag to upload artifacts under (e.g. v1.2.3 or nightly-abc1234)"
         required: true
         type: string
       release_name:
@@ -28,10 +39,61 @@ on:
         required: false
         type: boolean
         default: false
+      nightly:
+        description: >-
+          Stamp a monotonic prerelease version onto the build instead of using
+          `tauri.conf.json`'s version verbatim. Nightly builds all share the
+          last released version number, so without this every nightly would
+          report the same version and the updater would never consider a newer
+          one an upgrade.
+        required: false
+        type: boolean
+        default: false
+      updater_notes:
+        description: "Short one-liner shown in the in-app update toast"
+        required: false
+        type: string
+        default: "A new version of Revv is ready to install."
 
 jobs:
+  # Resolve the version once, up front, so both matrix legs and the manifest
+  # job agree on it. Doing this per-job would duplicate the bump formula and
+  # invite drift.
+  version:
+    name: Resolve build version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag_name }}
+
+      - name: Resolve version
+        id: resolve
+        env:
+          NIGHTLY: ${{ inputs.nightly }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          base=$(jq -r '.version' apps/desktop/tauri.conf.json)
+          if [[ "$NIGHTLY" == "true" ]]; then
+            # `0.23.0` → `0.23.1-nightly.<run>`. Bumping the patch keeps every
+            # nightly semver-greater than the stable release it was cut from,
+            # and the run number (numeric, so semver compares it numerically)
+            # keeps successive nightlies ordered. A short SHA would not — it
+            # sorts as an ASCII string.
+            IFS=. read -r major minor patch <<< "$base"
+            version="${major}.${minor}.$((patch + 1))-nightly.${RUN_NUMBER}"
+          else
+            version="$base"
+          fi
+          echo "Build version: ${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build (${{ matrix.label }})
+    needs: version
     permissions:
       contents: write
       id-token: write
@@ -45,10 +107,15 @@ jobs:
             platform: macos-latest
             args: "--target aarch64-apple-darwin"
             rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
+            # Suffix tauri-action appends to updater artifacts for this target.
+            # Must match, or the fallback upload publishes a duplicate asset
+            # under a second name instead of replacing tauri-action's.
+            arch: aarch64
           - label: macOS (Intel)
             platform: macos-latest
             args: "--target x86_64-apple-darwin"
             rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
+            arch: x64
 
     runs-on: ${{ matrix.platform }}
 
@@ -56,6 +123,32 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag_name }}
+
+      # Fail here rather than 15 minutes into the bundler. Without the key the
+      # build errors out anyway (createUpdaterArtifacts requires signing), and
+      # the bundler's message doesn't say which secret is missing.
+      - name: Check updater signing key
+        env:
+          SIGNING_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: |
+          if [[ -z "$SIGNING_KEY" ]]; then
+            echo "::error::TAURI_SIGNING_PRIVATE_KEY is not set. Updater artifacts cannot be signed — see docs/updater-setup.md."
+            exit 1
+          fi
+
+      # No-op for stable (writes back the value it read); stamps the nightly
+      # prerelease version otherwise. `tauri.conf.json`'s `version` is what
+      # ends up in `PackageInfo`, i.e. what the updater compares against — so
+      # patching it here is sufficient, no Cargo.toml edit needed.
+      - name: Stamp build version
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp)
+          jq --arg v "$VERSION" '.version = $v' apps/desktop/tauri.conf.json > "$tmp"
+          mv "$tmp" apps/desktop/tauri.conf.json
+          echo "Building version ${VERSION}"
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -78,9 +171,10 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Uncomment when updater signing is configured:
-          # TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          # TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          # Empty when the key was generated without a password; harmless to
+          # pass either way.
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: ./apps/desktop
           tauriScript: bunx tauri
@@ -90,10 +184,18 @@ jobs:
           releaseDraft: true
           prerelease: ${{ inputs.prerelease }}
           args: ${{ matrix.args }}
+          # tauri-action can build `latest.json` itself, but it does so by
+          # read-modify-writing the release asset once per matrix leg — two
+          # concurrent runners can each read the empty manifest and the second
+          # write drops the first architecture. The `manifest` job below
+          # composes it once, after both legs, instead.
+          includeUpdaterJson: false
 
       - name: Find bundle artifacts
         id: bundles
         shell: bash
+        env:
+          ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
           bundles=()
@@ -101,20 +203,60 @@ jobs:
             bundles+=("$f")
           done < <(find apps/desktop/target -type f -name '*.dmg' -print0)
           if [[ ${#bundles[@]} -eq 0 ]]; then
-            echo "No bundle files found."
+            echo "::error::No bundle files found."
             exit 1
           fi
 
-          echo "Found bundles: ${bundles[*]}"
+          updater=()
+          while IFS= read -r -d '' f; do
+            updater+=("$f")
+          done < <(find apps/desktop/target -type f -name '*.app.tar.gz' -print0)
+          if [[ ${#updater[@]} -eq 0 ]]; then
+            echo "::error::No .app.tar.gz produced — is bundle.createUpdaterArtifacts still enabled?"
+            exit 1
+          fi
+
+          # Stage the updater tarball and its signature under the architecture
+          # suffix. On disk both matrix legs produce the same
+          # `<product>.app.tar.gz`, so uploading them verbatim would have the
+          # two legs clobber each other under one name. The suffixed name is
+          # also exactly what tauri-action uploads them as, so the fallback
+          # below replaces its copy rather than adding a second one. (GitHub
+          # rewrites spaces and parens in asset names to dots server-side;
+          # both paths go through the same rewrite, so they still collide.)
+          staged="${RUNNER_TEMP}/updater"
+          mkdir -p "$staged"
+          staged_paths=()
+          for f in "${updater[@]}"; do
+            # A build that silently skipped signing would publish a manifest
+            # the installed app then refuses to verify. Fail now instead.
+            if [[ ! -f "${f}.sig" ]]; then
+              echo "::error::${f} has no .sig — updater signing did not run."
+              exit 1
+            fi
+            base=$(basename "$f" .app.tar.gz)
+            cp "$f"       "${staged}/${base}_${ARCH}.app.tar.gz"
+            cp "${f}.sig" "${staged}/${base}_${ARCH}.app.tar.gz.sig"
+            staged_paths+=("${staged}/${base}_${ARCH}.app.tar.gz" "${staged}/${base}_${ARCH}.app.tar.gz.sig")
+          done
+
+          echo "Found bundles: ${bundles[*]} ${staged_paths[*]}"
           {
             echo "paths<<EOF"
-            printf '%s\n' "${bundles[@]}"
+            printf '%s\n' "${bundles[@]}" "${staged_paths[@]}"
+            echo "EOF"
+            # `.sig` files are short signatures over artifacts that are
+            # themselves attested; attesting them separately adds nothing.
+            echo "attest_paths<<EOF"
+            printf '%s\n' "${bundles[@]}" "${updater[@]}"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
       # tauri-action uploads bundles automatically, but it can silently fail
       # when the release already exists (e.g. created by release-please). This
-      # fallback ensures every platform's bundles land on the release.
+      # fallback ensures every platform's bundles land on the release —
+      # including the updater tarball and signature, which the `manifest` job
+      # below reads back off the release.
       - name: Upload bundles (fallback)
         shell: bash
         env:
@@ -137,4 +279,69 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v3
         with:
-          subject-path: ${{ steps.bundles.outputs.paths }}
+          subject-path: ${{ steps.bundles.outputs.attest_paths }}
+
+  # Compose `latest.json` — the manifest `tauri-plugin-updater` fetches — from
+  # the signatures both matrix legs just uploaded. Done in a dedicated job
+  # rather than letting tauri-action merge per-leg manifests, because two
+  # concurrent runners read-modify-writing the same asset is a race.
+  manifest:
+    name: Publish updater manifest
+    runs-on: ubuntu-latest
+    needs: [version, build]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Compose and upload latest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag_name }}
+          VERSION: ${{ needs.version.outputs.version }}
+          NOTES: ${{ inputs.updater_notes }}
+        run: |
+          set -euo pipefail
+          workdir=$(mktemp -d)
+          # Works on draft releases too — this runs before the caller's
+          # publish step un-drafts them.
+          gh release download "$TAG" --dir "$workdir" --pattern '*.app.tar.gz.sig'
+
+          platforms='{}'
+          for sig in "$workdir"/*.app.tar.gz.sig; do
+            # `gh release download` names files after the GitHub *asset* name
+            # (spaces normalised to dots), so stripping `.sig` yields exactly
+            # the tarball's asset name — and therefore its download URL.
+            tarball=$(basename "$sig" .sig)
+            case "$tarball" in
+              *_aarch64.app.tar.gz) key="darwin-aarch64" ;;
+              *_x64.app.tar.gz|*_x86_64.app.tar.gz) key="darwin-x86_64" ;;
+              *) echo "::error::Cannot map ${tarball} to an updater platform key."; exit 1 ;;
+            esac
+            # Built by hand rather than taken from the API: a draft release's
+            # browser_download_url can carry an `untagged-<hash>` path that
+            # stops resolving once the release is published.
+            url="https://github.com/${GH_REPO}/releases/download/${TAG}/${tarball}"
+            platforms=$(jq --arg k "$key" --arg s "$(cat "$sig")" --arg u "$url" \
+              '.[$k] = {signature: $s, url: $u}' <<< "$platforms")
+          done
+
+          # One entry per matrix leg. Anything less means a leg failed
+          # (fail-fast is off) and publishing would strand that architecture
+          # on a manifest that never offers it an update.
+          count=$(jq 'length' <<< "$platforms")
+          if [[ "$count" -lt 2 ]]; then
+            echo "::error::Only ${count} platform(s) in the manifest; expected 2 (aarch64 + x86_64)."
+            exit 1
+          fi
+
+          jq -n \
+            --arg version "$VERSION" \
+            --arg notes "$NOTES" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --argjson platforms "$platforms" \
+            '{version: $version, notes: $notes, pub_date: $pub_date, platforms: $platforms}' \
+            > "$workdir/latest.json"
+
+          cat "$workdir/latest.json"
+          gh release upload "$TAG" "$workdir/latest.json" --clobber

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,6 +92,8 @@ jobs:
       release_name: "Revv nightly (${{ needs.prep.outputs.short_sha }})"
       release_body: "Auto-built from main @ ${{ github.sha }}. Expect bugs."
       prerelease: true
+      nightly: true
+      updater_notes: "Nightly build from main @ ${{ needs.prep.outputs.short_sha }}. Expect bugs."
     secrets: inherit
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
       release_name: "Revv ${{ needs.release-please.outputs.version }}"
       prerelease: false
+      updater_notes: "Revv ${{ needs.release-please.outputs.version }} is available. See the release notes on GitHub for what changed."
     secrets: inherit
 
   # ── Package and attest the signed installers ──────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ apps/desktop/target/
 # Tooling
 .context/
 .openlogs/
+.repos/effect

--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.21.2"
+version = "0.23.0"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -15,6 +15,7 @@
       "app",
       "dmg"
     ],
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -71,10 +72,12 @@
     "updater": {
       "active": true,
       "endpoints": [
+        "http://localhost:45678/api/update-manifest",
         "https://github.com/alexandre-schaffner/revv/releases/latest/download/latest.json"
       ],
+      "dangerousInsecureTransportProtocol": true,
       "dialog": false,
-      "pubkey": "REPLACE_WITH_MINISIGN_PUBLIC_KEY"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ3MzUxMzFGRUFERTc5QjUKUldTMWVkN3FIeE0xUndlSmxEUnlDZnkwUmt2by84L0s4dHI3aldXcDFmUGZ5amF3dWJ6ZFVRNXUK"
     }
   }
 }

--- a/apps/server/src/ai/acp/presets.test.ts
+++ b/apps/server/src/ai/acp/presets.test.ts
@@ -65,32 +65,29 @@ describe("ACP launch presets", () => {
     });
     expect(resolveAcpLaunchById("codex")).toEqual({
       command: "npx",
-      args: ["-y", "@zed-industries/codex-acp"],
+      args: ["-y", "@agentclientprotocol/codex-acp"],
     });
   });
 
-  it("passes the selected model to codex-acp at launch", () => {
+  it("passes the selected model to codex-acp through CODEX_CONFIG", () => {
     if (serverEnv.acpCommand) return;
-    expect(resolveAcpLaunchById("codex", { model: "gpt-5.5" })).toEqual({
+    expect(resolveAcpLaunchById("codex", { model: "gpt-5.6-sol" })).toEqual({
       command: "npx",
-      args: ["-y", "@zed-industries/codex-acp", "-c", 'model="gpt-5.5"'],
+      args: ["-y", "@agentclientprotocol/codex-acp"],
+      env: { CODEX_CONFIG: JSON.stringify({ model: "gpt-5.6-sol" }) },
     });
   });
 
-  it("injects model + reasoning effort as codex `-c` args", () => {
+  it("injects model + reasoning effort as Codex session config", () => {
     if (serverEnv.acpCommand) return;
     expect(
-      resolveAcpLaunchById("codex", { model: "gpt-5.5", thinkingEffort: "extra-high" }),
+      resolveAcpLaunchById("codex", { model: "gpt-5.6-sol", thinkingEffort: "extra-high" }),
     ).toEqual({
       command: "npx",
-      args: [
-        "-y",
-        "@zed-industries/codex-acp",
-        "-c",
-        'model="gpt-5.5"',
-        "-c",
-        'model_reasoning_effort="xhigh"',
-      ],
+      args: ["-y", "@agentclientprotocol/codex-acp"],
+      env: {
+        CODEX_CONFIG: JSON.stringify({ model: "gpt-5.6-sol", model_reasoning_effort: "xhigh" }),
+      },
     });
   });
 
@@ -161,10 +158,11 @@ describe("ACP launch presets", () => {
 
   it("falls back from npx to bun x when only bun is available", () => {
     withPathExecutable("bun", (path) => {
-      const launch = resolveAcpProcessLaunchById("codex", { model: "gpt-5.5" }, {}, path);
+      const launch = resolveAcpProcessLaunchById("codex", { model: "gpt-5.6-sol" }, {}, path);
 
       expect(launch.command).toBe("bun");
-      expect(launch.args).toEqual(["x", "@zed-industries/codex-acp", "-c", 'model="gpt-5.5"']);
+      expect(launch.args).toEqual(["x", "@agentclientprotocol/codex-acp"]);
+      expect(launch.env.CODEX_CONFIG).toBe(JSON.stringify({ model: "gpt-5.6-sol" }));
     });
   });
 
@@ -182,7 +180,7 @@ describe("ACP launch presets", () => {
 
   it("never leaks CLAUDE_CONFIG_DIR to a non-claude-code adapter", () => {
     if (serverEnv.acpCommand) return;
-    const launch = resolveAcpProcessLaunchById("codex", { model: "gpt-5.5" }, {}, "/usr/bin", {
+    const launch = resolveAcpProcessLaunchById("codex", { model: "gpt-5.6-sol" }, {}, "/usr/bin", {
       claudeConfigDir: "/tmp/x",
     });
 
@@ -233,8 +231,8 @@ describe("ACP login commands", () => {
 
 describe("resolveGenerationModel", () => {
   it("keeps a model valid for the agent", () => {
-    expect(resolveGenerationModel("claude-code", "claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
-    expect(resolveGenerationModel("codex", "gpt-5.5")).toBe("gpt-5.5");
+    expect(resolveGenerationModel("claude-code", "claude-sonnet-5")).toBe("claude-sonnet-5");
+    expect(resolveGenerationModel("codex", "gpt-5.6-sol")).toBe("gpt-5.6-sol");
   });
 
   it("falls back to the agent default when the model belongs to another agent", () => {

--- a/apps/server/src/ai/acp/presets.ts
+++ b/apps/server/src/ai/acp/presets.ts
@@ -63,13 +63,13 @@ export interface AcpProcessEnvOptions {
   readonly claudeConfigDir?: string | undefined;
 }
 
-// Revv thinking-effort tier → Codex `model_reasoning_effort`. Codex's ladder is
-// per-model (`supported_reasoning_levels` in the catalog it fetches from
-// OpenAI), so the tier is clamped to the selected model's capabilities before
-// it gets here — see `clampThinkingEffort`.
-const CODEX_REASONING_EFFORT: Record<ThinkingEffort, string> = {
-  ultrathink: "ultra",
-  max: "max",
+// Revv thinking-effort tier → Codex `model_reasoning_effort`. The vocabulary is
+// the one `@zed-industries/codex-acp` vendors — none/minimal/low/medium/high/
+// xhigh — NOT the standalone `codex` CLI's, which has since added `max` and
+// `ultra`. Sending a level the adapter predates makes it fail to parse its own
+// config, so ultrathink/max stay unmapped; `clampThinkingEffort` steps a stale
+// setting down before it reaches here.
+const CODEX_REASONING_EFFORT: Partial<Record<ThinkingEffort, string>> = {
   "extra-high": "xhigh",
   high: "high",
   medium: "medium",
@@ -161,12 +161,11 @@ export function resolveAcpLaunchById(id: AcpAgentId, config: AcpLaunchConfig = {
   switch (id) {
     case "codex": {
       if (model) args.push("-c", `model=${JSON.stringify(model)}`);
-      // Clamp rather than trust the persisted tier: model and effort are stored
-      // independently, so a tier picked on a frontier model can outlive a switch
-      // to one that rejects it — Codex errors on an unsupported level.
-      const tier = clampThinkingEffort(id, model ?? getAcpAgentDefaultModel(id), thinkingEffort);
-      if (tier)
-        args.push("-c", `model_reasoning_effort=${JSON.stringify(CODEX_REASONING_EFFORT[tier])}`);
+      // Clamp rather than trust the persisted tier: effort and agent are stored
+      // independently, so a tier picked on Claude Code outlives a switch here.
+      const tier = clampThinkingEffort(id, thinkingEffort);
+      const effort = tier ? CODEX_REASONING_EFFORT[tier] : undefined;
+      if (effort) args.push("-c", `model_reasoning_effort=${JSON.stringify(effort)}`);
       break;
     }
     case "claude-code": {

--- a/apps/server/src/ai/acp/presets.ts
+++ b/apps/server/src/ai/acp/presets.ts
@@ -13,6 +13,7 @@ import { delimiter, isAbsolute, join } from "node:path";
 import {
   type AcpAgentId,
   type ContextWindow,
+  clampThinkingEffort,
   getAcpAgent,
   getAcpAgentDefaultModel,
   getAgentCapabilities,
@@ -62,9 +63,13 @@ export interface AcpProcessEnvOptions {
   readonly claudeConfigDir?: string | undefined;
 }
 
-// Revv thinking-effort tier → Codex `model_reasoning_effort`. Codex has no
-// ultrathink/max tier, so those fall through to undefined (no override).
-const CODEX_REASONING_EFFORT: Partial<Record<ThinkingEffort, string>> = {
+// Revv thinking-effort tier → Codex `model_reasoning_effort`. Codex's ladder is
+// per-model (`supported_reasoning_levels` in the catalog it fetches from
+// OpenAI), so the tier is clamped to the selected model's capabilities before
+// it gets here — see `clampThinkingEffort`.
+const CODEX_REASONING_EFFORT: Record<ThinkingEffort, string> = {
+  ultrathink: "ultra",
+  max: "max",
   "extra-high": "xhigh",
   high: "high",
   medium: "medium",
@@ -156,8 +161,12 @@ export function resolveAcpLaunchById(id: AcpAgentId, config: AcpLaunchConfig = {
   switch (id) {
     case "codex": {
       if (model) args.push("-c", `model=${JSON.stringify(model)}`);
-      const effort = thinkingEffort ? CODEX_REASONING_EFFORT[thinkingEffort] : undefined;
-      if (effort) args.push("-c", `model_reasoning_effort=${JSON.stringify(effort)}`);
+      // Clamp rather than trust the persisted tier: model and effort are stored
+      // independently, so a tier picked on a frontier model can outlive a switch
+      // to one that rejects it — Codex errors on an unsupported level.
+      const tier = clampThinkingEffort(id, model ?? getAcpAgentDefaultModel(id), thinkingEffort);
+      if (tier)
+        args.push("-c", `model_reasoning_effort=${JSON.stringify(CODEX_REASONING_EFFORT[tier])}`);
       break;
     }
     case "claude-code": {

--- a/apps/server/src/ai/acp/presets.ts
+++ b/apps/server/src/ai/acp/presets.ts
@@ -6,7 +6,7 @@
 // entry there. This module holds the server-only concerns: the `REVV_ACP_AGENT`
 // / `REVV_ACP_COMMAND` overrides, availability checks, and — since ACP has no
 // model protocol — per-adapter injection of the selected model / thinking-effort
-// / context-window at launch time (args for Codex/opencode, env for Claude Code).
+// / context-window at launch time (env for Codex/Claude Code/opencode).
 
 import { accessSync, constants } from "node:fs";
 import { delimiter, isAbsolute, join } from "node:path";
@@ -26,7 +26,7 @@ import { detectClaudeSubscriptionAuth, isCommandOnPath } from "../providers/cli-
 export interface AcpLaunch {
   readonly command: string;
   readonly args: readonly string[];
-  /** Extra env vars merged over `process.env` when spawning (Claude Code model/effort/context). */
+  /** Extra env vars merged over `process.env` when spawning. */
   readonly env?: Readonly<Record<string, string>>;
 }
 
@@ -63,12 +63,8 @@ export interface AcpProcessEnvOptions {
   readonly claudeConfigDir?: string | undefined;
 }
 
-// Revv thinking-effort tier → Codex `model_reasoning_effort`. The vocabulary is
-// the one `@zed-industries/codex-acp` vendors — none/minimal/low/medium/high/
-// xhigh — NOT the standalone `codex` CLI's, which has since added `max` and
-// `ultra`. Sending a level the adapter predates makes it fail to parse its own
-// config, so ultrathink/max stay unmapped; `clampThinkingEffort` steps a stale
-// setting down before it reaches here.
+// Revv thinking-effort tier → Codex `model_reasoning_effort`. The maintained
+// Codex ACP adapter merges this into the session config through CODEX_CONFIG.
 const CODEX_REASONING_EFFORT: Partial<Record<ThinkingEffort, string>> = {
   "extra-high": "xhigh",
   high: "high",
@@ -160,12 +156,18 @@ export function resolveAcpLaunchById(id: AcpAgentId, config: AcpLaunchConfig = {
 
   switch (id) {
     case "codex": {
-      if (model) args.push("-c", `model=${JSON.stringify(model)}`);
       // Clamp rather than trust the persisted tier: effort and agent are stored
       // independently, so a tier picked on Claude Code outlives a switch here.
       const tier = clampThinkingEffort(id, thinkingEffort);
       const effort = tier ? CODEX_REASONING_EFFORT[tier] : undefined;
-      if (effort) args.push("-c", `model_reasoning_effort=${JSON.stringify(effort)}`);
+      // `@agentclientprotocol/codex-acp` starts Codex's App Server and reads
+      // CODEX_CONFIG, rather than forwarding the legacy adapter's `-c` flags.
+      if (model || effort) {
+        env.CODEX_CONFIG = JSON.stringify({
+          ...(model ? { model } : {}),
+          ...(effort ? { model_reasoning_effort: effort } : {}),
+        });
+      }
       break;
     }
     case "claude-code": {

--- a/apps/server/src/ai/providers/cli-agent.ts
+++ b/apps/server/src/ai/providers/cli-agent.ts
@@ -11,6 +11,7 @@ import {
 } from "@revv/shared";
 import { serverEnv } from "../../config";
 import { CLI_CACHE_TTL_MS } from "../../constants";
+import { debug, logError } from "../../logger";
 import { resolveClaudeConfigDir } from "../acp/claude-config";
 
 // ── CLI agent detection ──────────────────────────────────────────────────────
@@ -475,12 +476,45 @@ function isCliAgentAvailable(agent: CliAgent): boolean {
 }
 
 /**
+ * Directories where opencode's installers commonly place the binary. The
+ * login-shell PATH probe (see {@link resolveUserPath}) usually finds it, but
+ * package-manager installs (bun, official installer, Homebrew) can live in
+ * directories that a launchd-spawned server doesn't inherit on its process
+ * PATH and that the user's shell profile doesn't expose to non-interactive
+ * probes. This fallback is the last resort before giving up.
+ */
+function opencodeFallbackBinDirs(): string[] {
+  const home = homedir();
+  return [
+    join(home, ".bun", "bin"),
+    join(home, ".opencode", "bin"),
+    join(home, ".local", "bin"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+  ];
+}
+
+function resolveOpencodeFallbackBin(): string | null {
+  for (const dir of opencodeFallbackBinDirs()) {
+    const candidate = join(dir, "opencode");
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
  * Absolute path to the CLI binary if we have one, else the bare name so
  * Bun.spawn falls back to PATH resolution. Callers should pass the result
  * directly as argv[0] of a spawn call.
  */
 export function resolveCliBin(agent: CliAgent): string {
-  return pinnedBin(agent) || resolveCommandPath(agent) || agent;
+  const resolved = pinnedBin(agent) || resolveCommandPath(agent);
+  if (resolved) return resolved;
+  if (agent === "opencode") {
+    const fallback = resolveOpencodeFallbackBin();
+    if (fallback) return fallback;
+  }
+  return agent;
 }
 
 /**
@@ -625,13 +659,28 @@ export async function listCliModels(agent: AcpAgentId): Promise<CliModelOption[]
 
   // opencode: run `opencode models --verbose` and parse interleaved output
   // Format: line with "provider/id", then JSON blob with model metadata, repeated
+  const opencodeBin = resolveCliBin("opencode");
+  debug("listCliModels", "opencode binary:", opencodeBin);
   try {
-    const proc = Bun.spawn([resolveCliBin("opencode"), "models", "--verbose"], {
+    const proc = Bun.spawn([opencodeBin, "models", "--verbose"], {
       stdout: "pipe",
       stderr: "pipe",
+      // Inherit the login-shell PATH so the spawn can resolve a bare binary
+      // name even when the server process inherits a sanitized PATH.
+      env: { ...process.env, PATH: resolveUserPath() },
     });
     const text = await new Response(proc.stdout).text();
+    const stderrText = await new Response(proc.stderr).text();
     await proc.exited;
+
+    if (proc.exitCode !== 0) {
+      logError(
+        "listCliModels",
+        `opencode models --verbose exited ${proc.exitCode ?? "with signal"}`,
+        stderrText.slice(0, 500),
+      );
+      return [];
+    }
 
     const models: CliModelOption[] = [];
     const lines = text.split("\n");
@@ -672,7 +721,12 @@ export async function listCliModels(agent: AcpAgentId): Promise<CliModelOption[]
       }
     }
     return models;
-  } catch {
+  } catch (e) {
+    logError(
+      "listCliModels",
+      "failed to list opencode models",
+      e instanceof Error ? e.message : String(e),
+    );
     // Fallback: empty list (frontend will show empty state)
     return [];
   }

--- a/apps/server/src/ai/providers/cli-agent.ts
+++ b/apps/server/src/ai/providers/cli-agent.ts
@@ -24,7 +24,7 @@ import { resolveClaudeConfigDir } from "../acp/claude-config";
 //      installer's shell PATH). Survives a restricted LaunchAgent PATH.
 //   2. Auth-only fallback for the npx-adapter agents whose adapter authenticates
 //      from a local store instead of shelling out to the named CLI:
-//        • Codex  — `@zed-industries/codex-acp` reads `~/.codex/auth.json`
+//        • Codex  — `@agentclientprotocol/codex-acp` reads `~/.codex/auth.json`
 //          (honoring `CODEX_HOME`). CLI *or* Codex desktop app login counts.
 //        • Claude — `claude-agent-acp` runs on the Claude Agent SDK; an
 //          `ANTHROPIC_API_KEY`, `~/.claude/.credentials.json`, or the macOS

--- a/apps/server/src/routes/update-manifest.ts
+++ b/apps/server/src/routes/update-manifest.ts
@@ -1,10 +1,25 @@
 // Update-manifest dispatcher for the Tauri auto-updater.
 //
 // `tauri-plugin-updater` reads its endpoint list from `tauri.conf.json` at
-// compile time and offers no runtime override. Release builds also reject
-// insecure updater endpoints, so the packaged desktop app points directly at
-// the HTTPS stable manifest. This local route remains for source installs and
-// CLI-managed channel experiments that already have the local API server up.
+// compile time and offers no runtime override, so a channel switch cannot
+// change which URL it fetches. This route is that indirection: the desktop
+// app's first endpoint is `http://localhost:45678/api/update-manifest`, and
+// the channel is resolved here, per request, from SQLite. Switching channels
+// therefore takes effect on the next check with no rebuild and no restart.
+//
+// The plugin normally refuses non-HTTPS endpoints in release builds; the app
+// opts out via `dangerousInsecureTransportProtocol`. What that gives up is
+// small: the server binds to loopback only, and the payload this manifest
+// points at is still minisign-verified against the pinned public key before
+// anything is installed. A local process squatting on the port could at worst
+// suppress or misdirect an update, not install one.
+//
+// The GitHub stable manifest stays in the endpoint list as a second entry.
+// The plugin walks endpoints in order and skips any that error, so a stopped
+// LaunchAgent degrades to stable-channel checks instead of failing outright.
+// Note that a 204 from this route ends the walk (the plugin reads it as "no
+// update") — that is deliberate, and why the not-yet-published cases below
+// return 204 while genuine failures return 502.
 //
 // The route is intentionally unauthenticated — the updater plugin runs in
 // the Rust host and doesn't forward bearer tokens, and the server only binds
@@ -43,21 +58,34 @@ interface GitHubRelease {
   assets: GitHubAsset[];
 }
 
-async function resolveNightlyManifestUrl(): Promise<string | null> {
+/**
+ * Resolves the newest published nightly's `latest.json` URL.
+ *
+ * Distinguishes "no nightly exists yet" (`"none"`, a legitimate silent state)
+ * from "couldn't ask GitHub" (`"error"`, e.g. the API is down or rate-limited).
+ * Collapsing the two would report an unreachable GitHub as "you're up to
+ * date", which is exactly the kind of silent failure that let the updater stay
+ * broken across 23 releases.
+ */
+async function resolveNightlyManifestUrl(): Promise<
+  { kind: "ok"; url: string } | { kind: "none" } | { kind: "error" }
+> {
   const res = await fetch(NIGHTLY_RELEASES_API_URL, {
     headers: { Accept: "application/vnd.github+json" },
     signal: AbortSignal.timeout(10_000),
   });
-  if (!res.ok) return null;
+  if (!res.ok) return { kind: "error" };
   const releases = (await res.json()) as GitHubRelease[];
   // The releases API returns results sorted by published_at desc, so the
   // first matching entry is the newest nightly.
   const nightly = releases.find(
     (r) => r.prerelease && !r.draft && r.tag_name.startsWith(NIGHTLY_TAG_PREFIX),
   );
-  if (!nightly) return null;
+  if (!nightly) return { kind: "none" };
   const asset = nightly.assets.find((a) => a.name === "latest.json");
-  return asset?.browser_download_url ?? null;
+  // A published nightly release that lacks the manifest means the release
+  // pipeline's `manifest` job didn't run — a failure, not an absence.
+  return asset ? { kind: "ok", url: asset.browser_download_url } : { kind: "error" };
 }
 
 export const updateManifestRoute = new Elysia()
@@ -70,23 +98,27 @@ export const updateManifestRoute = new Elysia()
       }).pipe(Effect.orElseSucceed(() => "stable" as const)),
     );
 
-    let target: string | null;
+    let target: string;
     if (channel === "nightly") {
-      target = await resolveNightlyManifestUrl();
-      // No nightly published yet — keep the toast silent.
-      if (!target) return new Response(null, { status: 204 });
+      const resolved = await resolveNightlyManifestUrl();
+      // No nightly published yet — a real "nothing to offer", so 204 and let
+      // the plugin end its endpoint walk quietly.
+      if (resolved.kind === "none") return new Response(null, { status: 204 });
+      if (resolved.kind === "error") return new Response(null, { status: 502 });
+      target = resolved.url;
     } else {
       target = STABLE_MANIFEST_URL;
     }
 
-    // The updater plugin treats any non-2xx as "no update available". When
-    // the tag hasn't been published yet, returning 204 keeps the toast
-    // silent rather than surfacing a bogus error.
+    // 502 rather than 204 on failure: 204 would end the plugin's endpoint
+    // walk and render as "You're up to date", whereas a non-success status
+    // makes it fall through to the GitHub endpoint and, if that fails too,
+    // surface a real error on manual checks. A missing manifest is a broken
+    // release pipeline, not an absence of updates.
     const upstream = await fetch(target, {
       redirect: "follow",
       signal: AbortSignal.timeout(10_000),
     });
-    if (upstream.status === 404) return new Response(null, { status: 204 });
     if (!upstream.ok) return new Response(null, { status: 502 });
 
     return new Response(await upstream.text(), {

--- a/apps/web/src/lib/components/layout/ModelSelector.svelte
+++ b/apps/web/src/lib/components/layout/ModelSelector.svelte
@@ -140,13 +140,12 @@ function selectWindow(value: ContextWindow) {
 						{group.label}
 					</div>
 				{/if}
-				{#each group.models as opt (opt.value)}
-					<button
-						class="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-text-secondary transition-colors hover:bg-bg-tertiary"
-						onclick={() => select(opt.value)}
-					>
-					<ProviderIcon provider={group.provider} size={14} class="shrink-0 opacity-60 text-text-secondary" />
-					<span class="min-w-0 flex-1 truncate text-left">{opt.label}</span>
+			{#each group.models as opt (opt.value)}
+				<button
+					class="flex w-full cursor-pointer items-center justify-between rounded-sm px-2 py-1.5 text-xs text-text-secondary transition-colors hover:bg-bg-tertiary"
+					onclick={() => select(opt.value)}
+				>
+					<span class="min-w-0 truncate text-left">{opt.label}</span>
 					{#if currentModel === opt.value}
 						<Check size={12} weight="regular" class="shrink-0 text-accent" />
 					{/if}

--- a/apps/web/src/lib/components/layout/ThinkingEffortSelector.svelte
+++ b/apps/web/src/lib/components/layout/ThinkingEffortSelector.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-import { getAgentCapabilities, type ThinkingEffort } from "@revv/shared";
+import {
+  clampThinkingEffort,
+  getAgentCapabilities,
+  getModelThinkingEfforts,
+  type ThinkingEffort,
+} from "@revv/shared";
 import Brain from "phosphor-svelte/lib/Brain";
 import Check from "phosphor-svelte/lib/Check";
 import {
@@ -12,26 +17,25 @@ import { getSettings, resolveChatAgentId, updateSettings } from "$lib/stores/set
 import SelectTrigger from "./SelectTrigger.svelte";
 
 let open = $state(false);
-// Thinking-effort options follow the selected chat agent's capabilities.
+// Thinking-effort options follow the selected chat agent — and, on agents whose
+// ladder is per-model (Codex), the selected model too.
 let currentId = $derived(resolveChatAgentId(getSettings()));
 let caps = $derived(getAgentCapabilities(currentId));
 let visible = $derived(caps.thinkingEfforts.length > 0);
-let options = $derived(
-  THINKING_EFFORT_OPTIONS.filter((o) => caps.thinkingEfforts.includes(o.value)),
-);
+let allowed = $derived(getModelThinkingEfforts(currentId, getSettings()?.aiModel));
+let options = $derived(THINKING_EFFORT_OPTIONS.filter((o) => allowed.includes(o.value)));
 let currentEffort = $derived((getSettings()?.aiThinkingEffort ?? "medium") as ThinkingEffort);
 let currentLabel = $derived(
   options.find((o) => o.value === currentEffort)?.label ?? options[0]?.label ?? "High",
 );
 
-// If the selected effort isn't valid for the current agent (e.g. an opus-only
-// tier after switching to codex, or any tier after switching to an agent with
-// no thinking-effort knob), reset to one the agent supports.
+// If the selected effort isn't valid for the current agent+model (a tier the
+// agent lacks entirely after switching provider, or one the newly-selected
+// model doesn't reach), step down to the nearest tier that is.
 $effect(() => {
-  if (visible && !caps.thinkingEfforts.includes(currentEffort)) {
-    const fallback = caps.thinkingEfforts.includes("high") ? "high" : caps.thinkingEfforts[0];
-    if (fallback) updateSettings({ aiThinkingEffort: fallback });
-  }
+  if (!visible || allowed.includes(currentEffort)) return;
+  const fallback = clampThinkingEffort(currentId, getSettings()?.aiModel, currentEffort);
+  if (fallback) updateSettings({ aiThinkingEffort: fallback });
 });
 
 function select(value: ThinkingEffort) {

--- a/apps/web/src/lib/components/layout/ThinkingEffortSelector.svelte
+++ b/apps/web/src/lib/components/layout/ThinkingEffortSelector.svelte
@@ -1,10 +1,5 @@
 <script lang="ts">
-import {
-  clampThinkingEffort,
-  getAgentCapabilities,
-  getModelThinkingEfforts,
-  type ThinkingEffort,
-} from "@revv/shared";
+import { clampThinkingEffort, getAgentCapabilities, type ThinkingEffort } from "@revv/shared";
 import Brain from "phosphor-svelte/lib/Brain";
 import Check from "phosphor-svelte/lib/Check";
 import {
@@ -17,24 +12,24 @@ import { getSettings, resolveChatAgentId, updateSettings } from "$lib/stores/set
 import SelectTrigger from "./SelectTrigger.svelte";
 
 let open = $state(false);
-// Thinking-effort options follow the selected chat agent — and, on agents whose
-// ladder is per-model (Codex), the selected model too.
+// Thinking-effort options follow the selected chat agent's capabilities.
 let currentId = $derived(resolveChatAgentId(getSettings()));
 let caps = $derived(getAgentCapabilities(currentId));
 let visible = $derived(caps.thinkingEfforts.length > 0);
-let allowed = $derived(getModelThinkingEfforts(currentId, getSettings()?.aiModel));
-let options = $derived(THINKING_EFFORT_OPTIONS.filter((o) => allowed.includes(o.value)));
+let options = $derived(
+  THINKING_EFFORT_OPTIONS.filter((o) => caps.thinkingEfforts.includes(o.value)),
+);
 let currentEffort = $derived((getSettings()?.aiThinkingEffort ?? "medium") as ThinkingEffort);
 let currentLabel = $derived(
   options.find((o) => o.value === currentEffort)?.label ?? options[0]?.label ?? "High",
 );
 
-// If the selected effort isn't valid for the current agent+model (a tier the
-// agent lacks entirely after switching provider, or one the newly-selected
-// model doesn't reach), step down to the nearest tier that is.
+// If the selected effort isn't valid for the current agent (e.g. a Claude-only
+// tier after switching to codex, or any tier after switching to an agent with
+// no thinking-effort knob), step down to the nearest tier the agent supports.
 $effect(() => {
-  if (!visible || allowed.includes(currentEffort)) return;
-  const fallback = clampThinkingEffort(currentId, getSettings()?.aiModel, currentEffort);
+  if (!visible || caps.thinkingEfforts.includes(currentEffort)) return;
+  const fallback = clampThinkingEffort(currentId, currentEffort);
   if (fallback) updateSettings({ aiThinkingEffort: fallback });
 });
 

--- a/apps/web/src/lib/constants/models.ts
+++ b/apps/web/src/lib/constants/models.ts
@@ -33,7 +33,7 @@ export function getDefaultModel(agent: AcpAgentId): string {
 const DEFAULT_SUGGESTIONS_MODEL_BY_AGENT: Record<AcpAgentId, string> = {
   opencode: "opencode/big-pickle",
   "claude-code": "claude-haiku-4-5-20251001",
-  codex: "gpt-5.4-mini",
+  codex: "gpt-5.6-luna",
   cursor: "auto",
 };
 

--- a/apps/web/src/lib/constants/models.ts
+++ b/apps/web/src/lib/constants/models.ts
@@ -1,18 +1,27 @@
-import { type AcpAgentId, getAcpAgentDefaultModel, type ThinkingEffort } from "@revv/shared";
+import {
+  type AcpAgentId,
+  getAcpAgentDefaultModel,
+  THINKING_EFFORT_ORDER,
+  type ThinkingEffort,
+} from "@revv/shared";
 
 export type ModelOption = { label: string; value: string };
 
-// Display labels for every thinking-effort tier. Which tiers a given agent
-// actually offers is declared per-agent in the ACP registry capabilities
-// (`getAgentCapabilities`); this is just the label source the selector filters.
-export const THINKING_EFFORT_OPTIONS: { label: string; value: ThinkingEffort }[] = [
-  { label: "Ultrathink", value: "ultrathink" },
-  { label: "Max", value: "max" },
-  { label: "Extra High", value: "extra-high" },
-  { label: "High", value: "high" },
-  { label: "Medium", value: "medium" },
-  { label: "Low", value: "low" },
-];
+const THINKING_EFFORT_LABELS: Record<ThinkingEffort, string> = {
+  ultrathink: "Ultrathink",
+  max: "Max",
+  "extra-high": "Extra High",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+// Display labels for every thinking-effort tier, strongest first. Which tiers a
+// given agent+model actually offers comes from the ACP registry
+// (`getModelThinkingEfforts`); this is just the label source the selector
+// filters. Ordering is inherited from the registry so the two can't drift.
+export const THINKING_EFFORT_OPTIONS: { label: string; value: ThinkingEffort }[] =
+  THINKING_EFFORT_ORDER.map((value) => ({ label: THINKING_EFFORT_LABELS[value], value }));
 
 export function getDefaultModel(agent: AcpAgentId): string {
   return getAcpAgentDefaultModel(agent);

--- a/apps/web/src/lib/stores/settings.svelte.ts
+++ b/apps/web/src/lib/stores/settings.svelte.ts
@@ -212,6 +212,9 @@ export async function fetchModels(agent: AcpAgentId): Promise<ModelOption[]> {
       modelsLoadedByAgent = { ...modelsLoadedByAgent, [agent]: true };
       return list;
     } catch {
+      // Mark loaded even on failure so the UI doesn't stay in "Loading…"
+      // forever; the cached (possibly empty) list is the best fallback.
+      modelsLoadedByAgent = { ...modelsLoadedByAgent, [agent]: true };
       return modelsByAgent[agent] ?? [];
     } finally {
       delete modelsInFlight[agent];

--- a/apps/web/src/lib/updater/client.ts
+++ b/apps/web/src/lib/updater/client.ts
@@ -29,12 +29,24 @@ export type UpdateInfo = {
 };
 
 /**
+ * Per-endpoint timeout for the manifest fetch.
+ *
+ * The first configured endpoint is the local API server
+ * (`/api/update-manifest`), which resolves the release channel. A connection
+ * refused there fails instantly, but a wedged server would otherwise hang the
+ * request forever — and `runCheck`'s `inFlight` guard would then suppress
+ * every subsequent check for the life of the process. Bounding it lets the
+ * plugin move on to the GitHub fallback instead.
+ */
+const CHECK_TIMEOUT_MS = 15_000;
+
+/**
  * Returns the available update, or `null` if we're already on the latest
  * version or the updater is unreachable.
  */
 export async function checkForUpdate(): Promise<UpdateInfo | null> {
   const { check } = await import("@tauri-apps/plugin-updater");
-  const update = await check();
+  const update = await check({ timeout: CHECK_TIMEOUT_MS });
   if (!update) return null;
 
   return {

--- a/docs/updater-setup.md
+++ b/docs/updater-setup.md
@@ -3,77 +3,160 @@
 Internal runbook for signing and publishing Revv releases. Not a user-facing
 doc — keep it terse.
 
-## One-time: generate the signing keypair
+Releases are automated. `release.yml` (stable) and `nightly.yml` both call
+`_build-tauri.yml`, which builds both macOS architectures, signs the updater
+artifacts, and publishes the `latest.json` manifest the in-app updater reads.
+The only manual part is the one-time signing-key setup below.
 
-Tauri's updater uses minisign signatures. Generate the keypair once and keep
-the private key off of the repo:
+## One-time: the signing keypair
+
+Tauri's updater uses minisign signatures. The keypair was generated with:
 
 ```bash
 bun x @tauri-apps/cli signer generate -w ~/.tauri/revv-updater.key
 ```
 
-- The public key is printed to stdout. Paste it into
-  `apps/desktop/tauri.conf.json` → `plugins.updater.pubkey` (replaces the
-  `REPLACE_WITH_MINISIGN_PUBLIC_KEY` placeholder). Commit that change.
-- The private key is written to `~/.tauri/revv-updater.key`. Add it to your
-  machine's backups. **Do not commit it.** Anyone with this key can push a
-  malicious update to every installed copy of Revv.
-- The CLI will also ask for a password — set one and store it in your
-  password manager.
+- The **public** key is committed in `apps/desktop/tauri.conf.json` →
+  `plugins.updater.pubkey`. Every installed copy of Revv verifies downloaded
+  updates against it.
+- The **private** key lives at `~/.tauri/revv-updater.key` on the maintainer's
+  machine and in the `TAURI_SIGNING_PRIVATE_KEY` repo secret. Back it up.
+  **Never commit it.** Anyone holding it can push a malicious update to every
+  installed copy of Revv.
+- The current key has **no password**, so `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+  is unset in CI. If you regenerate with one, add it as a second repo secret
+  under that name — the workflow already passes it through.
 
-## One-time: point the endpoint at the real repo
+Rotating the key is a breaking change: builds signed by the new key will not
+verify on copies of Revv shipped with the old `pubkey`, so those users have to
+reinstall by hand. Only rotate on suspected compromise.
 
-`tauri.conf.json` → `plugins.updater.endpoints[0]` currently points at
-`https://github.com/alexmerkl/revv/releases/latest/download/latest.json`.
-If the GitHub org/repo changes, update that URL before the first release.
+### Repo secrets
 
-## Per release
+| Secret                               | Required | Value                               |
+| ------------------------------------ | -------- | ----------------------------------- |
+| `TAURI_SIGNING_PRIVATE_KEY`          | yes      | contents of `~/.tauri/revv-updater.key` |
+| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | no       | only if the key has a password      |
 
-1. Bump the version **in every file that tracks it** — they must match for
-   Tauri's "is this newer?" comparison to work:
-   - `apps/desktop/tauri.conf.json` → `version`
-   - `apps/desktop/Cargo.toml` → `[package] version`
-   - `apps/web/package.json` → `version`
-   - `apps/server/package.json` → `version`
-   - root `package.json` → `version`
-2. Build the signed installer:
-   ```bash
-   TAURI_SIGNING_PRIVATE_KEY="$(cat ~/.tauri/revv-updater.key)" \
-   TAURI_SIGNING_PRIVATE_KEY_PASSWORD='<your-password>' \
-   make dist
-   ```
-   This emits the `.app`, `.dmg`, and a matching `.sig` into
-   `apps/desktop/target/release/bundle/`.
-3. Hand-craft `latest.json`. Shape:
-   ```json
-   {
-     "version": "0.0.2",
-     "notes": "Short release notes shown in the toast description.",
-     "pub_date": "2026-04-20T00:00:00Z",
-     "platforms": {
-       "darwin-aarch64": {
-         "signature": "<contents of the .sig file>",
-         "url": "https://github.com/alexmerkl/revv/releases/download/v0.0.2/Revv_0.0.2_aarch64.app.tar.gz"
-       },
-       "darwin-x86_64": {
-         "signature": "…",
-         "url": "…"
-       }
-     }
-   }
-   ```
-   Tauri's docs have the full schema.
-4. Create a GitHub Release tagged `v<version>` and upload:
-   - the `.dmg` (user-facing download)
-   - the `.tar.gz` referenced in `latest.json` (what the updater downloads)
-   - `latest.json` itself
+Set with:
 
-The endpoint URL in `tauri.conf.json` uses GitHub's
-`releases/latest/download/<asset>` redirect, so as long as the newest release
-is tagged "latest" the updater will find the JSON automatically.
+```bash
+gh secret set TAURI_SIGNING_PRIVATE_KEY --repo alexandre-schaffner/revv < ~/.tauri/revv-updater.key
+```
 
-## Out of scope (PRD 06)
+`_build-tauri.yml` fails fast with an explicit error if the key secret is
+missing, rather than letting the bundler fail deep in the build.
 
-Automating steps 2–4 in a GitHub Actions `release.yml` workflow is tracked
-in `docs/prds/06-polish-ship.md:277-295`. Until that lands, releases are
-manual.
+## What CI publishes
+
+`bundle.createUpdaterArtifacts` is `true` in `tauri.conf.json`, so each build
+emits, per architecture:
+
+- `Revv.Alpha._<version>_<arch>.dmg` — the user-facing download
+- `Revv.Alpha._<arch>.app.tar.gz` — what the updater actually downloads
+- `Revv.Alpha._<arch>.app.tar.gz.sig` — its minisign signature
+
+The `manifest` job then composes `latest.json` from both architectures'
+signatures and uploads it to the release:
+
+```json
+{
+  "version": "0.24.0",
+  "notes": "Short one-liner shown in the update toast.",
+  "pub_date": "2026-08-17T09:00:00Z",
+  "platforms": {
+    "darwin-aarch64": { "signature": "…", "url": "https://github.com/…/Revv.Alpha._aarch64.app.tar.gz" },
+    "darwin-x86_64":  { "signature": "…", "url": "https://github.com/…/Revv.Alpha._x64.app.tar.gz" }
+  }
+}
+```
+
+It is composed in a dedicated job rather than by `tauri-action`
+(`includeUpdaterJson: false`) because the two matrix legs run concurrently and
+each only knows its own platform — letting both read-modify-write the same
+asset is a race that can drop an architecture.
+
+On disk both legs produce an identically-named `<product>.app.tar.gz`, so the
+build job stages arch-suffixed copies before uploading. The suffix matches
+what `tauri-action` uses, so the fallback upload replaces its copy instead of
+adding a second one.
+
+`notes` comes from the `updater_notes` workflow input, not the GitHub release
+body: it renders as a Sonner toast description, so it needs to be one line,
+not a changelog.
+
+## Versioning
+
+- **Stable** builds use `tauri.conf.json` → `version` verbatim (release-please
+  keeps it in sync with `Cargo.toml` and the `package.json`s via the
+  `x-release-please-version` markers).
+- **Nightly** builds are stamped `<major>.<minor>.<patch+1>-nightly.<run>` at
+  build time. Every nightly is cut from the same released version, so without
+  the bump they would all report an identical version and the updater would
+  never see one as newer. Patch+1 keeps a nightly above the stable release it
+  came from and below the next stable one; the run number is numeric, so
+  semver orders successive nightlies correctly (a short SHA would not — it
+  sorts as an ASCII string).
+
+## Endpoints and channel switching
+
+`tauri-plugin-updater` reads `plugins.updater.endpoints` from
+`tauri.conf.json` at compile time and offers no runtime override, so the
+endpoint list cannot depend on the selected release channel. The indirection
+that makes `Settings → Updates → Release channel` work is the local API
+server. Two endpoints, in order:
+
+1. `http://localhost:45678/api/update-manifest` — resolves the channel from
+   SQLite per request and proxies the right manifest
+   (`apps/server/src/routes/update-manifest.ts`). Channel switches take effect
+   on the next check: no rebuild, no restart.
+2. `https://github.com/alexandre-schaffner/revv/releases/latest/download/latest.json`
+   — stable manifest, reached only if the first endpoint errors (e.g. the
+   `com.revv.server` LaunchAgent is stopped). Degrades to stable-channel
+   checks rather than failing outright.
+
+The port in endpoint 1 is hard-coded: `tauri.conf.json` is plain JSON read by
+the Rust host, so it cannot import `API_PORT` from `@revv/shared`. Changing
+the port means changing both.
+
+### Status codes matter
+
+The plugin walks the endpoint list in order, and **a 204 ends the walk** — it
+reads as "no update available". So the route returns:
+
+- **204** only for genuine absence (nightly channel, no nightly published yet)
+- **502** for any failure (missing manifest, GitHub unreachable, rate-limited)
+
+Returning 204 on failure would render as "You're up to date" and hide a broken
+release pipeline — which is how the updater stayed broken across 23 releases.
+
+### `dangerousInsecureTransportProtocol`
+
+Release builds normally refuse non-HTTPS updater endpoints; endpoint 1 needs
+the app to opt out via `plugins.updater.dangerousInsecureTransportProtocol`.
+Without the flag the plugin rejects the whole config at startup, so this is
+not something to remove casually.
+
+What it gives up is small. The server binds to loopback only, and the payload
+the manifest points at is still minisign-verified against the pinned public
+key before installation. A local process squatting on port 45678 could at
+worst suppress or misdirect an update — it cannot get one installed.
+
+## Verifying a release by hand
+
+```bash
+# The published manifest
+curl -sL https://github.com/alexandre-schaffner/revv/releases/latest/download/latest.json | jq
+
+# What the app actually fetches (respects the selected channel)
+curl -si http://localhost:45678/api/update-manifest | head -1
+```
+
+The first should return a manifest whose `version` matches the latest tag and
+whose two `platforms` URLs both resolve. If it 404s, the `manifest` job did
+not run or failed — the in-app check then reports "Could not fetch a valid
+release JSON from the remote".
+
+The second should be `200` with that manifest, or `204` on the nightly channel
+before any nightly exists. A `502` means the channel's manifest could not be
+fetched.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dist": "cd apps/desktop && bunx tauri build",
     "dist:debug": "cd apps/desktop && bunx tauri build --debug",
     "clean": "rm -rf apps/web/build apps/web/.svelte-kit apps/server/dist apps/desktop/target .turbo",
+    "prepare": "./scripts/prepare-effect.sh",
     "postinstall": "echo $'\\n  Run `bun run dev` to start developing, or `bun run dist` to build an installer.\\n'"
   },
   "devDependencies": {

--- a/packages/shared/src/acp-agents.ts
+++ b/packages/shared/src/acp-agents.ts
@@ -161,32 +161,22 @@ export const ACP_AGENTS = [
     description: "OpenAI's coding agent.",
     icon: "openai",
     command: "npx",
-    args: ["-y", "@zed-industries/codex-acp"],
+    args: ["-y", "@agentclientprotocol/codex-acp"],
     capabilities: {
-      defaultModel: "gpt-5.5",
-      // ⚠️ The ceiling here is `@zed-industries/codex-acp` (see `args` above),
-      // NOT the `codex` CLI on PATH. The adapter vendors its own — older —
-      // codex core, and the API rejects a model it predates with
-      // `400 "The '<model>' model requires a newer version of Codex"`, which
-      // reaches the user as a bare "Internal error".
-      //
-      // So do NOT curate this from `codex --version` or `~/.codex/
-      // models_cache.json`; the standalone CLI runs well ahead of the adapter
-      // (0.146.0 vs a ~0.137.0 core at codex-acp 0.16.0). Read the roster out
-      // of the adapter binary instead:
-      //   strings "$(npm root -g)/../_npx/*/node_modules/@zed-industries/\
-      //     codex-acp-darwin-arm64/bin/codex-acp" | grep -oE 'gpt-5\.[0-9]+[a-z-]*'
-      // GPT-5.6 Sol/Terra/Luna are deliberately absent until it catches up.
+      defaultModel: "gpt-5.6-sol",
+      // This maintained adapter embeds a current Codex App Server, so the
+      // selector can expose the current GPT-5.6 family. Do not replace it with
+      // the deprecated `@zed-industries/codex-acp`: that adapter embeds an
+      // older Codex core which rejects GPT-5.6 models.
       models: [
-        { label: "GPT-5.5", value: "gpt-5.5" },
-        { label: "GPT-5.4", value: "gpt-5.4" },
-        { label: "GPT-5.4 Mini", value: "gpt-5.4-mini" },
+        { label: "GPT-5.6 Sol", value: "gpt-5.6-sol" },
+        { label: "GPT-5.6 Terra", value: "gpt-5.6-terra" },
+        { label: "GPT-5.6 Luna", value: "gpt-5.6-luna" },
       ],
       contextWindow: false,
-      // Same ceiling: the adapter's `model_reasoning_effort` enum is
-      // none/minimal/low/medium/high/xhigh — it cannot parse the `max` and
-      // `ultra` levels the current standalone CLI offers, so extra-high (xhigh)
-      // is the top tier Revv can ask for.
+      // The GPT-5.6 family supports the existing selector's xhigh-or-below
+      // ladder. The adapter also supports newer tiers; keep those out of this
+      // shared setting until the UI can model each model's distinct limits.
       thinkingEfforts: ["extra-high", "high", "medium", "low"],
       // Codex requires danger-full-access for MCP tool execution, so there is
       // no enforceable read-only plan turn yet.
@@ -202,26 +192,22 @@ export const ACP_AGENTS = [
     args: ["-y", "cursor-agent-acp"],
     capabilities: {
       defaultModel: "auto",
-      // Curated from Cursor's CLI model roster (`cursor-agent --list-models`).
-      //
-      // STALE — the Anthropic entries below are a generation behind (Sonnet 4.6
-      // / Opus 4.7 vs Sonnet 5 / Opus 5). Not refreshed with the Claude Code and
-      // Codex catalogs because `--list-models` requires a logged-in Cursor CLI
-      // and the slugs are Cursor's own, not guessable from the model names. Run
-      // `cursor-agent login && cursor-agent --list-models` and paste the result.
-      //
-      // Low blast radius today: the `cursor-agent-acp` adapter doesn't forward a
-      // model, so this list is a stored preference Cursor never reads (see
-      // `resolveAcpLaunchById`). It starts mattering the moment that lands.
+      // Cursor documents these exact IDs in its Models & Pricing catalog. The
+      // ACP adapter does not yet forward a selected model, so this remains a
+      // stored preference until it gains a model passthrough.
       models: [
         { label: "Auto", value: "auto" },
-        { label: "Composer 2.5", value: "composer" },
-        { label: "Claude Sonnet 4.6", value: "sonnet-4.6" },
-        { label: "Claude Sonnet 4.6 Thinking", value: "sonnet-4.6-thinking" },
-        { label: "Claude Opus 4.7", value: "opus-4.7" },
-        { label: "GPT-5.5", value: "gpt-5.5" },
-        { label: "Gemini 3 Pro", value: "gemini-3-pro" },
-        { label: "Grok 4", value: "grok-4" },
+        { label: "Claude Fable 5", value: "claude-fable-5" },
+        { label: "Claude Opus 5", value: "claude-opus-5" },
+        { label: "Claude Sonnet 5", value: "claude-sonnet-5" },
+        { label: "Composer 2.5", value: "composer-2.5" },
+        { label: "Gemini 3.1 Pro", value: "gemini-3.1-pro" },
+        { label: "Gemini 3.7 Flash", value: "gemini-3.7-flash" },
+        { label: "GPT-5.6 Sol", value: "gpt-5.6-sol" },
+        { label: "GPT-5.6 Terra", value: "gpt-5.6-terra" },
+        { label: "GPT-5.6 Luna", value: "gpt-5.6-luna" },
+        { label: "Grok 4.6", value: "grok-4.6" },
+        { label: "Grok 4.5", value: "grok-4.5" },
       ],
       contextWindow: false,
       thinkingEfforts: [],

--- a/packages/shared/src/acp-agents.ts
+++ b/packages/shared/src/acp-agents.ts
@@ -21,16 +21,6 @@ export type AcpAgentIconKey = "anthropic" | "openai" | "opencode" | "cursor" | "
 export interface AcpAgentModel {
   readonly label: string;
   readonly value: string;
-  /**
-   * Thinking-effort tiers this specific model accepts, when it accepts fewer
-   * than its agent does. Omitted = the agent's full
-   * {@link AcpAgentCapabilities.thinkingEfforts} applies.
-   *
-   * Codex is the reason this exists: its reasoning ladder is per-model, not
-   * per-provider (`supported_reasoning_levels` in the catalog it fetches from
-   * OpenAI), so the frontier models accept tiers the older ones reject.
-   */
-  readonly thinkingEfforts?: readonly ThinkingEffort[];
 }
 
 /**
@@ -49,13 +39,7 @@ export interface AcpAgentCapabilities {
   readonly models: readonly AcpAgentModel[] | "dynamic";
   /** Whether the 200K / 1M context-window control applies (Claude Code only). */
   readonly contextWindow: boolean;
-  /**
-   * Thinking-effort tiers offered; empty = no thinking-effort control. Where a
-   * model accepts fewer than this, it narrows the list via its own
-   * {@link AcpAgentModel.thinkingEfforts} — so this is the union across the
-   * agent's catalog, not a guarantee every model takes every tier. Resolve with
-   * {@link getModelThinkingEfforts} rather than reading this directly.
-   */
+  /** Thinking-effort tiers offered; empty = no thinking-effort control. */
   readonly thinkingEfforts: readonly ThinkingEffort[];
   /**
    * Whether the agent supports a read-only plan turn — i.e. it advertises a
@@ -104,11 +88,7 @@ export interface AcpAgentDescriptor {
   readonly keychainAuth?: AcpAgentKeychainAuth;
 }
 
-/**
- * Every thinking-effort tier, strongest first. The ordering is the contract
- * {@link clampThinkingEffort} steps down through, and the order the web renders
- * the selector in.
- */
+/** Every thinking-effort tier, strongest first — the order the web renders. */
 export const THINKING_EFFORT_ORDER = [
   "ultrathink",
   "max",
@@ -117,10 +97,6 @@ export const THINKING_EFFORT_ORDER = [
   "medium",
   "low",
 ] as const satisfies readonly ThinkingEffort[];
-
-// Shared per-model effort ladders, so the Codex catalog below reads as data.
-const MAX_AND_BELOW = THINKING_EFFORT_ORDER.slice(1);
-const XHIGH_AND_BELOW = THINKING_EFFORT_ORDER.slice(2);
 
 // ⇩ Add a new ACP agent here — one entry is all it takes. ⇩
 export const ACP_AGENTS = [
@@ -188,23 +164,30 @@ export const ACP_AGENTS = [
     args: ["-y", "@zed-industries/codex-acp"],
     capabilities: {
       defaultModel: "gpt-5.5",
-      // Mirrors the `supported_reasoning_levels` Codex caches in
-      // `~/.codex/models_cache.json`; re-verify against that file when OpenAI
-      // ships a model. (`codex-auto-review` is in the catalog too, but it's
-      // Codex's internal review model, not a selectable chat model.)
+      // ⚠️ The ceiling here is `@zed-industries/codex-acp` (see `args` above),
+      // NOT the `codex` CLI on PATH. The adapter vendors its own — older —
+      // codex core, and the API rejects a model it predates with
+      // `400 "The '<model>' model requires a newer version of Codex"`, which
+      // reaches the user as a bare "Internal error".
+      //
+      // So do NOT curate this from `codex --version` or `~/.codex/
+      // models_cache.json`; the standalone CLI runs well ahead of the adapter
+      // (0.146.0 vs a ~0.137.0 core at codex-acp 0.16.0). Read the roster out
+      // of the adapter binary instead:
+      //   strings "$(npm root -g)/../_npx/*/node_modules/@zed-industries/\
+      //     codex-acp-darwin-arm64/bin/codex-acp" | grep -oE 'gpt-5\.[0-9]+[a-z-]*'
+      // GPT-5.6 Sol/Terra/Luna are deliberately absent until it catches up.
       models: [
-        { label: "GPT-5.6 Sol", value: "gpt-5.6-sol" },
-        { label: "GPT-5.6 Terra", value: "gpt-5.6-terra" },
-        { label: "GPT-5.6 Luna", value: "gpt-5.6-luna", thinkingEfforts: MAX_AND_BELOW },
-        { label: "GPT-5.5", value: "gpt-5.5", thinkingEfforts: XHIGH_AND_BELOW },
-        { label: "GPT-5.4", value: "gpt-5.4", thinkingEfforts: XHIGH_AND_BELOW },
-        { label: "GPT-5.4 Mini", value: "gpt-5.4-mini", thinkingEfforts: XHIGH_AND_BELOW },
+        { label: "GPT-5.5", value: "gpt-5.5" },
+        { label: "GPT-5.4", value: "gpt-5.4" },
+        { label: "GPT-5.4 Mini", value: "gpt-5.4-mini" },
       ],
       contextWindow: false,
-      // Union across the catalog — Codex maps each tier onto its own
-      // `model_reasoning_effort` ladder (ultrathink→ultra, extra-high→xhigh).
-      // Only Sol and Terra reach the top; the rest narrow it per model above.
-      thinkingEfforts: ["ultrathink", "max", "extra-high", "high", "medium", "low"],
+      // Same ceiling: the adapter's `model_reasoning_effort` enum is
+      // none/minimal/low/medium/high/xhigh — it cannot parse the `max` and
+      // `ultra` levels the current standalone CLI offers, so extra-high (xhigh)
+      // is the top tier Revv can ask for.
+      thinkingEfforts: ["extra-high", "high", "medium", "low"],
       // Codex requires danger-full-access for MCP tool execution, so there is
       // no enforceable read-only plan turn yet.
       planMode: false,
@@ -275,39 +258,21 @@ export function getAcpAgentDefaultModel(id: AcpAgentId): string {
 }
 
 /**
- * Thinking-effort tiers valid for one agent+model pair.
+ * Clamp a selected effort to a tier the agent actually accepts.
  *
- * Falls back to the agent's full list when the model declares no narrower one —
- * which covers agents with a uniform ladder (Claude Code), a dynamic catalog
- * (opencode), and any Codex model that accepts every tier. An unknown model id
- * (a stale persisted value, or one from opencode's live catalog) also gets the
- * agent-level list, since there's nothing narrower to apply.
- */
-export function getModelThinkingEfforts(
-  id: AcpAgentId,
-  model: string | undefined,
-): readonly ThinkingEffort[] {
-  const caps = getAgentCapabilities(id);
-  if (caps.models === "dynamic" || !model) return caps.thinkingEfforts;
-  return caps.models.find((m) => m.value === model)?.thinkingEfforts ?? caps.thinkingEfforts;
-}
-
-/**
- * Clamp a selected effort to something the agent+model actually accepts.
- *
- * The persisted effort and the persisted model move independently, so a user
- * who picked Ultrathink on Sol and then switched to GPT-5.4 holds a tier that
- * model rejects. Steps down to the nearest supported tier rather than dropping
- * the setting, so "as much thinking as this model allows" survives the switch.
+ * Effort and agent are persisted independently, so a tier picked on one agent
+ * outlives a switch to another that tops out lower — and an out-of-range tier
+ * is not inert: Codex's adapter fails to parse a `model_reasoning_effort` it
+ * doesn't know. Steps down to the nearest supported tier rather than dropping
+ * the setting, so "as much thinking as this agent allows" survives the switch.
  * Returns `undefined` when the agent has no thinking-effort control at all.
  */
 export function clampThinkingEffort(
   id: AcpAgentId,
-  model: string | undefined,
   effort: ThinkingEffort | undefined,
 ): ThinkingEffort | undefined {
   if (!effort) return undefined;
-  const allowed = getModelThinkingEfforts(id, model);
+  const allowed = getAgentCapabilities(id).thinkingEfforts;
   if (allowed.length === 0) return undefined;
   if (allowed.includes(effort)) return effort;
   // THINKING_EFFORT_ORDER is strongest-first, so the first allowed tier at or

--- a/packages/shared/src/acp-agents.ts
+++ b/packages/shared/src/acp-agents.ts
@@ -21,6 +21,16 @@ export type AcpAgentIconKey = "anthropic" | "openai" | "opencode" | "cursor" | "
 export interface AcpAgentModel {
   readonly label: string;
   readonly value: string;
+  /**
+   * Thinking-effort tiers this specific model accepts, when it accepts fewer
+   * than its agent does. Omitted = the agent's full
+   * {@link AcpAgentCapabilities.thinkingEfforts} applies.
+   *
+   * Codex is the reason this exists: its reasoning ladder is per-model, not
+   * per-provider (`supported_reasoning_levels` in the catalog it fetches from
+   * OpenAI), so the frontier models accept tiers the older ones reject.
+   */
+  readonly thinkingEfforts?: readonly ThinkingEffort[];
 }
 
 /**
@@ -39,7 +49,13 @@ export interface AcpAgentCapabilities {
   readonly models: readonly AcpAgentModel[] | "dynamic";
   /** Whether the 200K / 1M context-window control applies (Claude Code only). */
   readonly contextWindow: boolean;
-  /** Thinking-effort tiers offered; empty = no thinking-effort control. */
+  /**
+   * Thinking-effort tiers offered; empty = no thinking-effort control. Where a
+   * model accepts fewer than this, it narrows the list via its own
+   * {@link AcpAgentModel.thinkingEfforts} — so this is the union across the
+   * agent's catalog, not a guarantee every model takes every tier. Resolve with
+   * {@link getModelThinkingEfforts} rather than reading this directly.
+   */
   readonly thinkingEfforts: readonly ThinkingEffort[];
   /**
    * Whether the agent supports a read-only plan turn — i.e. it advertises a
@@ -88,6 +104,24 @@ export interface AcpAgentDescriptor {
   readonly keychainAuth?: AcpAgentKeychainAuth;
 }
 
+/**
+ * Every thinking-effort tier, strongest first. The ordering is the contract
+ * {@link clampThinkingEffort} steps down through, and the order the web renders
+ * the selector in.
+ */
+export const THINKING_EFFORT_ORDER = [
+  "ultrathink",
+  "max",
+  "extra-high",
+  "high",
+  "medium",
+  "low",
+] as const satisfies readonly ThinkingEffort[];
+
+// Shared per-model effort ladders, so the Codex catalog below reads as data.
+const MAX_AND_BELOW = THINKING_EFFORT_ORDER.slice(1);
+const XHIGH_AND_BELOW = THINKING_EFFORT_ORDER.slice(2);
+
 // ⇩ Add a new ACP agent here — one entry is all it takes. ⇩
 export const ACP_AGENTS = [
   {
@@ -99,14 +133,18 @@ export const ACP_AGENTS = [
     args: ["-y", "@agentclientprotocol/claude-agent-acp"],
     capabilities: {
       defaultModel: "claude-sonnet-5",
+      // Current-generation Anthropic models only. Opus 4.8 was dropped when
+      // Opus 5 superseded it; a user still on a delisted id keeps working (the
+      // value is passed through to the agent), they just can't reselect it.
       models: [
         { label: "Claude Fable 5", value: "claude-fable-5" },
         { label: "Claude Opus 5", value: "claude-opus-5" },
-        { label: "Claude Opus 4.8", value: "claude-opus-4-8" },
         { label: "Claude Sonnet 5", value: "claude-sonnet-5" },
         { label: "Claude Haiku 4.5", value: "claude-haiku-4-5-20251001" },
       ],
       contextWindow: true,
+      // Claude Code takes a `MAX_THINKING_TOKENS` budget rather than a named
+      // tier, so every model accepts every tier — no per-model narrowing.
       thinkingEfforts: ["ultrathink", "max", "extra-high", "high", "medium", "low"],
       // claude-agent-acp advertises a read-only plan mode.
       planMode: true,
@@ -150,17 +188,23 @@ export const ACP_AGENTS = [
     args: ["-y", "@zed-industries/codex-acp"],
     capabilities: {
       defaultModel: "gpt-5.5",
+      // Mirrors the `supported_reasoning_levels` Codex caches in
+      // `~/.codex/models_cache.json`; re-verify against that file when OpenAI
+      // ships a model. (`codex-auto-review` is in the catalog too, but it's
+      // Codex's internal review model, not a selectable chat model.)
       models: [
         { label: "GPT-5.6 Sol", value: "gpt-5.6-sol" },
         { label: "GPT-5.6 Terra", value: "gpt-5.6-terra" },
-        { label: "GPT-5.6 Luna", value: "gpt-5.6-luna" },
-        { label: "GPT-5.5", value: "gpt-5.5" },
-        { label: "GPT-5.4", value: "gpt-5.4" },
-        { label: "GPT-5.4 Mini", value: "gpt-5.4-mini" },
+        { label: "GPT-5.6 Luna", value: "gpt-5.6-luna", thinkingEfforts: MAX_AND_BELOW },
+        { label: "GPT-5.5", value: "gpt-5.5", thinkingEfforts: XHIGH_AND_BELOW },
+        { label: "GPT-5.4", value: "gpt-5.4", thinkingEfforts: XHIGH_AND_BELOW },
+        { label: "GPT-5.4 Mini", value: "gpt-5.4-mini", thinkingEfforts: XHIGH_AND_BELOW },
       ],
       contextWindow: false,
-      // Codex maps these onto its `model_reasoning_effort` (no ultrathink/max).
-      thinkingEfforts: ["extra-high", "high", "medium", "low"],
+      // Union across the catalog — Codex maps each tier onto its own
+      // `model_reasoning_effort` ladder (ultrathink→ultra, extra-high→xhigh).
+      // Only Sol and Terra reach the top; the rest narrow it per model above.
+      thinkingEfforts: ["ultrathink", "max", "extra-high", "high", "medium", "low"],
       // Codex requires danger-full-access for MCP tool execution, so there is
       // no enforceable read-only plan turn yet.
       planMode: false,
@@ -176,7 +220,16 @@ export const ACP_AGENTS = [
     capabilities: {
       defaultModel: "auto",
       // Curated from Cursor's CLI model roster (`cursor-agent --list-models`).
-      // Re-verify when Cursor ships/retires models.
+      //
+      // STALE — the Anthropic entries below are a generation behind (Sonnet 4.6
+      // / Opus 4.7 vs Sonnet 5 / Opus 5). Not refreshed with the Claude Code and
+      // Codex catalogs because `--list-models` requires a logged-in Cursor CLI
+      // and the slugs are Cursor's own, not guessable from the model names. Run
+      // `cursor-agent login && cursor-agent --list-models` and paste the result.
+      //
+      // Low blast radius today: the `cursor-agent-acp` adapter doesn't forward a
+      // model, so this list is a stored preference Cursor never reads (see
+      // `resolveAcpLaunchById`). It starts mattering the moment that lands.
       models: [
         { label: "Auto", value: "auto" },
         { label: "Composer 2.5", value: "composer" },
@@ -219,6 +272,48 @@ export function getAgentCapabilities(id: AcpAgentId): AcpAgentCapabilities {
 /** Revv's persisted-model default for an ACP agent. */
 export function getAcpAgentDefaultModel(id: AcpAgentId): string {
   return getAcpAgent(id).capabilities.defaultModel;
+}
+
+/**
+ * Thinking-effort tiers valid for one agent+model pair.
+ *
+ * Falls back to the agent's full list when the model declares no narrower one —
+ * which covers agents with a uniform ladder (Claude Code), a dynamic catalog
+ * (opencode), and any Codex model that accepts every tier. An unknown model id
+ * (a stale persisted value, or one from opencode's live catalog) also gets the
+ * agent-level list, since there's nothing narrower to apply.
+ */
+export function getModelThinkingEfforts(
+  id: AcpAgentId,
+  model: string | undefined,
+): readonly ThinkingEffort[] {
+  const caps = getAgentCapabilities(id);
+  if (caps.models === "dynamic" || !model) return caps.thinkingEfforts;
+  return caps.models.find((m) => m.value === model)?.thinkingEfforts ?? caps.thinkingEfforts;
+}
+
+/**
+ * Clamp a selected effort to something the agent+model actually accepts.
+ *
+ * The persisted effort and the persisted model move independently, so a user
+ * who picked Ultrathink on Sol and then switched to GPT-5.4 holds a tier that
+ * model rejects. Steps down to the nearest supported tier rather than dropping
+ * the setting, so "as much thinking as this model allows" survives the switch.
+ * Returns `undefined` when the agent has no thinking-effort control at all.
+ */
+export function clampThinkingEffort(
+  id: AcpAgentId,
+  model: string | undefined,
+  effort: ThinkingEffort | undefined,
+): ThinkingEffort | undefined {
+  if (!effort) return undefined;
+  const allowed = getModelThinkingEfforts(id, model);
+  if (allowed.length === 0) return undefined;
+  if (allowed.includes(effort)) return effort;
+  // THINKING_EFFORT_ORDER is strongest-first, so the first allowed tier at or
+  // below the request is the nearest step down.
+  const from = THINKING_EFFORT_ORDER.indexOf(effort);
+  return THINKING_EFFORT_ORDER.slice(from).find((t) => allowed.includes(t)) ?? allowed[0];
 }
 
 /** Keychain-login details for an agent, or `undefined` when it isn't keychain-backed. */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -3,6 +3,10 @@ export type AppChannel = "prod" | "dev";
 export const APP_CHANNELS: readonly AppChannel[] = ["prod", "dev"];
 export const DEFAULT_APP_CHANNEL: AppChannel = "prod";
 
+// Changing API_PORT means also changing the updater endpoint hard-coded in
+// `apps/desktop/tauri.conf.json` → `plugins.updater.endpoints[0]`. That file
+// is plain JSON evaluated by the Rust host before any TS runs, so it cannot
+// import this constant. See `docs/updater-setup.md`.
 export const API_PORT = 45678;
 export const DEV_API_PORT = 45679;
 export const API_BASE_URL = `http://localhost:${API_PORT}`;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,7 +16,6 @@ export {
   getAcpAgentDefaultModel,
   getAgentCapabilities,
   getAgentKeychainAuth,
-  getModelThinkingEfforts,
   isAcpAgentId,
   THINKING_EFFORT_ORDER,
 } from "./acp-agents";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,11 +11,14 @@ export type {
 export {
   ACP_AGENT_IDS,
   ACP_AGENTS,
+  clampThinkingEffort,
   getAcpAgent,
   getAcpAgentDefaultModel,
   getAgentCapabilities,
   getAgentKeychainAuth,
+  getModelThinkingEfforts,
   isAcpAgentId,
+  THINKING_EFFORT_ORDER,
 } from "./acp-agents";
 export type { Activity, ActivityKind, ActivityResult, ToolDiffOutput } from "./activity";
 export {

--- a/scripts/prepare-effect.sh
+++ b/scripts/prepare-effect.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -eu
+
+repo_dir=".repos/effect"
+repo_url="https://github.com/Effect-TS/effect-smol"
+
+if [ -d "$repo_dir/.git" ]; then
+  exit 0
+fi
+
+mkdir -p ".repos"
+git clone "$repo_url" "$repo_dir"


### PR DESCRIPTION
The in-app update check has never succeeded — `latest.json` is absent from every release, so `tauri-plugin-updater` fails with `ReleaseNotFound` ("Could not fetch a valid release JSON from the remote"), and background checks only `console.error`, so a 100% failure rate stayed invisible: `bundle.createUpdaterArtifacts` was never enabled, `TAURI_SIGNING_PRIVATE_KEY` was commented out, and `pubkey` was still the `REPLACE_WITH_MINISIGN_PUBLIC_KEY` placeholder.

This enables updater artifacts, pins the real minisign public key, wires up signing, and adds a `manifest` job that composes `latest.json` once both matrix legs finish — rather than letting tauri-action read-modify-write the same asset per leg, which races and can drop an architecture — and stamps nightly builds `<patch+1>-nightly.<run_number>`, since they all inherited the last released version and could never be seen as newer.

It also makes `Settings → Release channel` work: the plugin reads endpoints at compile time, so the app now checks `/api/update-manifest` first (channel resolved from SQLite per request) with the GitHub stable manifest as fallback, which needs `dangerousInsecureTransportProtocol` — the payload is still minisign-verified against the pinned key and the server is loopback-only. That route also returned 204 on an upstream 404, which the plugin reads as "no update available" and renders as "You're up to date", so it reported success while the updater was broken; failures now return 502.

**Before merging:** `gh secret set TAURI_SIGNING_PRIVATE_KEY --repo alexandre-schaffner/revv < ~/.tauri/revv-updater.key` — without it every build fails at the new signing-key check. Note the first update is verified against the new pubkey, so already-installed copies (which carry the placeholder) need one manual reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)