### PR TITLE
perf(github): stop re-fetching diffs on every view, cut poll/sync API cost

### DIFF
--- a/apps/desktop/Cargo.lock
+++ b/apps/desktop/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "revv-desktop"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "serde_json",
  "tauri",

--- a/apps/server/src/db/migrations/0320_pr_diff_files_cached_count.sql
+++ b/apps/server/src/db/migrations/0320_pr_diff_files_cached_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pull_requests` ADD `diff_files_cached_count` integer;

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1779645000000,
       "tag": "0310_walkthrough_error_message",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "6",
+      "when": 1779650000000,
+      "tag": "0320_pr_diff_files_cached_count",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema/pull-requests.ts
+++ b/apps/server/src/db/schema/pull-requests.ts
@@ -22,6 +22,25 @@ export const pullRequests = sqliteTable(
     additions: integer("additions").notNull().default(0),
     deletions: integer("deletions").notNull().default(0),
     changedFiles: integer("changed_files").notNull().default(0),
+    /**
+     * How many `pr_diff_files` rows the last complete GitHub files fetch
+     * produced for this PR. Written only by `DiffCacheService.cacheFiles`, in
+     * the same transaction as the rows themselves, and cleared when the cache
+     * is invalidated.
+     *
+     * Deliberately separate from `changed_files`. That column is GitHub's own
+     * stat and counts file *entries*, which exceeds the number of distinct
+     * paths whenever a file's type changed (GitHub reports one `removed` and
+     * one `added` entry for the same path). `pr_diff_files` is keyed on
+     * `(prId, path)`, so the cached row count for such a PR can never reach
+     * `changed_files` — and the completeness guard, comparing the two, made
+     * every single page view re-fetch all 30 pages from GitHub. This column is
+     * the honest signal: "the cache holds everything the last fetch returned."
+     * Null on rows written before this column existed, and on rows whose diff
+     * cache was invalidated; both fall back to the `changed_files` comparison
+     * and self-heal after one fetch.
+     */
+    diffFilesCachedCount: integer("diff_files_cached_count"),
     headSha: text("head_sha"),
     baseSha: text("base_sha"),
     createdAt: text("created_at").notNull(),

--- a/apps/server/src/domain/errors.ts
+++ b/apps/server/src/domain/errors.ts
@@ -12,7 +12,27 @@ export class GitHubAuthError extends Data.TaggedError("GitHubAuthError")<{
   readonly message: string;
 }> {}
 
+/**
+ * Transport-level failure: DNS, TLS, connection reset, request timeout, or a
+ * 5xx/408 from GitHub. **Retryable** — `retryTransient` in `github-rest.ts`
+ * only retries this class, so nothing else may be mapped to it.
+ */
 export class GitHubNetworkError extends Data.TaggedError("GitHubNetworkError")<{
+  readonly cause: unknown;
+}> {}
+
+/**
+ * GitHub understood the request and rejected it: a 4xx that isn't
+ * 401/403/404/429, or a GraphQL response carrying an `errors` array.
+ * **Not retryable** — replaying it produces the same rejection, so retrying
+ * only burns the backoff budget (2s + 4s + 8s per call) and stalls the
+ * sequential sync loops.
+ *
+ * `cause` is a human-readable string (status + response body when available)
+ * so callers can sniff GitHub's error text; see `isExistingPendingReviewError`.
+ */
+export class GitHubApiError extends Data.TaggedError("GitHubApiError")<{
+  readonly status: number;
   readonly cause: unknown;
 }> {}
 
@@ -31,6 +51,7 @@ export type GitHubError =
   | GitHubAuthError
   | GitHubAccessDeniedError
   | GitHubNetworkError
+  | GitHubApiError
   | GitHubNotFoundError;
 
 // General errors

--- a/apps/server/src/routes/middleware.ts
+++ b/apps/server/src/routes/middleware.ts
@@ -7,6 +7,7 @@ import {
   CloneInProgressError,
   CloneNotReadyError,
   GitHubAccessDeniedError,
+  GitHubApiError,
   GitHubAuthError,
   GitHubNetworkError,
   GitHubNotFoundError,
@@ -182,6 +183,14 @@ export function handleAppError(
 
   if (e instanceof GitHubNetworkError) {
     ctx.set.status = 502;
+    return { error: `GitHub API error: ${String(e.cause)}` };
+  }
+
+  // GitHub rejected the request on its merits, so this is not a bad-gateway
+  // condition — pass its own 4xx through (clamped, since a mapped 401/403/404
+  // is already handled above by its dedicated error class).
+  if (e instanceof GitHubApiError) {
+    ctx.set.status = e.status >= 400 && e.status < 500 ? e.status : 502;
     return { error: `GitHub API error: ${String(e.cause)}` };
   }
 

--- a/apps/server/src/routes/prs.ts
+++ b/apps/server/src/routes/prs.ts
@@ -418,10 +418,39 @@ export const prRoutes = new Elysia({ prefix: "/api/prs" })
     }
   })
 
+  // Full sync of every repo. Forked, not awaited: a cold-start cycle also runs
+  // the hourly metadata refresh and the archive backfill (up to 150 detail
+  // fetches per repo), which is minutes of work — far too long to hold an HTTP
+  // request open. Completion reaches the client over SSE (`prs:sync-complete`),
+  // which is what it already listens for. `syncNow` coalesces, so a double-click
+  // does not start a second pass.
   .post("/sync", async (ctx) => {
     try {
-      await AppRuntime.runPromise(Effect.flatMap(PollScheduler, (s) => s.syncNow()));
+      await AppRuntime.runPromise(
+        Effect.flatMap(PollScheduler, (s) => Effect.forkDaemon(s.syncNow())),
+      );
+      return { success: true };
+    } catch (e) {
+      return handleAppError(e, ctx);
+    }
+  })
 
+  // Targeted refresh of a single PR. Bounded to a couple of GitHub requests, so
+  // unlike `/sync` it is awaited and reports failure directly. Prefer this
+  // wherever the user is asking about one PR rather than the whole list.
+  .post("/:id/refresh", async (ctx) => {
+    try {
+      // Ownership check before touching GitHub: `getPr` with the caller's
+      // accountId 404s on a PR belonging to another account, so a valid session
+      // can't refresh — or learn about — a repo it doesn't own.
+      await AppRuntime.runPromise(
+        Effect.gen(function* () {
+          const prService = yield* PullRequestService;
+          const scheduler = yield* PollScheduler;
+          yield* prService.getPr(ctx.params.id, ctx.account.accountId);
+          yield* scheduler.refreshPr(ctx.params.id);
+        }),
+      );
       return { success: true };
     } catch (e) {
       return handleAppError(e, ctx);

--- a/apps/server/src/routes/reviews/handlers/github-submit.ts
+++ b/apps/server/src/routes/reviews/handlers/github-submit.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import { GitHubNetworkError } from "../../../domain/errors";
+import { GitHubApiError, GitHubNetworkError } from "../../../domain/errors";
 import { AppRuntime } from "../../../runtime";
 import { Broadcaster } from "../../../services/Broadcaster";
 import { GitHubGateway } from "../../../services/GitHub";
@@ -30,7 +30,12 @@ export interface SubmitReviewInput {
 }
 
 export function isExistingPendingReviewError(error: unknown): boolean {
-  if (!(error instanceof GitHubNetworkError) || typeof error.cause !== "string") {
+  // GitHub answers the duplicate-review case with a 422, which the REST helpers
+  // surface as `GitHubApiError`. `GitHubNetworkError` stays accepted for the
+  // synthetic failure this module raises itself when the pending review can't
+  // be located.
+  const isSniffable = error instanceof GitHubApiError || error instanceof GitHubNetworkError;
+  if (!isSniffable || typeof error.cause !== "string") {
     return false;
   }
 

--- a/apps/server/src/services/DbMaintenance.ts
+++ b/apps/server/src/services/DbMaintenance.ts
@@ -1,11 +1,28 @@
 import { and, inArray, isNotNull, lt, sql } from "drizzle-orm";
 import { Context, Duration, Effect, Fiber, Layer, Ref, Schedule } from "effect";
-import { cacheEntries, kvCache, pullRequests } from "../db/schema/index";
+import { cacheEntries, githubEtagCache, kvCache, pullRequests } from "../db/schema/index";
 import { logError } from "../logger";
 import { DbService } from "./Db";
 
 const SWEEP_INTERVAL_HOURS = 6;
 const PR_RETENTION_DAYS = 7;
+/**
+ * Retention for `github_etag_cache`.
+ *
+ * Unlike `cache_entries` / `kv_cache`, rows here carry no `expires_at` — an
+ * ETag stays valid indefinitely — so without a sweep the table only grows. Two
+ * things grow it fast: `listReviewComments` folds its advancing `since`
+ * watermark into the cache key, so every watermark move for every PR leaves a
+ * permanently-unreachable row behind; and `listPrs` stores the entire
+ * accumulated multi-page body, which is megabytes for a repo with hundreds of
+ * open PRs.
+ *
+ * A week is comfortably longer than any live key's reuse interval (the poll
+ * touches every active key every few minutes), so this only ever reaps rows
+ * nothing will ask for again. Reaping a still-live key would cost one
+ * unconditional refetch, not a correctness bug.
+ */
+const ETAG_CACHE_RETENTION_DAYS = 7;
 
 type DbMaintenanceService = {
   readonly start: () => Effect.Effect<void>;
@@ -69,14 +86,33 @@ export const DbMaintenanceLive = Layer.effect(
         db.delete(pullRequests).where(expiredPrsPredicate).run();
       }
 
-      // 4. Checkpoint WAL to reclaim disk space from the WAL file
+      // 4. Sweep GitHub conditional-request cache rows not touched in a week.
+      // `fetched_at` is refreshed on every 200 AND left alone on a 304, so it
+      // is a last-write time, not a last-use time — which is the conservative
+      // direction: a key still being replayed via 304s can be reaped, costing
+      // one unconditional refetch, whereas a key genuinely in use as a 200
+      // target keeps getting stamped and survives.
+      const etagCutoffIso = new Date(
+        Date.now() - ETAG_CACHE_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const expiredEtags = db
+        .select({ n: sql<number>`COUNT(*)` })
+        .from(githubEtagCache)
+        .where(lt(githubEtagCache.fetchedAt, etagCutoffIso))
+        .get();
+      const etagsSwept = expiredEtags?.n ?? 0;
+      if (etagsSwept > 0) {
+        db.delete(githubEtagCache).where(lt(githubEtagCache.fetchedAt, etagCutoffIso)).run();
+      }
+
+      // 5. Checkpoint WAL to reclaim disk space from the WAL file
       db.run(sql`PRAGMA wal_checkpoint(TRUNCATE)`);
 
-      const total = cacheEntriesSwept + kvSwept + prsSwept;
+      const total = cacheEntriesSwept + kvSwept + prsSwept + etagsSwept;
       if (total > 0) {
         logError(
           "DbMaintenance",
-          `sweep complete — cache_entries: ${cacheEntriesSwept} rows, kv_cache: ${kvSwept} rows, pull_requests: ${prsSwept} rows, WAL checkpointed`,
+          `sweep complete — cache_entries: ${cacheEntriesSwept} rows, kv_cache: ${kvSwept} rows, pull_requests: ${prsSwept} rows, github_etag_cache: ${etagsSwept} rows, WAL checkpointed`,
         );
       }
     }).pipe(

--- a/apps/server/src/services/DiffCache.test.ts
+++ b/apps/server/src/services/DiffCache.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { eq } from "drizzle-orm";
 import { Effect, Layer } from "effect";
 import { createDb, type Db } from "../db";
-import { prDiffFiles } from "../db/schema";
+import { prDiffFiles, pullRequests } from "../db/schema";
 import { GitHubAuthError, GitHubRateLimitError } from "../domain/errors";
 import { DbService } from "./Db";
 import {
@@ -47,6 +47,25 @@ describe("hasCompleteCachedFiles", () => {
   it("caps the expected count to the GitHub files endpoint range", () => {
     const files = Array.from({ length: PR_FILES_MAX_COUNT }, (_, i) => cachedFile(`src/${i}.ts`));
     expect(hasCompleteCachedFiles(files, PR_FILES_MAX_COUNT + 1)).toBe(true);
+  });
+
+  // GitHub counts file *entries* in `changed_files`, and reports a path whose
+  // file type changed twice (removed + added). `pr_diff_files` is keyed on
+  // (prId, path), so the row count is permanently short of `changed_files` for
+  // such a PR — without the recorded fetch size, every page view re-fetched
+  // all 30 pages.
+  it("accepts a cache holding every row the last fetch produced", () => {
+    const files = Array.from({ length: 2998 }, (_, i) => cachedFile(`src/${i}.ts`));
+    expect(hasCompleteCachedFiles(files, 3000)).toBe(false);
+    expect(hasCompleteCachedFiles(files, 3000, 2998)).toBe(true);
+  });
+
+  it("falls back to the changed-files count when no fetch size was recorded", () => {
+    expect(hasCompleteCachedFiles([cachedFile("src/a.ts")], 2, null)).toBe(false);
+  });
+
+  it("rejects a cache that lost rows since the recorded fetch", () => {
+    expect(hasCompleteCachedFiles([cachedFile("src/a.ts")], undefined, 2)).toBe(false);
   });
 });
 
@@ -102,5 +121,73 @@ describe("cacheFiles", () => {
     expect(rows[0]?.oldPath).toBe("src/old-a.ts");
     expect(rows[0]?.additions).toBe(3);
     expect(rows[0]?.patch).toBe("@@ second");
+  });
+
+  it("records the stored row count, not the length of a list with repeats", async () => {
+    const db = createDb(":memory:");
+    const sqlite = (db as unknown as { session: { client: { run: (sql: string) => void } } })
+      .session.client;
+    sqlite.run("PRAGMA foreign_keys = OFF");
+    db.insert(pullRequests)
+      .values({
+        id: "pr-1",
+        externalId: 1,
+        repositoryId: "repo-1",
+        title: "t",
+        authorLogin: "alex",
+        sourceBranch: "feat",
+        targetBranch: "main",
+        url: "https://example.test/pr/1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        fetchedAt: "2026-01-01T00:00:00.000Z",
+      })
+      .run();
+
+    // GitHub reports a type-changed path twice: once removed, once added.
+    await cacheFiles(db, "pr-1", [
+      cachedFile("src/a.ts"),
+      cachedFile("AGENTS.md"),
+      cachedFile("AGENTS.md"),
+    ]);
+
+    const pr = db.select().from(pullRequests).where(eq(pullRequests.id, "pr-1")).get();
+    expect(pr?.diffFilesCachedCount).toBe(2);
+    expect(pr?.changedFiles).toBe(2);
+    // Not 3 — the repeated path must not be counted twice in the diff stats.
+    expect(pr?.additions).toBe(2);
+  });
+
+  it("clears the recorded count when the cache is invalidated", async () => {
+    const db = createDb(":memory:");
+    const sqlite = (db as unknown as { session: { client: { run: (sql: string) => void } } })
+      .session.client;
+    sqlite.run("PRAGMA foreign_keys = OFF");
+    db.insert(pullRequests)
+      .values({
+        id: "pr-1",
+        externalId: 1,
+        repositoryId: "repo-1",
+        title: "t",
+        authorLogin: "alex",
+        sourceBranch: "feat",
+        targetBranch: "main",
+        url: "https://example.test/pr/1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        fetchedAt: "2026-01-01T00:00:00.000Z",
+      })
+      .run();
+
+    await cacheFiles(db, "pr-1", [cachedFile("src/a.ts")]);
+    await Effect.runPromise(
+      Effect.flatMap(DiffCacheService, (s) => s.invalidateFiles("pr-1")).pipe(
+        Effect.provide(DiffCacheServiceLive),
+        Effect.provide(Layer.succeed(DbService, { db })),
+      ),
+    );
+
+    const pr = db.select().from(pullRequests).where(eq(pullRequests.id, "pr-1")).get();
+    expect(pr?.diffFilesCachedCount).toBeNull();
   });
 });

--- a/apps/server/src/services/DiffCache.ts
+++ b/apps/server/src/services/DiffCache.ts
@@ -1,6 +1,6 @@
 import { eq, inArray, sql } from "drizzle-orm";
 import { Context, Effect, Layer } from "effect";
-import { prDiffFiles } from "../db/schema/index";
+import { prDiffFiles, pullRequests } from "../db/schema/index";
 import { type GitHubError, GitHubRateLimitError } from "../domain/errors";
 import { withDb } from "../effects/with-db";
 import { DbService } from "./Db";
@@ -25,11 +25,26 @@ export class DiffCacheService extends Context.Tag("DiffCacheService")<
     readonly getCachedFiles: (
       prId: string,
     ) => Effect.Effect<CachedDiffFile[] | null, never, DbService>;
-    /** Atomically replace all cached files for a PR. */
+    /**
+     * Atomically replace all cached files for a PR, and record the PR's diff
+     * size from the same list.
+     *
+     * Callers must pass a *complete* file list from GitHub — every caller
+     * currently does, straight out of `getPrFiles`. The PR's
+     * additions/deletions/changed_files are derived here rather than by the
+     * caller so the cached rows and the recorded size land in one transaction
+     * and cannot drift apart.
+     */
     readonly cacheFiles: (
       prId: string,
       files: CachedDiffFile[],
     ) => Effect.Effect<void, never, DbService>;
+    /**
+     * How many rows the last complete fetch stored for this PR, or null when
+     * nothing has been cached since the column was introduced. See
+     * `pullRequests.diffFilesCachedCount`.
+     */
+    readonly getCachedFileCount: (prId: string) => Effect.Effect<number | null, never, DbService>;
     /** Delete all cached files for a PR. */
     readonly invalidateFiles: (prId: string) => Effect.Effect<void, never, DbService>;
     /** Delete all cached files for multiple PRs. */
@@ -60,12 +75,19 @@ export const DiffCacheServiceLive = Layer.succeed(DiffCacheService, {
   cacheFiles: (prId, files) =>
     Effect.gen(function* () {
       const { db } = yield* DbService;
+      // One row per path — the table is keyed on `(prId, path)`, so a repeated
+      // path would collapse on write anyway. Collapsing here first (last entry
+      // wins, matching the upsert) keeps the derived stats below counting each
+      // stored row exactly once. `GitHubGateway.prs.files` already dedupes, but
+      // this transaction owns the row-count invariant and must not depend on
+      // its callers to uphold it.
+      const rows = [...new Map(files.map((f) => [f.path, f])).values()];
       db.transaction((tx) => {
         tx.delete(prDiffFiles).where(eq(prDiffFiles.prId, prId)).run();
-        if (files.length > 0) {
+        if (rows.length > 0) {
           tx.insert(prDiffFiles)
             .values(
-              files.map((f) => ({
+              rows.map((f) => ({
                 id: `${prId}\0${f.path}`,
                 prId,
                 path: f.path,
@@ -91,21 +113,74 @@ export const DiffCacheServiceLive = Layer.succeed(DiffCacheService, {
               },
             })
             .run();
+
+          // Record the PR's real diff size from the same fetch.
+          //
+          // This is the only place an *open* PR learns it: the poll reads
+          // GitHub's list-PRs endpoint, which returns the "simple" PR object
+          // with no additions/deletions/changed_files. Leaving `changed_files`
+          // at 0 silently disables `hasCompleteCachedFiles` — it compares
+          // against `min(expected, PR_FILES_MAX_COUNT)`, so a 0 expectation
+          // accepts any cache, including a truncated one — and surfaces as
+          // "+0 / -0" in AI prompts and recaps.
+          let additions = 0;
+          let deletions = 0;
+          for (const f of rows) {
+            additions += f.additions;
+            deletions += f.deletions;
+          }
+          // `diffFilesCachedCount` records how many rows this write stored, so
+          // `hasCompleteCachedFiles` has a signal that doesn't depend on
+          // GitHub's `changed_files` stat agreeing with the number of distinct
+          // paths it actually lists — for a PR containing a file whose type
+          // changed, it never does. See the column's doc comment.
+          tx.update(pullRequests)
+            .set({
+              additions,
+              deletions,
+              changedFiles: rows.length,
+              diffFilesCachedCount: rows.length,
+            })
+            .where(eq(pullRequests.id, prId))
+            .run();
         }
       });
+    }),
+
+  getCachedFileCount: (prId) =>
+    Effect.gen(function* () {
+      const { db } = yield* DbService;
+      const row = db
+        .select({ count: pullRequests.diffFilesCachedCount })
+        .from(pullRequests)
+        .where(eq(pullRequests.id, prId))
+        .get();
+      return row?.count ?? null;
     }),
 
   invalidateFiles: (prId) =>
     Effect.gen(function* () {
       const { db } = yield* DbService;
-      db.delete(prDiffFiles).where(eq(prDiffFiles.prId, prId)).run();
+      db.transaction((tx) => {
+        tx.delete(prDiffFiles).where(eq(prDiffFiles.prId, prId)).run();
+        tx.update(pullRequests)
+          .set({ diffFilesCachedCount: null })
+          .where(eq(pullRequests.id, prId))
+          .run();
+      });
     }),
 
   invalidateFilesForPrs: (prIds) =>
     Effect.gen(function* () {
       const { db } = yield* DbService;
       if (prIds.length === 0) return;
-      db.delete(prDiffFiles).where(inArray(prDiffFiles.prId, prIds)).run();
+      db.transaction((tx) => {
+        tx.delete(prDiffFiles).where(inArray(prDiffFiles.prId, prIds)).run();
+        tx.update(pullRequests)
+          .set({ diffFilesCachedCount: null })
+          .where(inArray(pullRequests.id, prIds))
+          .run();
+      });
     }),
 
   getPrIdsWithCachedDiffs: () =>
@@ -116,10 +191,27 @@ export const DiffCacheServiceLive = Layer.succeed(DiffCacheService, {
     }),
 });
 
+/**
+ * Decide whether the cached rows are the whole diff, or a partial cache that
+ * has to be re-fetched.
+ *
+ * `cachedCount` — `pullRequests.diffFilesCachedCount`, written by `cacheFiles`
+ * — is the authoritative signal and is checked first: if the cache still holds
+ * every row the last fetch produced, it is complete by definition.
+ *
+ * `expectedChangedFiles` (GitHub's `changed_files`) is only the fallback, for
+ * rows cached before that column existed. It is *not* reliable on its own:
+ * GitHub counts file entries, and a path whose file type changed contributes
+ * two of them (`removed` + `added`) while collapsing to one `pr_diff_files`
+ * row. Treating that permanent gap as "cache incomplete" made a 3 000-file PR
+ * re-fetch 30 pages of GitHub JSON — ~18 s — on every single page view.
+ */
 export function hasCompleteCachedFiles(
   cached: readonly CachedDiffFile[],
   expectedChangedFiles?: number,
+  cachedCount?: number | null,
 ): boolean {
+  if (cachedCount != null) return cached.length >= cachedCount;
   if (expectedChangedFiles === undefined) return true;
   return cached.length >= Math.min(expectedChangedFiles, PR_FILES_MAX_COUNT);
 }
@@ -153,7 +245,10 @@ export const getOrFetchDiffFiles = (
     const { db } = yield* DbService;
 
     const cached = yield* withDb(db, diffCache.getCachedFiles(prId));
-    if (cached !== null && hasCompleteCachedFiles(cached, expectedChangedFiles)) return cached;
+    if (cached !== null) {
+      const cachedCount = yield* withDb(db, diffCache.getCachedFileCount(prId));
+      if (hasCompleteCachedFiles(cached, expectedChangedFiles, cachedCount)) return cached;
+    }
 
     const fetched = yield* github.prs.files(repoFullName, prExternalId, token).pipe(
       Effect.map((fileList) => ({ source: "github" as const, fileList })),

--- a/apps/server/src/services/GitHub.test.ts
+++ b/apps/server/src/services/GitHub.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { Effect, Either, Layer } from "effect";
 import { createDb, type Db } from "../db/index";
-import { GitHubRateLimitError } from "../domain/errors";
+import { GitHubApiError, GitHubRateLimitError } from "../domain/errors";
 import { DbService } from "./Db";
 import { GitHubGateway, GitHubGatewayLive } from "./GitHub";
 import { GitHubEtagCacheLive } from "./GitHubEtagCache";
@@ -186,17 +186,29 @@ describe("GitHubGateway conditional pagination", () => {
     expect(calls[1]?.headers.get("If-None-Match")).toBeNull();
   });
 
-  it("replays cached open PRs on 304 only when the cached set fit on one page", async () => {
+  // `listOpen` replays a cached 304 unconditionally, including a multi-page
+  // cached set. That is safe *because of the sort*: `?sort=updated&direction=desc`
+  // moves any changed PR onto page 1, so page 1's ETag — the one we send
+  // If-None-Match against — moves whenever anything anywhere in the list moves.
+  // A 304 there genuinely means "no page changed".
+  //
+  // Contrast `listComments` below, which does force a refetch on a full page.
+  it("replays the whole cached open-PR set on a 304, across pages", async () => {
     const db = createDb(":memory:");
     const firstPage = Array.from({ length: 100 }, (_, i) => rawPr(i + 1));
     const calls = stubFetch((_call, index) => {
       if (index === 0) {
-        return responseJson(firstPage, { headers: { ETag: '"prs-v1"' } });
+        return responseJson(firstPage, {
+          headers: {
+            ETag: '"prs-v1"',
+            Link: '<https://api.github.test/repos/octo/repo/pulls?page=2>; rel="next"',
+          },
+        });
       }
       if (index === 1) {
-        return new Response(null, { status: 304 });
+        return responseJson([rawPr(101)], { headers: { ETag: '"prs-v1-page2"' } });
       }
-      return responseJson([rawPr(101)], { headers: { ETag: '"prs-v2"' } });
+      return new Response(null, { status: 304 });
     });
 
     const prs = await Effect.runPromise(
@@ -212,11 +224,103 @@ describe("GitHubGateway conditional pagination", () => {
       }).pipe(Effect.provide(gatewayLayer(db))),
     );
 
-    expect(prs).toHaveLength(1);
-    expect(prs[0]?.externalId).toBe(101);
+    // Both pages of the first fetch, served back from cache.
+    expect(prs).toHaveLength(101);
     expect(calls).toHaveLength(3);
-    expect(calls[1]?.headers.get("If-None-Match")).toBe('"prs-v1"');
+    expect(calls[2]?.headers.get("If-None-Match")).toBe('"prs-v1"');
+  });
+
+  it("refuses to replay a cached review-comment page that was full", async () => {
+    const db = createDb(":memory:");
+    const fullPage = Array.from({ length: 100 }, (_, i) => rawComment(i + 1));
+    const calls = stubFetch((_call, index) => {
+      if (index === 0) {
+        return responseJson(fullPage, { headers: { ETag: '"comments-v1"' } });
+      }
+      if (index === 1) {
+        return new Response(null, { status: 304 });
+      }
+      return responseJson([rawComment(999)], { headers: { ETag: '"comments-v2"' } });
+    });
+
+    const comments = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        yield* github.reviews.listComments("octo/repo", 1, "2026-01-01T00:00:00Z", "token");
+        return yield* github.reviews.listComments("octo/repo", 1, "2026-01-01T00:00:00Z", "token");
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    // A full cached page means there may be a page 2 we never saw, so the 304 is
+    // discarded and the request repeated unconditionally.
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.id).toBe(999);
+    expect(calls).toHaveLength(3);
+    expect(calls[1]?.headers.get("If-None-Match")).toBe('"comments-v1"');
     expect(calls[2]?.headers.get("If-None-Match")).toBeNull();
+  });
+});
+
+// The API base URL is a per-repository property (`repositories.github_host`).
+// These pin that an explicitly-passed base wins over the settings-derived
+// fallback, which is what keeps a GitHub Enterprise repo's token from being
+// sent to api.github.com when both hosts are connected on one machine.
+describe("GitHubGateway per-host API base", () => {
+  it("honours an explicit apiBase on the PR detail fetch", async () => {
+    const db = createDb(":memory:");
+    const calls = stubFetch(() => responseJson(rawPr(7), { headers: { ETag: '"pr-7"' } }));
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        return yield* github.prs.get("octo/repo", 7, "token", "https://api.ghe.example.com");
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(calls[0]?.url).toBe("https://api.ghe.example.com/repos/octo/repo/pulls/7");
+  });
+
+  it("honours an explicit apiBase on the review-thread GraphQL call", async () => {
+    const db = createDb(":memory:");
+    const calls = stubFetch(() =>
+      responseJson({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [] },
+            },
+          },
+        },
+      }),
+    );
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        return yield* github.reviews.listThreads(
+          "octo/repo",
+          7,
+          "token",
+          "https://api.ghe.example.com",
+        );
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(calls[0]?.url).toBe("https://api.ghe.example.com/graphql");
+  });
+
+  it("falls back to the settings-derived base when none is passed", async () => {
+    const db = createDb(":memory:");
+    const calls = stubFetch(() => responseJson(rawPr(7), { headers: { ETag: '"pr-7"' } }));
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        return yield* github.prs.get("octo/repo", 7, "token");
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(calls[0]?.url).toBe("https://api.github.com/repos/octo/repo/pulls/7");
   });
 
   it("separates ETag cache entries by API base and token", async () => {
@@ -236,5 +340,105 @@ describe("GitHubGateway conditional pagination", () => {
     expect(calls[0]?.headers.get("If-None-Match")).toBeNull();
     expect(calls[1]?.headers.get("If-None-Match")).toBeNull();
     expect(calls[2]?.headers.get("If-None-Match")).toBeNull();
+  });
+});
+
+// `retryTransient` retries `GitHubNetworkError` and nothing else, so what gets
+// mapped to it decides whether a failure costs 1 request or 4 requests plus
+// ~14s of backoff. In the sequential thread sweep that backoff stalls every PR
+// queued behind the failing one, so the split is load-bearing, not cosmetic.
+describe("GitHubGateway error classification", () => {
+  // One failure only: the retry schedule is exponential from 2s, so failing
+  // twice would push this past a sane test timeout without proving anything
+  // more than failing once does.
+  it("retries a 5xx as transient", async () => {
+    const db = createDb(":memory:");
+    const calls = stubFetch((_call, index) =>
+      index < 1
+        ? new Response("boom", { status: 503 })
+        : responseJson([rawPr(1)], { headers: { ETag: '"prs-v1"' } }),
+    );
+
+    const prs = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        return yield* github.prs.listOpen(
+          "octo/repo",
+          "repo-1",
+          "token",
+          "https://api.github.test",
+        );
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(prs).toHaveLength(1);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("does not retry a 422", async () => {
+    const db = createDb(":memory:");
+    const calls = stubFetch(() => new Response("bad field", { status: 422 }));
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        return yield* github.prs
+          .listOpen("octo/repo", "repo-1", "token", "https://api.github.test")
+          .pipe(Effect.either);
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(GitHubApiError);
+    }
+  });
+
+  it("does not retry a GraphQL errors payload", async () => {
+    const db = createDb(":memory:");
+    const calls = stubFetch(() =>
+      responseJson({ errors: [{ message: "Field 'nope' doesn't exist" }] }),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        return yield* github.reviews.listThreads("octo/repo", 1, "token").pipe(Effect.either);
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(GitHubApiError);
+      expect(String((result.left as GitHubApiError).cause)).toContain("nope");
+    }
+  });
+});
+
+describe("getPrFiles", () => {
+  it("collapses the removed+added pair GitHub emits for a type-changed path", async () => {
+    const db = createDb(":memory:");
+    stubFetch(() =>
+      responseJson([
+        { filename: "src/a.ts", status: "modified", additions: 2, deletions: 1, patch: "@@ a" },
+        { filename: "AGENTS.md", status: "removed", additions: 0, deletions: 86, patch: "@@ old" },
+        { filename: "AGENTS.md", status: "added", additions: 1, deletions: 0, patch: "@@ new" },
+      ]),
+    );
+
+    const files = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubGateway;
+        return yield* github.prs.files("octo/repo", 1, "token", "https://api.github.test");
+      }).pipe(Effect.provide(gatewayLayer(db))),
+    );
+
+    expect(files.map((f) => f.filename)).toEqual(["src/a.ts", "AGENTS.md"]);
+    // Last entry wins, matching the diff cache's `onConflictDoUpdate`, so the
+    // surviving row is the file's final state.
+    expect(files[1]?.status).toBe("added");
+    expect(files[1]?.patch).toBe("@@ new");
   });
 });

--- a/apps/server/src/services/GitHub.ts
+++ b/apps/server/src/services/GitHub.ts
@@ -12,6 +12,7 @@ import { type GitHubError, GitHubNotFoundError } from "../domain/errors";
 import type { DbService } from "./Db";
 import type { GitHubEtagCache } from "./GitHubEtagCache";
 import {
+  apiBaseForHost,
   assertGitHubOk,
   conditionalFetch,
   conditionalFetchPaginated,
@@ -30,23 +31,21 @@ import {
 import { SettingsService } from "./Settings";
 
 /**
- * Resolve the GitHub REST API base URL at call time from user settings.
- * Falls back to `serverEnv.githubHost` when settings haven't been written yet
- * (first-run, or settings file missing). Returns `https://api.github.com` for
- * `github.com`; `https://api.<host>` for GitHub Enterprise.
+ * Fallback GitHub REST API base URL, derived from the *global* settings host.
+ *
+ * Only correct for flows that have no repository in hand: add-repo, onboarding,
+ * device auth, org/team pickers. Anything scoped to a repo must pass an
+ * explicit `apiBase` built from that repo's `githubHost` — the settings row
+ * holds one host, so relying on it silently sends GitHub Enterprise traffic to
+ * `api.github.com` (or vice versa) the moment two hosts coexist on one machine.
  */
 const resolveApiBase: Effect.Effect<string, never, SettingsService> = Effect.gen(function* () {
   const settings = yield* Effect.flatMap(SettingsService, (s) => s.getSettings()).pipe(
     Effect.orElseSucceed(() => null),
   );
   const host = settings?.githubHost?.trim() || serverEnv.githubHost;
-  return host === "github.com" ? "https://api.github.com" : `https://api.${host}`;
+  return apiBaseForHost(host);
 });
-
-/** Build the REST API base URL for an explicit host (no settings lookup needed). */
-function resolveApiBaseForHost(host: string): string {
-  return host === "github.com" ? "https://api.github.com" : `https://api.${host}`;
-}
 
 /** Parse "owner/repo" into parts, failing with GitHubNotFoundError if malformed. */
 function parseRepoFullName(
@@ -131,6 +130,34 @@ const PR_FILES_PAGE_SIZE = 100;
 export const PR_FILES_MAX_PAGES = 30;
 export const PR_FILES_MAX_COUNT = PR_FILES_PAGE_SIZE * PR_FILES_MAX_PAGES;
 
+/**
+ * Collapse repeated filenames in GitHub's PR-files list.
+ *
+ * GitHub emits *two* entries for one path when the file's type changed — a
+ * regular file replaced by a symlink comes back as a `removed` entry
+ * immediately followed by an `added` entry, both with the same `filename`.
+ * Two consequences, both bugs we hit:
+ *
+ *   • `pr_diff_files` is keyed on `(prId, path)`, so the pair collapses to a
+ *     single row on write. The stored row count then never reaches GitHub's
+ *     `changed_files` stat (which counts entries, not paths), and the
+ *     completeness guard re-fetched all 30 pages on *every* page view.
+ *   • `@pierre/trees` throws `Duplicate path` when the sidebar tree is built
+ *     from a list containing the same path twice. That throw happens inside a
+ *     Svelte `$effect`, which aborts the whole flush — the walkthrough's code
+ *     blocks silently never mount.
+ *
+ * Deduping at the gateway keeps what we return identical to what we store.
+ * Last entry wins, matching the cache write's `onConflictDoUpdate`; the
+ * surviving entry keeps the first occurrence's position so file order is
+ * stable.
+ */
+export function dedupePrFilesByPath(files: readonly PrFileMeta[]): PrFileMeta[] {
+  const byPath = new Map<string, PrFileMeta>();
+  for (const file of files) byPath.set(file.filename, file);
+  return [...byPath.values()];
+}
+
 export interface PrCommit {
   readonly sha: string;
   readonly message: string;
@@ -150,6 +177,7 @@ interface GitHubGatewayFlatService {
     repoFullName: string,
     prNumber: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<PullRequest, GitHubError, DbService | GitHubEtagCache | SettingsService>;
   /**
    * Find PR numbers closed (or merged) in a time window via GitHub's
@@ -167,6 +195,7 @@ interface GitHubGatewayFlatService {
     sinceIso: string,
     untilIso: string,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<
     ReadonlyArray<{
       readonly number: number;
@@ -179,6 +208,7 @@ interface GitHubGatewayFlatService {
   readonly getRepo: (
     fullName: string,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<Repository, GitHubError, DbService | GitHubEtagCache | SettingsService>;
   /**
    * Like `getRepo`, but bypasses the ETag cache. Required for fields that
@@ -221,22 +251,26 @@ interface GitHubGatewayFlatService {
     repoFullName: string,
     prNumber: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<PrMeta, GitHubError, DbService | GitHubEtagCache | SettingsService>;
   readonly getPrFiles: (
     repoFullName: string,
     prNumber: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<PrFileMeta[], GitHubError, DbService | GitHubEtagCache | SettingsService>;
   readonly listPrCommits: (
     repoFullName: string,
     prNumber: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<PrCommit[], GitHubError, SettingsService>;
   readonly getFileContent: (
     repoFullName: string,
     path: string,
     ref: string,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<string, GitHubError, SettingsService>;
   /**
    * Fetch the raw bytes for a file at a specific ref. Uses the
@@ -250,6 +284,7 @@ interface GitHubGatewayFlatService {
     path: string,
     ref: string,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<Uint8Array, GitHubError, SettingsService>;
   readonly postReview: (
     repoFullName: string,
@@ -267,24 +302,28 @@ interface GitHubGatewayFlatService {
       }>;
     },
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<{ id: number; htmlUrl: string }, GitHubError, SettingsService>;
   readonly findPendingReview: (
     repoFullName: string,
     prNumber: number,
     reviewerLogin: string,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<{ id: number; htmlUrl: string } | null, GitHubError, SettingsService>;
   readonly deletePendingReview: (
     repoFullName: string,
     prNumber: number,
     reviewId: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<void, GitHubError, SettingsService>;
   readonly listReviewCommentsForReview: (
     repoFullName: string,
     prNumber: number,
     reviewId: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<
     Array<{
       id: number;
@@ -309,6 +348,7 @@ interface GitHubGatewayFlatService {
       readonly commitSha: string;
     },
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<
     { id: number; htmlUrl: string; createdAt: string },
     GitHubError,
@@ -320,6 +360,7 @@ interface GitHubGatewayFlatService {
     commentId: string | number,
     body: string,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<
     { id: number; htmlUrl: string; createdAt: string },
     GitHubError,
@@ -330,19 +371,23 @@ interface GitHubGatewayFlatService {
     prNumber: number,
     since: string | null,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<GhReviewComment[], GitHubError, DbService | GitHubEtagCache | SettingsService>;
   readonly listReviewThreads: (
     repoFullName: string,
     prNumber: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<GhReviewThread[], GitHubError, SettingsService>;
   readonly resolveReviewThread: (
     threadNodeId: string,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<void, GitHubError, SettingsService>;
   readonly unresolveReviewThread: (
     threadNodeId: string,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<void, GitHubError, SettingsService>;
   /**
    * Flip an open PR to draft. GitHub only exposes this via GraphQL, which
@@ -353,12 +398,14 @@ interface GitHubGatewayFlatService {
     repoFullName: string,
     prNumber: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<void, GitHubError, SettingsService>;
   /** Inverse of {@link convertPrToDraft}: move a draft back to ready-for-review. */
   readonly markPrReadyForReview: (
     repoFullName: string,
     prNumber: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<void, GitHubError, SettingsService>;
   /**
    * Close (but do not merge) the PR via REST PATCH /pulls/:number with
@@ -369,6 +416,7 @@ interface GitHubGatewayFlatService {
     repoFullName: string,
     prNumber: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<void, GitHubError, SettingsService>;
   /**
    * Check whether the authenticated viewer can merge this PR, and whether
@@ -379,6 +427,7 @@ interface GitHubGatewayFlatService {
     repoFullName: string,
     prNumber: number,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<MergeEligibility, GitHubError, SettingsService>;
   /**
    * Merge a pull request via the REST API. GitHub returns 405 when the PR
@@ -390,6 +439,7 @@ interface GitHubGatewayFlatService {
     prNumber: number,
     mergeMethod: MergeMethod,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<void, GitHubError, SettingsService>;
   /**
    * Fetch the authenticated viewer (`GET /user`), bypassing the ETag cache.
@@ -431,6 +481,7 @@ interface GitHubGatewayFlatService {
       readonly draft?: boolean;
     },
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<
     {
       readonly id: number;
@@ -457,6 +508,7 @@ interface GitHubGatewayFlatService {
     repoFullName: string,
     headBranch: string,
     token: string,
+    apiBase?: string,
   ) => Effect.Effect<
     {
       readonly number: number;
@@ -529,9 +581,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       return (data as Record<string, unknown>[]).map((pr) => mapPr(pr, repositoryId));
     }).pipe(retryTransient),
 
-  getPr: (repoFullName, prNumber, token) =>
+  getPr: (repoFullName, prNumber, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const data = yield* conditionalFetch(
         `/repos/${owner}/${repo}/pulls/${prNumber}`,
@@ -541,9 +593,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       return mapPr(data as Record<string, unknown>, `${owner}/${repo}`);
     }).pipe(retryTransient),
 
-  searchClosedPrsInWindow: (repoFullName, sinceIso, untilIso, token) =>
+  searchClosedPrsInWindow: (repoFullName, sinceIso, untilIso, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       // GitHub's search query syntax: `repo:owner/name is:pr is:closed
       // closed:since..until`. Timestamps in ISO form are accepted with
@@ -592,9 +644,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       }>;
     }).pipe(retryTransient),
 
-  getRepo: (fullName, token) =>
+  getRepo: (fullName, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(fullName);
       const data = yield* conditionalFetch(`/repos/${owner}/${repo}`, token, apiBase);
       return mapRepo(data as Record<string, unknown>);
@@ -789,9 +841,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       return yield* fromRest;
     }).pipe(retryTransient),
 
-  getPrMeta: (repoFullName, prNumber, token) =>
+  getPrMeta: (repoFullName, prNumber, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const data = yield* conditionalFetch(
         `/repos/${owner}/${repo}/pulls/${prNumber}`,
@@ -804,9 +856,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       return { baseSha: base.sha as string, headSha: head.sha as string };
     }).pipe(retryTransient),
 
-  getPrFiles: (repoFullName, prNumber, token) =>
+  getPrFiles: (repoFullName, prNumber, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       // GitHub returns PR files in 100-file pages. Fetch the endpoint's full
       // supported range so large PRs don't cache an incomplete sidebar/diff.
@@ -816,19 +868,21 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
         PR_FILES_MAX_PAGES,
         apiBase,
       );
-      return (data as Record<string, unknown>[]).map((f) => ({
-        filename: f.filename as string,
-        previousFilename: (f.previous_filename as string | undefined) ?? null,
-        status: f.status as string,
-        additions: (f.additions as number | undefined) ?? 0,
-        deletions: (f.deletions as number | undefined) ?? 0,
-        patch: (f.patch as string | undefined) ?? null,
-      }));
+      return dedupePrFilesByPath(
+        (data as Record<string, unknown>[]).map((f) => ({
+          filename: f.filename as string,
+          previousFilename: (f.previous_filename as string | undefined) ?? null,
+          status: f.status as string,
+          additions: (f.additions as number | undefined) ?? 0,
+          deletions: (f.deletions as number | undefined) ?? 0,
+          patch: (f.patch as string | undefined) ?? null,
+        })),
+      );
     }).pipe(retryTransient),
 
-  listPrCommits: (repoFullName, prNumber, token) =>
+  listPrCommits: (repoFullName, prNumber, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       // Paginate to capture the head commit. GitHub's PR commits endpoint
       // returns up to 250 commits in ascending date order (oldest first),
@@ -905,9 +959,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       );
     }).pipe(retryTransient),
 
-  getFileContent: (repoFullName, path, ref, token) =>
+  getFileContent: (repoFullName, path, ref, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const encodedPath = path.split("/").map(encodeURIComponent).join("/");
       const data = yield* githubFetch(
@@ -923,9 +977,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       return "";
     }).pipe(retryTransient),
 
-  getFileRawBytes: (repoFullName, path, ref, token) =>
+  getFileRawBytes: (repoFullName, path, ref, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const encodedPath = path.split("/").map(encodeURIComponent).join("/");
       const url = `${apiBase}/repos/${owner}/${repo}/contents/${encodedPath}?ref=${ref}`;
@@ -948,9 +1002,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       });
     }).pipe(retryTransient),
 
-  postReview: (repoFullName, prNumber, review, token) =>
+  postReview: (repoFullName, prNumber, review, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const payload: Record<string, unknown> = {
         event: review.event,
@@ -984,9 +1038,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
-  findPendingReview: (repoFullName, prNumber, reviewerLogin, token) =>
+  findPendingReview: (repoFullName, prNumber, reviewerLogin, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const data = yield* githubFetchPaginated(
         `/repos/${owner}/${repo}/pulls/${prNumber}/reviews?per_page=100`,
@@ -1007,9 +1061,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
-  deletePendingReview: (repoFullName, prNumber, reviewId, token) =>
+  deletePendingReview: (repoFullName, prNumber, reviewId, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       yield* githubDelete(
         `/repos/${owner}/${repo}/pulls/${prNumber}/reviews/${reviewId}`,
@@ -1018,9 +1072,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       );
     }),
 
-  listReviewCommentsForReview: (repoFullName, prNumber, reviewId, token) =>
+  listReviewCommentsForReview: (repoFullName, prNumber, reviewId, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const data = yield* githubFetch(
         `/repos/${owner}/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments`,
@@ -1037,9 +1091,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       }));
     }),
 
-  postReviewComment: (repoFullName, prNumber, c, token) =>
+  postReviewComment: (repoFullName, prNumber, c, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const payload: Record<string, unknown> = {
         body: c.body,
@@ -1066,9 +1120,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
-  replyToComment: (repoFullName, prNumber, commentId, body, token) =>
+  replyToComment: (repoFullName, prNumber, commentId, body, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const data = yield* githubPost(
         `/repos/${owner}/${repo}/pulls/${prNumber}/comments/${commentId}/replies`,
@@ -1084,9 +1138,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
-  listReviewComments: (repoFullName, prNumber, since, token) =>
+  listReviewComments: (repoFullName, prNumber, since, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const sinceQ = since ? `&since=${encodeURIComponent(since)}` : "";
       // Conditional (ETag) fetch: this is the per-PR REST call the 30s thread
@@ -1123,9 +1177,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       });
     }).pipe(retryTransient),
 
-  listReviewThreads: (repoFullName, prNumber, token) =>
+  listReviewThreads: (repoFullName, prNumber, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       // GraphQL paginates at 100 per page — most PRs fit, but we page just in case.
       const query = `
@@ -1185,9 +1239,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       return out;
     }).pipe(retryTransient),
 
-  resolveReviewThread: (threadNodeId, token) =>
+  resolveReviewThread: (threadNodeId, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       yield* githubGraphql(
         `mutation($id: ID!) { resolveReviewThread(input: { threadId: $id }) { clientMutationId } }`,
         { id: threadNodeId },
@@ -1196,9 +1250,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       );
     }),
 
-  unresolveReviewThread: (threadNodeId, token) =>
+  unresolveReviewThread: (threadNodeId, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       yield* githubGraphql(
         `mutation($id: ID!) { unresolveReviewThread(input: { threadId: $id }) { clientMutationId } }`,
         { id: threadNodeId },
@@ -1221,7 +1275,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
 
   getAuthenticatedUserFreshForHost: (token, host) =>
     Effect.gen(function* () {
-      const apiBase = resolveApiBaseForHost(host);
+      const apiBase = apiBaseForHost(host);
       const data = yield* githubFetch(`/user`, token, apiBase);
       const raw = data as Record<string, unknown>;
       return {
@@ -1231,9 +1285,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }).pipe(retryTransient),
 
-  convertPrToDraft: (repoFullName, prNumber, token) =>
+  convertPrToDraft: (repoFullName, prNumber, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const nodeId = yield* resolvePrNodeId(owner, repo, prNumber, token, apiBase);
       yield* githubGraphql(
@@ -1244,9 +1298,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       );
     }),
 
-  markPrReadyForReview: (repoFullName, prNumber, token) =>
+  markPrReadyForReview: (repoFullName, prNumber, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const nodeId = yield* resolvePrNodeId(owner, repo, prNumber, token, apiBase);
       yield* githubGraphql(
@@ -1257,9 +1311,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       );
     }),
 
-  closePullRequest: (repoFullName, prNumber, token) =>
+  closePullRequest: (repoFullName, prNumber, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       yield* githubPatch(
         `/repos/${owner}/${repo}/pulls/${prNumber}`,
@@ -1269,9 +1323,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       );
     }),
 
-  getMergeEligibility: (repoFullName, prNumber, token) =>
+  getMergeEligibility: (repoFullName, prNumber, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const query = `
         query($owner: String!, $repo: String!, $number: Int!) {
@@ -1317,9 +1371,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
-  mergePullRequest: (repoFullName, prNumber, mergeMethod, token) =>
+  mergePullRequest: (repoFullName, prNumber, mergeMethod, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       yield* githubPut(
         `/repos/${owner}/${repo}/pulls/${prNumber}/merge`,
@@ -1329,9 +1383,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       );
     }),
 
-  createPullRequest: (repoFullName, params, token) =>
+  createPullRequest: (repoFullName, params, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       const body: Record<string, unknown> = {
         title: params.title,
@@ -1354,9 +1408,9 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
       };
     }),
 
-  findPrByHead: (repoFullName, headBranch, token) =>
+  findPrByHead: (repoFullName, headBranch, token, explicitApiBase) =>
     Effect.gen(function* () {
-      const apiBase = yield* resolveApiBase;
+      const apiBase = explicitApiBase ?? (yield* resolveApiBase);
       const { owner, repo } = yield* parseRepoFullName(repoFullName);
       // GitHub expects head as `owner:branch` to disambiguate forks.
       const headQuery = encodeURIComponent(`${owner}:${headBranch}`);
@@ -1382,7 +1436,7 @@ const githubGatewayFlat: GitHubGatewayFlatService = {
   getCollaboratorPermission: (token, host, owner, repo, username) =>
     Effect.tryPromise({
       try: async () => {
-        const apiBase = resolveApiBaseForHost(host);
+        const apiBase = apiBaseForHost(host);
         const path = `/repos/${owner}/${repo}/collaborators/${username}/permission`;
         const res = await fetch(`${apiBase}${path}`, { headers: githubHeaders(token) });
         if (res.status === 404) return "none" as const;

--- a/apps/server/src/services/PollScheduler.ts
+++ b/apps/server/src/services/PollScheduler.ts
@@ -4,7 +4,15 @@ import { eq, inArray } from "drizzle-orm";
 import { Cause, Chunk, Context, Duration, Effect, Fiber, Layer, Ref, Schedule } from "effect";
 import { repositories } from "../db/schema";
 import { account, user } from "../db/schema/auth";
-import { GitHubAccessDeniedError, GitHubAuthError, GitHubRateLimitError } from "../domain/errors";
+import {
+  GitHubAccessDeniedError,
+  GitHubAuthError,
+  type GitHubError,
+  GitHubRateLimitError,
+  type NotFoundError,
+  type ValidationError,
+} from "../domain/errors";
+import { extractHostFromProviderId } from "../domain/provider-id";
 import { withDb as withDbHelper } from "../effects/with-db";
 import { debug, logError } from "../logger";
 import { Broadcaster } from "./Broadcaster";
@@ -12,7 +20,7 @@ import { DbService } from "./Db";
 import { DiffCacheService } from "./DiffCache";
 import { GitHubGateway } from "./GitHub";
 import { GitHubEtagCache } from "./GitHubEtagCache";
-import { githubFetch } from "./github-rest";
+import { apiBaseForHost, githubFetch } from "./github-rest";
 import { PullRequestService } from "./PullRequest";
 import { RemoteUserService } from "./RemoteUser";
 import { RepoCloneService } from "./RepoClone";
@@ -27,7 +35,24 @@ type PollSchedulerService = {
   readonly start: () => Effect.Effect<void>;
   readonly stop: () => Effect.Effect<void>;
   readonly restart: (intervalMinutes: number) => Effect.Effect<void>;
+  /**
+   * Full sync of every repo on every account. Coalesces onto an in-flight
+   * cycle rather than starting a second one.
+   */
   readonly syncNow: () => Effect.Effect<void>;
+  /**
+   * Re-read ONE pull request from GitHub and reconcile it.
+   *
+   * The targeted counterpart to {@link syncNow}: bounded to a couple of
+   * requests instead of a full pass over every repo, so it is what the UI's
+   * per-PR refresh should call. It also uses GitHub's PR *detail* endpoint,
+   * which — unlike the list endpoint the poll runs on — carries
+   * additions/deletions/changed_files, making this the path by which an open PR
+   * acquires real diff stats.
+   */
+  readonly refreshPr: (
+    prId: string,
+  ) => Effect.Effect<void, NotFoundError | ValidationError | GitHubAuthError | GitHubError>;
   readonly syncThreadsNow: (prId: string) => Effect.Effect<void>;
 };
 
@@ -36,18 +61,16 @@ export class PollScheduler extends Context.Tag("PollScheduler")<
   PollSchedulerService
 >() {}
 
-/** Derive the GitHub REST API base URL from a stored repo host string. */
-function hostToApiBase(host: string): string {
-  return host === "github.com" ? "https://api.github.com" : `https://api.${host}`;
-}
-
-/** Derive the GitHub host from a `github:{host}` (or legacy `github`) providerId. */
-function hostFromProviderId(providerId: string): string {
-  return providerId.split(":")[1] ?? "github.com";
-}
-
 const METADATA_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 const ARCHIVE_BACKFILL_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Per-cycle cap on how many just-closed PRs we individually re-fetch to learn
+ * whether they were merged or plain-closed. Applied per item, not to the batch:
+ * exceeding it degrades the tail of the list to `'closed'`, it does not
+ * abandon status resolution for the whole batch.
+ */
+const CLOSED_PR_STATUS_FETCH_LIMIT = 10;
 
 export const PollSchedulerLive = Layer.effect(
   PollScheduler,
@@ -112,6 +135,25 @@ export const PollSchedulerLive = Layer.effect(
     const suppressSummaryRef = yield* Ref.make(false);
     const broadcastGlobal = (msg: import("@revv/shared").ServerEventMessage) =>
       broadcaster.broadcastAll(msg).pipe(Effect.orElseSucceed(() => undefined));
+    const broadcastToAccount = (
+      accountId: string,
+      msg: import("@revv/shared").ServerEventMessage,
+    ) => broadcaster.broadcastToAccount(accountId, msg).pipe(Effect.orElseSucceed(() => undefined));
+
+    /**
+     * Fan a data-bearing sync envelope out to every account with repos, one
+     * scoped message each. `prs:sync-started` / `prs:sync-complete` carry an
+     * account's open-PR count, so per `docs/conventions.md` §3 they must not go
+     * out via `broadcastAll` — that leaks one account's numbers to another's
+     * clients.
+     */
+    const broadcastPerAccount = (
+      accountIds: readonly string[],
+      msg: (accountId: string) => import("@revv/shared").ServerEventMessage,
+    ): Effect.Effect<void> =>
+      Effect.forEach(accountIds, (id) => broadcastToAccount(id, msg(id)), {
+        discard: true,
+      });
 
     // Fiber ref for the running poll loop — null when stopped
     const fiberRef = yield* Ref.make<Fiber.RuntimeFiber<number, never> | null>(null);
@@ -134,11 +176,11 @@ export const PollSchedulerLive = Layer.effect(
             .all();
           const repoToAccountId = new Map(repoRowsForAccount.map((r) => [r.id, r.accountId]));
           const accountIdSet = Array.from(new Set(repoRowsForAccount.map((r) => r.accountId)));
-          yield* broadcastGlobal({ type: "prs:sync-started" });
+          yield* broadcastPerAccount(accountIdSet, () => ({ type: "prs:sync-started" }));
 
           if (allRepos.length === 0) {
             const etagStatsAfter = etagCache.stats();
-            yield* broadcastGlobal({
+            yield* broadcastPerAccount(accountIdSet, () => ({
               type: "prs:sync-complete",
               data: {
                 count: 0,
@@ -146,7 +188,7 @@ export const PollSchedulerLive = Layer.effect(
                 cached: etagStatsAfter.hits304 - etagStatsBefore.hits304,
                 refetched: etagStatsAfter.misses200 - etagStatsBefore.misses200,
               },
-            });
+            }));
             return;
           }
 
@@ -213,7 +255,7 @@ export const PollSchedulerLive = Layer.effect(
                 .broadcastToAccount(meta.id, {
                   type: "auth:reauth-required",
                   data: {
-                    host: hostFromProviderId(meta.providerId),
+                    host: extractHostFromProviderId(meta.providerId),
                     githubLogin: meta.githubLogin,
                   },
                 })
@@ -222,7 +264,7 @@ export const PollSchedulerLive = Layer.effect(
             accountRows.push({
               id: meta.id,
               userId: meta.userId,
-              host: hostFromProviderId(meta.providerId),
+              host: extractHostFromProviderId(meta.providerId),
               accessToken: token,
               githubLogin: meta.githubLogin,
               avatarUrl: meta.avatarUrl,
@@ -325,7 +367,7 @@ export const PollSchedulerLive = Layer.effect(
               const tokenStillValid = yield* githubFetch(
                 "/user",
                 acc.accessToken,
-                hostToApiBase(acc.host),
+                apiBaseForHost(acc.host),
               ).pipe(
                 Effect.as(true),
                 Effect.orElseSucceed(() => false),
@@ -384,8 +426,12 @@ export const PollSchedulerLive = Layer.effect(
               Effect.catchAll(() => Effect.succeed(null as A | null)),
             );
 
-          // Capture existing SHAs before sync for change detection
+          // Pre-sync snapshot, the baseline for every "did this change?"
+          // question below: which diffs to invalidate, which walkthroughs to
+          // supersede, which notifications to raise, and whether the cycle
+          // produced anything worth broadcasting at all.
           const existingPrs = yield* withDb(prService.listPrs());
+          const existingMap = new Map(existingPrs.map((pr) => [pr.id, pr]));
           const existingShaMap = new Map(
             existingPrs.map((pr) => [pr.id, { headSha: pr.headSha, baseSha: pr.baseSha }]),
           );
@@ -413,7 +459,7 @@ export const PollSchedulerLive = Layer.effect(
                     github.repos.getFresh(
                       repo.fullName,
                       live.token,
-                      hostToApiBase(repo.githubHost),
+                      apiBaseForHost(repo.githubHost),
                     ),
                   );
                   if (!fresh) return;
@@ -475,9 +521,14 @@ export const PollSchedulerLive = Layer.effect(
                 Effect.gen(function* () {
                   const live = liveAccount(acc);
                   if (!live) return;
+                  // ...ForHost, not the settings-derived variant: each account
+                  // carries its own `providerId` host, so resolving the API base
+                  // from the single global settings row would send a GitHub
+                  // Enterprise token to api.github.com as soon as two hosts are
+                  // connected on this machine.
                   const fresh = yield* tryGuarded(
                     live.acc,
-                    github.users.authenticatedFresh(live.token),
+                    github.users.authenticatedFreshForHost(live.token, live.acc.host),
                   );
                   if (!fresh) return;
 
@@ -577,7 +628,7 @@ export const PollSchedulerLive = Layer.effect(
                     repo.fullName,
                     repo.id,
                     live.token,
-                    hostToApiBase(repo.githubHost),
+                    apiBaseForHost(repo.githubHost),
                   ),
                   { errorLabel: `listPrs error for ${repo.fullName}` },
                 );
@@ -585,13 +636,22 @@ export const PollSchedulerLive = Layer.effect(
                 // listPrs failed — leave existing DB rows untouched for this repo
                 if (prs === null) return null;
 
-                // Upsert PR authors into remote_users so their avatars are cached.
+                // Upsert PR authors into remote_users so their avatars are
+                // cached. Deduped by login: a prolific author appears on many of
+                // a repo's open PRs, and each upsert is a SELECT + UPSERT on the
+                // poll's critical path.
+                const authorsByLogin = new Map<string, string | null>();
                 for (const pr of prs) {
+                  if (!authorsByLogin.has(pr.authorLogin)) {
+                    authorsByLogin.set(pr.authorLogin, pr.authorAvatarUrl);
+                  }
+                }
+                for (const [login, avatarUrl] of authorsByLogin) {
                   yield* remoteUserService.upsert({
                     provider: "github",
                     providerUserId: "", // Numeric ID not available from listPrs
-                    login: pr.authorLogin,
-                    avatarUrl: pr.authorAvatarUrl,
+                    login,
+                    avatarUrl,
                   });
                 }
 
@@ -645,36 +705,40 @@ export const PollSchedulerLive = Layer.effect(
             const updates: Array<{ id: string; status: "closed" | "merged"; closedAt: string }> =
               yield* Effect.forEach(
                 closedPrObjects,
-                (pr) =>
+                (pr, index) =>
                   Effect.gen(function* () {
-                    // Cap at 10 API fetches per cycle to avoid hammering GitHub
-                    if (closedPrIds.length > 10) {
-                      return {
-                        id: pr.id,
-                        status: "closed" as const,
-                        closedAt: new Date().toISOString(),
-                      };
-                    }
+                    // `'closed'` is the degraded answer: it records that the PR
+                    // left the open list without claiming to know whether it
+                    // merged. Nothing ever revisits it — the archive backfill
+                    // only fetches PRs missing from the mirror — so a wrong
+                    // answer here is permanent, and shows up later as a merged
+                    // PR labelled "closed" with +0/-0 stats in recaps.
+                    const degraded = {
+                      id: pr.id,
+                      status: "closed" as const,
+                      closedAt: new Date().toISOString(),
+                    };
+
+                    // Bound the GitHub cost per cycle. Applied to this item's
+                    // position, so a burst of closures degrades only its tail;
+                    // testing the batch size instead would degrade *every* PR
+                    // the moment the batch crossed the limit.
+                    if (index >= CLOSED_PR_STATUS_FETCH_LIMIT) return degraded;
+
                     const repo = repoMap.get(pr.repositoryId);
                     const live = repo ? liveAccountForRepo(repo.id) : null;
-                    if (!repo || !live) {
-                      return {
-                        id: pr.id,
-                        status: "closed" as const,
-                        closedAt: new Date().toISOString(),
-                      };
-                    }
+                    if (!repo || !live) return degraded;
+
                     const fetched = yield* tryGuarded(
                       live.acc,
-                      github.prs.get(repo.fullName, pr.externalId, live.token),
+                      github.prs.get(
+                        repo.fullName,
+                        pr.externalId,
+                        live.token,
+                        apiBaseForHost(repo.githubHost),
+                      ),
                     );
-                    if (!fetched) {
-                      return {
-                        id: pr.id,
-                        status: "closed" as const,
-                        closedAt: new Date().toISOString(),
-                      };
-                    }
+                    if (!fetched) return degraded;
                     const resolvedStatus = fetched.status === "merged" ? "merged" : "closed";
                     const closedAt = fetched.closedAt ?? new Date().toISOString();
                     return { id: pr.id, status: resolvedStatus as "closed" | "merged", closedAt };
@@ -737,6 +801,7 @@ export const PollSchedulerLive = Layer.effect(
           // GitHub. Per-repo fetch cap defends against bursty repos. Failures
           // are non-fatal — we degrade silently to whatever the local mirror
           // already has.
+          let archiveBackfillUpserted = 0;
           const shouldRunArchiveBackfill =
             Date.now() - lastArchiveBackfillAt >= ARCHIVE_BACKFILL_INTERVAL_MS;
           if (shouldRunArchiveBackfill) {
@@ -772,6 +837,7 @@ export const PollSchedulerLive = Layer.effect(
                   const live = liveAccountForRepo(repo.id);
                   if (!live) return;
 
+                  const repoApiBase = apiBaseForHost(repo.githubHost);
                   const searched = yield* tryGuarded(
                     live.acc,
                     github.prs.searchClosedInWindow(
@@ -779,6 +845,7 @@ export const PollSchedulerLive = Layer.effect(
                       backfillSinceIso,
                       backfillUntilIso,
                       live.token,
+                      repoApiBase,
                     ),
                     { errorLabel: `archive backfill search failed for ${repo.fullName}` },
                   );
@@ -793,7 +860,10 @@ export const PollSchedulerLive = Layer.effect(
                   const fetched = yield* Effect.forEach(
                     missing,
                     (m) =>
-                      tryGuarded(live.acc, github.prs.get(repo.fullName, m.number, live.token)),
+                      tryGuarded(
+                        live.acc,
+                        github.prs.get(repo.fullName, m.number, live.token, repoApiBase),
+                      ),
                     { concurrency: 3 },
                   );
 
@@ -811,6 +881,11 @@ export const PollSchedulerLive = Layer.effect(
                   if (upsertable.length === 0) return;
 
                   yield* withDb(prService.upsertPrs(upsertable)).pipe(
+                    Effect.tap(() =>
+                      Effect.sync(() => {
+                        archiveBackfillUpserted += upsertable.length;
+                      }),
+                    ),
                     Effect.tapError((err) =>
                       Effect.sync(() => {
                         logError(
@@ -890,7 +965,12 @@ export const PollSchedulerLive = Layer.effect(
 
                     const fileList = yield* tryGuarded(
                       live.acc,
-                      github.prs.files(repo.fullName, pr.externalId, live.token),
+                      github.prs.files(
+                        repo.fullName,
+                        pr.externalId,
+                        live.token,
+                        apiBaseForHost(repo.githubHost),
+                      ),
                     );
                     if (!fileList) return;
 
@@ -904,6 +984,9 @@ export const PollSchedulerLive = Layer.effect(
                       fetchedAt: new Date().toISOString(),
                     }));
 
+                    // `cacheFiles` also records the PR's real diff size from
+                    // this list — the only place an open PR gets one, since the
+                    // list endpoint above doesn't report it.
                     yield* withDb(diffCache.cacheFiles(prId, files)).pipe(
                       Effect.orElseSucceed(() => undefined),
                     );
@@ -913,20 +996,52 @@ export const PollSchedulerLive = Layer.effect(
             }
           }
 
-          // Broadcast the canonical open-PR DB state per account. This includes
-          // repos whose GitHub fetch failed this cycle, so clients can safely
-          // treat `prs:updated` as full-state instead of a merge patch.
-          for (const accountId of accountIdSet) {
-            const accountPrs = yield* withDb(prService.listPrs(accountId));
-            yield* broadcaster.broadcastToAccount(accountId, {
-              type: "prs:updated",
-              data: accountPrs,
-            });
+          // ── Broadcast the canonical open-PR DB state per account ─────────────
+          //
+          // `prs:updated` is full-state, not a patch — it includes repos whose
+          // GitHub fetch failed this cycle, so a client can always treat it as
+          // the whole truth. That also makes it expensive: the entire PR list
+          // per account, and a whole-array swap in `replacePullRequests` that
+          // re-derives every sidebar filter and sort.
+          //
+          // So only send it when this cycle actually moved something. A client
+          // that misses one still reconciles: `reconcileOnReconnect` refetches
+          // via REST on every SSE (re)connect.
+          //
+          // `updatedAt` is the cheap catch-all — GitHub bumps it for pushes,
+          // edits, label and reviewer changes — with the fields the UI keys on
+          // checked explicitly alongside it.
+          const prSetChanged = allPrs.some((pr) => {
+            const existing = existingMap.get(pr.id);
+            if (!existing) return true; // PR we had never seen
+            return (
+              existing.updatedAt !== pr.updatedAt ||
+              existing.headSha !== pr.headSha ||
+              existing.baseSha !== pr.baseSha ||
+              existing.title !== pr.title ||
+              existing.isDraft !== pr.isDraft
+            );
+          });
+          const stateChanged =
+            prSetChanged || closedPrIds.length > 0 || archiveBackfillUpserted > 0 || anyRepoChanged;
+          // A manual sync always answers, even with nothing to say: the user
+          // pressed a button and the client is holding a spinner. Same for the
+          // first cycle after boot, which is a client's initial hydration.
+          const forceBroadcast =
+            (yield* Ref.get(suppressSummaryRef)) || !(yield* Ref.get(hasPeriodicSyncedOnceRef));
+
+          if (stateChanged || forceBroadcast) {
+            for (const accountId of accountIdSet) {
+              const accountPrs = yield* withDb(prService.listPrs(accountId));
+              yield* broadcastToAccount(accountId, {
+                type: "prs:updated",
+                data: accountPrs,
+              });
+            }
           }
 
           // ── Sync diff: compute what changed for notifications ────────────────
           const changes: SyncChange[] = [];
-          const existingMap = new Map(existingPrs.map((pr) => [pr.id, pr]));
 
           if (existingPrs.length > 0) {
             for (const pr of allPrs) {
@@ -1070,16 +1185,33 @@ export const PollSchedulerLive = Layer.effect(
           yield* Ref.set(hasPeriodicSyncedOnceRef, true);
           yield* Ref.set(suppressSummaryRef, false);
 
+          // Per-account, and with that account's own PR count: this envelope
+          // carries data, so `broadcastAll` would hand account A's totals to
+          // account B's clients.
+          //
+          // `cached` / `refetched` are process-wide conditional-request counters
+          // sampled around this cycle, so they also include anything the thread
+          // sweep did in the same window. They are a cache-efficiency readout,
+          // not a per-cycle audit — don't derive request counts from them.
           const etagStatsAfter = etagCache.stats();
-          yield* broadcastGlobal({
+          const syncCompletedAt = new Date().toISOString();
+          const cached = etagStatsAfter.hits304 - etagStatsBefore.hits304;
+          const refetched = etagStatsAfter.misses200 - etagStatsBefore.misses200;
+          const openPrCountByAccount = new Map<string, number>();
+          for (const pr of allPrs) {
+            const accountId = repoToAccountId.get(pr.repositoryId);
+            if (!accountId) continue;
+            openPrCountByAccount.set(accountId, (openPrCountByAccount.get(accountId) ?? 0) + 1);
+          }
+          yield* broadcastPerAccount(accountIdSet, (accountId) => ({
             type: "prs:sync-complete",
             data: {
-              count: allPrs.length,
-              timestamp: new Date().toISOString(),
-              cached: etagStatsAfter.hits304 - etagStatsBefore.hits304,
-              refetched: etagStatsAfter.misses200 - etagStatsBefore.misses200,
+              count: openPrCountByAccount.get(accountId) ?? 0,
+              timestamp: syncCompletedAt,
+              cached,
+              refetched,
             },
-          });
+          }));
         }),
       ).pipe(
         Effect.tapErrorCause((cause) =>
@@ -1095,6 +1227,93 @@ export const PollSchedulerLive = Layer.effect(
         ),
       );
 
+    // One sync cycle at a time, process-wide.
+    //
+    // `syncNow` used to run `syncAllRepos` inline with no coordination, so a
+    // manual refresh landing mid-cycle started a second full pass concurrently:
+    // double the GitHub cost, both cycles racing the single `suppressSummaryRef`
+    // boolean and the `lastMetadataRefreshAt` / `lastArchiveBackfillAt` closure
+    // vars, and the first one to finish clearing the client's spinner while the
+    // other was still running.
+    //
+    // Concurrent callers coalesce onto the in-flight cycle rather than queue
+    // behind it — queueing would just run the duplicate pass a moment later,
+    // and the in-flight cycle already broadcasts `prs:sync-complete`, so a
+    // waiting client sees its refresh finish either way.
+    const syncInFlightRef = yield* Ref.make(false);
+
+    const runSyncOnce = (opts: {
+      readonly suppressSummary: boolean;
+    }): Effect.Effect<void, never, DbService | GitHubEtagCache | SettingsService> =>
+      Effect.gen(function* () {
+        const acquired = yield* Ref.modify(syncInFlightRef, (busy) =>
+          busy ? ([false, true] as const) : ([true, true] as const),
+        );
+        if (!acquired) {
+          debug("PollScheduler", "sync already in flight — coalescing this request");
+          return;
+        }
+        if (opts.suppressSummary) yield* Ref.set(suppressSummaryRef, true);
+        yield* syncAllRepos.pipe(Effect.ensuring(Ref.set(syncInFlightRef, false)));
+      });
+
+    /**
+     * Reconcile a single PR against GitHub's PR *detail* endpoint.
+     *
+     * Repeats the poll's follow-through on a head-SHA move — invalidate the
+     * cached diff, supersede walkthroughs pinned to the old SHA — because
+     * without it a refresh would leave the UI showing a new head SHA against
+     * the previous commit's diff.
+     */
+    const refreshPr = (
+      prId: string,
+    ): Effect.Effect<
+      void,
+      NotFoundError | ValidationError | GitHubAuthError | GitHubError,
+      DbService | GitHubEtagCache | SettingsService
+    > =>
+      Effect.gen(function* () {
+        const existing = yield* withDb(prService.getPr(prId));
+        const repo = yield* withDb(repoService.getRepoById(existing.repositoryId));
+        const accountId = yield* withDb(repoService.getAccountIdForRepo(repo.id));
+        const token = yield* tokenProvider.getTokenByAccountId(accountId);
+
+        const fresh = yield* github.prs.get(
+          repo.fullName,
+          existing.externalId,
+          token,
+          apiBaseForHost(repo.githubHost),
+        );
+        // `getPr` derives id/repositoryId from `owner/repo` because it has no
+        // idea what our local row is called. Repoint before writing.
+        const row = { ...fresh, id: existing.id, repositoryId: existing.repositoryId };
+        yield* withDb(prService.upsertPrs([row]));
+
+        if (row.headSha !== existing.headSha) {
+          yield* withDb(diffCache.invalidateFiles(prId)).pipe(
+            Effect.orElseSucceed(() => undefined),
+          );
+          yield* walkthroughJobs
+            .supersedeForPr(prId, row.headSha ?? undefined)
+            .pipe(Effect.catchAll(() => Effect.void));
+        }
+
+        if (row.status !== "open") {
+          yield* broadcastToAccount(accountId, {
+            type: "pr:archived",
+            data: {
+              prId: row.id,
+              repoId: row.repositoryId,
+              status: row.status === "merged" ? "merged" : "closed",
+              closedAt: row.closedAt ?? new Date().toISOString(),
+            },
+          });
+        }
+
+        const accountPrs = yield* withDb(prService.listPrs(accountId));
+        yield* broadcastToAccount(accountId, { type: "prs:updated", data: accountPrs });
+      });
+
     const stopFiber: Effect.Effect<void> = Effect.gen(function* () {
       const fiber = yield* Ref.get(fiberRef);
       if (fiber !== null) {
@@ -1104,25 +1323,73 @@ export const PollSchedulerLive = Layer.effect(
     });
 
     // ── Thread sync loop ──────────────────────────────────────────────────
-    // Separate fiber that periodically reconciles threads for all open PRs.
+    // Separate fiber that periodically reconciles threads for open PRs.
     // Opening a PR triggers an immediate targeted sync, so this background
     // sweep stays intentionally slow to avoid GitHub rate-limit bursts.
     const threadFiberRef = yield* Ref.make<Fiber.RuntimeFiber<number, never> | null>(null);
+
+    // `pr.updatedAt` as of the last sweep that reconciled this PR. Purely a
+    // cost optimisation and fully reconstructible — losing it on restart just
+    // means one extra sweep per PR.
+    const lastThreadSweepUpdatedAt = new Map<string, string>();
 
     const syncThreadsForOpenPrs: Effect.Effect<void> = Effect.gen(function* () {
       const prs = yield* withDb(prService.listPrs()).pipe(
         Effect.orElseSucceed(() => [] as PullRequest[]),
       );
       const openPrs = prs.filter((p) => p.status === "open");
-      // Sequential is fine: each PR-sync is lightweight (REST + a small
-      // GraphQL call). Running them concurrently would spike rate-limit risk.
+
+      // Narrow to the PRs that can actually have moved.
+      //
+      // GitHub bumps `updated_at` when a review comment is added, edited, or
+      // deleted, so an unchanged `updated_at` means no comment activity. The one
+      // thing it does NOT cover is a resolve/unresolve, which changes thread
+      // state without touching the PR — so any PR that still has an unresolved
+      // local thread is always swept.
+      //
+      // This matters because the reconcile needs a GraphQL call, and GraphQL has
+      // no conditional-request equivalent: unlike the REST half of the sweep,
+      // where a 304 is free, every one of those is billed. Sweeping every open
+      // PR every tick made the GraphQL fan-out scale with the size of the PR
+      // list rather than with the set of PRs anyone is actually reviewing.
+      const candidates: PullRequest[] = [];
+      for (const pr of openPrs) {
+        const lastSeen = lastThreadSweepUpdatedAt.get(pr.id);
+        if (lastSeen === undefined || lastSeen !== pr.updatedAt) {
+          candidates.push(pr);
+          continue;
+        }
+        const summary = yield* withDb(syncService.getThreadSummary(pr.id, null)).pipe(
+          Effect.orElseSucceed(() => null),
+        );
+        if (summary === null || summary.total > summary.resolved) candidates.push(pr);
+      }
+
+      const skipped = openPrs.length - candidates.length;
+      if (skipped > 0) {
+        debug(
+          "PollScheduler",
+          `thread sweep: ${candidates.length}/${openPrs.length} PRs need a reconcile (${skipped} unchanged and fully resolved)`,
+        );
+      }
+
+      // Sequential on purpose: each PR-sync is lightweight (REST + a small
+      // GraphQL call), and running them concurrently is what trips GitHub's
+      // secondary (abuse) rate limit.
       yield* Effect.forEach(
-        openPrs,
+        candidates,
         (pr) =>
           provideInfra(syncService.syncThreads(pr.id)).pipe(
+            Effect.tap(() =>
+              Effect.sync(() => {
+                lastThreadSweepUpdatedAt.set(pr.id, pr.updatedAt);
+              }),
+            ),
             Effect.asVoid,
             Effect.catchAllCause((cause) =>
               Effect.sync(() => {
+                // Leave the watermark alone on failure so the next sweep retries
+                // this PR instead of assuming it is up to date.
                 logError(
                   "PollScheduler",
                   `Thread sync failed for PR ${pr.id}:`,
@@ -1133,6 +1400,15 @@ export const PollSchedulerLive = Layer.effect(
           ),
         { concurrency: 1 },
       );
+
+      // Drop watermarks for PRs that are no longer open so the map can't grow
+      // without bound across a long-running process.
+      if (lastThreadSweepUpdatedAt.size > openPrs.length) {
+        const openIds = new Set(openPrs.map((p) => p.id));
+        for (const id of lastThreadSweepUpdatedAt.keys()) {
+          if (!openIds.has(id)) lastThreadSweepUpdatedAt.delete(id);
+        }
+      }
     }).pipe(
       Effect.catchAllCause((cause) =>
         broadcastGlobal({
@@ -1175,7 +1451,7 @@ export const PollSchedulerLive = Layer.effect(
         // Run immediately on start, then repeat at the given interval
         const schedule = Schedule.spaced(Duration.minutes(intervalMinutes));
         const fiber: Fiber.RuntimeFiber<number, never> = yield* Effect.fork(
-          provideInfra(syncAllRepos.pipe(Effect.repeat(schedule))),
+          provideInfra(runSyncOnce({ suppressSummary: false }).pipe(Effect.repeat(schedule))),
         );
         yield* Ref.set(fiberRef, fiber);
       });
@@ -1206,16 +1482,15 @@ export const PollSchedulerLive = Layer.effect(
           yield* startWithInterval(minutes);
         }),
 
-      syncNow: () =>
-        provideInfra(
-          Effect.gen(function* () {
-            yield* Ref.set(suppressSummaryRef, true);
-            yield* syncAllRepos;
-          }),
-        ),
+      syncNow: () => provideInfra(runSyncOnce({ suppressSummary: true })),
 
+      refreshPr: (prId) => provideInfra(refreshPr(prId)),
+
+      // `force: true` — a user-initiated sync must emit `threads:synced` even
+      // when nothing changed, because that envelope is what clears the client's
+      // per-PR spinner. Only the background sweep stays quiet on no-ops.
       syncThreadsNow: (prId: string) =>
-        provideInfra(syncService.syncThreads(prId)).pipe(
+        provideInfra(syncService.syncThreads(prId, { force: true })).pipe(
           Effect.asVoid,
           Effect.catchIf(
             (e) => (e as { _tag?: string })._tag === "NotFoundError",

--- a/apps/server/src/services/PrContext.ts
+++ b/apps/server/src/services/PrContext.ts
@@ -8,19 +8,27 @@ import { DbService } from "./Db";
 import { type CachedDiffFile, DiffCacheService, hasCompleteCachedFiles } from "./DiffCache";
 import { GitHubGateway, type PrCommit, type PrFileMeta, type PrMeta } from "./GitHub";
 import type { GitHubEtagCache } from "./GitHubEtagCache";
+import { apiBaseForHost } from "./github-rest";
 import { PullRequestService } from "./PullRequest";
 import { RepositoryService } from "./Repository";
 import type { SettingsService } from "./Settings";
 import { TokenProvider } from "./TokenProvider";
 
 /**
- * Minimal PR context — the DB-backed trio that almost every PR-scoped feature
- * needs to talk to GitHub.
+ * Minimal PR context — the DB-backed values that almost every PR-scoped
+ * feature needs to talk to GitHub.
+ *
+ * `apiBase` is derived from `repo.githubHost`, not from global settings. Pass
+ * it to every `GitHubGateway` call made with this context: the settings row
+ * holds a single host, so a github.com repo and a GitHub Enterprise repo on the
+ * same machine would otherwise both be addressed at whichever host happens to
+ * be configured, sending each token to the wrong API.
  */
 export interface PrContextBasic {
   readonly pr: PullRequest;
   readonly repo: Repository;
   readonly token: string;
+  readonly apiBase: string;
 }
 
 /**
@@ -77,6 +85,7 @@ export class PrContextService extends Context.Tag("PrContextService")<
       repoFullName: string,
       externalId: number,
       token: string,
+      apiBase?: string,
     ) => Effect.Effect<PrMeta, GitHubError, DbService | GitHubEtagCache | SettingsService>;
     /**
      * Raw changed-file list for an arbitrary PR. Thin forward to the GitHub
@@ -87,6 +96,7 @@ export class PrContextService extends Context.Tag("PrContextService")<
       repoFullName: string,
       externalId: number,
       token: string,
+      apiBase?: string,
     ) => Effect.Effect<PrFileMeta[], GitHubError, DbService | GitHubEtagCache | SettingsService>;
     /**
      * Full PR fetch by number. Thin forward to the GitHub gateway. Used by
@@ -97,6 +107,7 @@ export class PrContextService extends Context.Tag("PrContextService")<
       repoFullName: string,
       externalId: number,
       token: string,
+      apiBase?: string,
     ) => Effect.Effect<PullRequest, GitHubError, DbService | GitHubEtagCache | SettingsService>;
     /**
      * Search for PRs closed (or merged) in a time window. Thin forward to the
@@ -108,6 +119,7 @@ export class PrContextService extends Context.Tag("PrContextService")<
       sinceIso: string,
       untilIso: string,
       token: string,
+      apiBase?: string,
     ) => Effect.Effect<
       ReadonlyArray<{
         readonly number: number;
@@ -170,7 +182,12 @@ export const PrContextServiceLive = Layer.effect(
                 ),
               ),
             );
-        return { pr, repo, token } satisfies PrContextBasic;
+        return {
+          pr,
+          repo,
+          token,
+          apiBase: apiBaseForHost(repo.githubHost),
+        } satisfies PrContextBasic;
       });
 
     // Cache-or-fetch diff files. Inlined from DiffCache.getOrFetchDiffFiles so
@@ -183,12 +200,16 @@ export const PrContextServiceLive = Layer.effect(
       prExternalId: number,
       token: string,
       expectedChangedFiles: number,
+      apiBase: string,
     ) =>
       Effect.gen(function* () {
         const { db } = yield* DbService;
         const cached = yield* withDb(db, diffCache.getCachedFiles(prId));
-        if (cached !== null && hasCompleteCachedFiles(cached, expectedChangedFiles)) return cached;
-        const fileList = yield* github.prs.files(repoFullName, prExternalId, token);
+        if (cached !== null) {
+          const cachedCount = yield* withDb(db, diffCache.getCachedFileCount(prId));
+          if (hasCompleteCachedFiles(cached, expectedChangedFiles, cachedCount)) return cached;
+        }
+        const fileList = yield* github.prs.files(repoFullName, prExternalId, token, apiBase);
         const fresh: CachedDiffFile[] = fileList.map((f) => ({
           path: f.filename,
           oldPath: f.previousFilename,
@@ -205,13 +226,19 @@ export const PrContextServiceLive = Layer.effect(
     const resolveWithDiff = (prId: string, userId: string) =>
       Effect.gen(function* () {
         const basic = yield* resolveBasic(prId, userId);
-        const meta = yield* github.prs.meta(basic.repo.fullName, basic.pr.externalId, basic.token);
+        const meta = yield* github.prs.meta(
+          basic.repo.fullName,
+          basic.pr.externalId,
+          basic.token,
+          basic.apiBase,
+        );
         const cachedFiles = yield* cacheOrFetchFiles(
           basic.pr.id,
           basic.repo.fullName,
           basic.pr.externalId,
           basic.token,
           basic.pr.changedFiles,
+          basic.apiBase,
         );
         const files = cachedFiles.map((f) => ({
           filename: f.path,
@@ -231,6 +258,7 @@ export const PrContextServiceLive = Layer.effect(
           basic.repo.fullName,
           basic.pr.externalId,
           basic.token,
+          basic.apiBase,
         );
         return { ...basic, meta, files, commits } satisfies PrContextWithDiff;
       });
@@ -240,18 +268,19 @@ export const PrContextServiceLive = Layer.effect(
     // requirement channel; the deps are discharged by the caller, not here.
     // They exist so feature modules reach GitHub through PrContext only
     // (enforced by scripts/check-import-boundaries.ts).
-    const prMeta = (repoFullName: string, externalId: number, token: string) =>
-      github.prs.meta(repoFullName, externalId, token);
-    const prFiles = (repoFullName: string, externalId: number, token: string) =>
-      github.prs.files(repoFullName, externalId, token);
-    const fetchPr = (repoFullName: string, externalId: number, token: string) =>
-      github.prs.get(repoFullName, externalId, token);
+    const prMeta = (repoFullName: string, externalId: number, token: string, apiBase?: string) =>
+      github.prs.meta(repoFullName, externalId, token, apiBase);
+    const prFiles = (repoFullName: string, externalId: number, token: string, apiBase?: string) =>
+      github.prs.files(repoFullName, externalId, token, apiBase);
+    const fetchPr = (repoFullName: string, externalId: number, token: string, apiBase?: string) =>
+      github.prs.get(repoFullName, externalId, token, apiBase);
     const searchClosedPrs = (
       repoFullName: string,
       sinceIso: string,
       untilIso: string,
       token: string,
-    ) => github.prs.searchClosedInWindow(repoFullName, sinceIso, untilIso, token);
+      apiBase?: string,
+    ) => github.prs.searchClosedInWindow(repoFullName, sinceIso, untilIso, token, apiBase);
 
     const resolveRepoToken = (repoId: string) =>
       Effect.gen(function* () {

--- a/apps/server/src/services/PullRequest.test.ts
+++ b/apps/server/src/services/PullRequest.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "bun:test";
+import type { PullRequest } from "@revv/shared";
+import { eq } from "drizzle-orm";
 import { Effect, Layer } from "effect";
 import { createDb, type Db } from "../db/index";
 import { account, pullRequests, repositories, user } from "../db/schema";
 import { DbService } from "./Db";
+import { DiffCacheService, DiffCacheServiceLive } from "./DiffCache";
 import {
   type ListArchivedPrsParams,
   PullRequestService,
@@ -149,5 +152,158 @@ describe("listArchivedPrs author filter", () => {
     seed(db);
     const { prs } = await listArchived(db, { authorLogins: [] });
     expect(prs.map((p) => p.id)).toEqual(["pr-merged-bob", "pr-closed-alice", "pr-closed-carol"]);
+  });
+});
+
+// ── upsertPrs: what the poll is allowed to overwrite ────────────────────────
+//
+// The poll's only source for open PRs is GitHub's list-PRs endpoint, which
+// returns the "simple" PR object: no additions, deletions, or changed_files,
+// and therefore zeroes after mapping. These tests pin the two columns whose
+// prior values must survive that.
+
+/** A PR as it arrives from the *list* endpoint: real metadata, zeroed stats. */
+function listSourcedPr(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    id: "pr-open-alice",
+    externalId: 1,
+    repositoryId: REPO_ID,
+    title: "updated title",
+    body: null,
+    authorLogin: "alice",
+    authorAvatarContent: null,
+    authorAvatarUrl: null,
+    requestedReviewers: [],
+    status: "open",
+    reviewStatus: "pending",
+    isDraft: false,
+    sourceBranch: "feature",
+    targetBranch: "main",
+    url: "https://example.com",
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    headSha: "sha-new",
+    baseSha: "base-new",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-02-01T00:00:00Z",
+    fetchedAt: "2026-02-01T00:00:00Z",
+    closedAt: null,
+    ...overrides,
+  };
+}
+
+function runSvc<A, E>(
+  db: Db,
+  f: (svc: typeof PullRequestService.Service) => Effect.Effect<A, E, DbService>,
+) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const svc = yield* PullRequestService;
+      return yield* f(svc).pipe(Effect.orDie);
+    }).pipe(
+      Effect.provide(PullRequestServiceLive),
+      Effect.provide(Layer.succeed(DbService, { db })),
+    ),
+  );
+}
+
+function readRow(db: Db, id: string) {
+  const row = db.select().from(pullRequests).where(eq(pullRequests.id, id)).get();
+  if (!row) throw new Error(`missing row ${id}`);
+  return row;
+}
+
+/**
+ * Seed real diff stats the way production does — by caching a changed-file
+ * list, which records the PR's size in the same transaction.
+ */
+function seedDiffStats(
+  db: Db,
+  prId: string,
+  files: ReadonlyArray<{ path: string; additions: number; deletions: number }>,
+): Promise<void> {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const svc = yield* DiffCacheService;
+      yield* svc.cacheFiles(
+        prId,
+        files.map((f) => ({
+          path: f.path,
+          oldPath: null,
+          status: "modified",
+          additions: f.additions,
+          deletions: f.deletions,
+          patch: null,
+          fetchedAt: "2026-02-01T00:00:00Z",
+        })),
+      );
+    }).pipe(Effect.provide(DiffCacheServiceLive), Effect.provide(Layer.succeed(DbService, { db }))),
+  );
+}
+
+describe("upsertPrs diff stats", () => {
+  it("keeps existing stats when the incoming row reports changedFiles = 0", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    await seedDiffStats(db, "pr-open-alice", [
+      { path: "a.ts", additions: 10, deletions: 3 },
+      { path: "b.ts", additions: 5, deletions: 0 },
+    ]);
+    expect(readRow(db, "pr-open-alice").changedFiles).toBe(2);
+
+    await runSvc(db, (svc) => svc.upsertPrs([listSourcedPr()]));
+
+    const row = readRow(db, "pr-open-alice");
+    expect(row.additions).toBe(15);
+    expect(row.deletions).toBe(3);
+    expect(row.changedFiles).toBe(2);
+    // Everything else on the row still tracks GitHub.
+    expect(row.title).toBe("updated title");
+    expect(row.headSha).toBe("sha-new");
+  });
+
+  it("takes incoming stats when the source actually carried them", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    await runSvc(db, (svc) =>
+      svc.upsertPrs([listSourcedPr({ additions: 42, deletions: 7, changedFiles: 4 })]),
+    );
+    const row = readRow(db, "pr-open-alice");
+    expect(row.additions).toBe(42);
+    expect(row.deletions).toBe(7);
+    expect(row.changedFiles).toBe(4);
+  });
+
+  it("allows a genuinely empty diff to be recorded on first insert", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    await runSvc(db, (svc) =>
+      svc.upsertPrs([listSourcedPr({ id: "pr-brand-new", externalId: 99 })]),
+    );
+    expect(readRow(db, "pr-brand-new").changedFiles).toBe(0);
+  });
+});
+
+describe("upsertPrs mentioned users", () => {
+  it("preserves comment-sourced mentions across a poll cycle", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    // The comment sync harvests a mention that appears nowhere in the PR body.
+    await runSvc(db, (svc) => svc.appendMentionedUsers("pr-open-alice", ["dave"]));
+    expect(JSON.parse(readRow(db, "pr-open-alice").mentionedUsers ?? "[]")).toEqual(["dave"]);
+
+    await runSvc(db, (svc) => svc.upsertPrs([listSourcedPr({ body: "cc @erin" })]));
+
+    const mentioned = JSON.parse(readRow(db, "pr-open-alice").mentionedUsers ?? "[]") as string[];
+    expect(mentioned.sort()).toEqual(["dave", "erin"]);
+  });
+
+  it("does not duplicate a login already present", async () => {
+    const db = createDb(":memory:");
+    seed(db);
+    await runSvc(db, (svc) => svc.upsertPrs([listSourcedPr({ body: "cc @erin" })]));
+    await runSvc(db, (svc) => svc.upsertPrs([listSourcedPr({ body: "cc @erin again" })]));
+    expect(JSON.parse(readRow(db, "pr-open-alice").mentionedUsers ?? "[]")).toEqual(["erin"]);
   });
 });

--- a/apps/server/src/services/PullRequest.ts
+++ b/apps/server/src/services/PullRequest.ts
@@ -89,6 +89,35 @@ export interface ArchivedPrWithWalkthrough {
   readonly walkthrough: ArchivedPrWalkthroughSummary | null;
 }
 
+/**
+ * Merge GitHub logins into a PR's `mentioned_users` JSON array, in place.
+ *
+ * Shared by `upsertPrs` (body mentions) and `appendMentionedUsers` (mentions
+ * harvested from review comments) because both write the same column and
+ * neither owns it: the column is the union of everywhere a login was mentioned,
+ * so the only safe write is a merge.
+ */
+function mergeMentionedUsers(
+  db: (typeof DbService)["Service"]["db"],
+  prId: string,
+  logins: readonly string[],
+): void {
+  if (logins.length === 0) return;
+  const row = db
+    .select({ mentionedUsers: pullRequests.mentionedUsers })
+    .from(pullRequests)
+    .where(eq(pullRequests.id, prId))
+    .get();
+  if (!row) return;
+  const existing = JSON.parse(row.mentionedUsers ?? "[]") as string[];
+  const merged = [...new Set([...existing, ...logins])];
+  if (merged.length === existing.length) return;
+  db.update(pullRequests)
+    .set({ mentionedUsers: JSON.stringify(merged) })
+    .where(eq(pullRequests.id, prId))
+    .run();
+}
+
 /** Default page size for `listArchivedPrs` when caller doesn't specify. */
 export const DEFAULT_ARCHIVE_PAGE_LIMIT = 50;
 /** Upper bound on `listArchivedPrs` page size — defends against pathologically large pulls. */
@@ -105,6 +134,19 @@ export class PullRequestService extends Context.Tag("PullRequestService")<
       id: string,
       accountId?: string,
     ) => Effect.Effect<PullRequest, NotFoundError, DbService>;
+    /**
+     * Upsert PR rows from GitHub.
+     *
+     * Two columns are deliberately not assigned from the incoming row:
+     *   - `mentioned_users` is merged, never replaced (see
+     *     {@link mergeMentionedUsers}).
+     *   - `additions` / `deletions` / `changed_files` are only taken when the
+     *     source actually carried them. GitHub's list-PRs endpoint returns the
+     *     "simple" PR object without those fields, so a poll-sourced row has
+     *     zeroes that must not overwrite real numbers from a detail fetch.
+     *     Real stats arrive via `DiffCacheService.cacheFiles`, which derives
+     *     them from the changed-file list alongside the cached diff.
+     */
     readonly upsertPrs: (prs: PullRequest[]) => Effect.Effect<void, ValidationError, DbService>;
     readonly deletePrs: (ids: string[]) => Effect.Effect<void, ValidationError, DbService>;
     /**
@@ -301,11 +343,14 @@ export const PullRequestServiceLive = Layer.succeed(PullRequestService, {
     Effect.gen(function* () {
       const { db } = yield* DbService;
       if (prs.length === 0) return;
+      const bodyMentionsByPrId = new Map<string, string[]>();
       yield* Effect.tryPromise({
         try: () => {
           const values = prs.map((pr) => {
-            // Extract @-mentions from the PR body.
+            // Extract @-mentions from the PR body. Used verbatim for a fresh
+            // insert; merged (not assigned) into an existing row afterwards.
             const bodyMentions = pr.body ? extractGitHubMentions(pr.body) : [];
+            if (bodyMentions.length > 0) bodyMentionsByPrId.set(pr.id, bodyMentions);
             const base: typeof pullRequests.$inferInsert = {
               id: pr.id,
               externalId: pr.externalId,
@@ -356,20 +401,48 @@ export const PullRequestServiceLive = Layer.succeed(PullRequestService, {
                   body: sql`excluded.body`,
                   status: sql`excluded.status`,
                   isDraft: sql`excluded.is_draft`,
-                  additions: sql`excluded.additions`,
-                  deletions: sql`excluded.deletions`,
-                  changedFiles: sql`excluded.changed_files`,
+                  // Diff stats are conditional. GitHub's list-PRs endpoint —
+                  // the poll's source for every open PR — returns the "simple"
+                  // PR object, which has no additions/deletions/changed_files,
+                  // so those arrive as 0. Assigning them unconditionally
+                  // overwrote the real numbers a detail fetch had recorded, and
+                  // left every open PR at changed_files = 0 forever, which
+                  // silently disabled the diff-cache completeness guard.
+                  //
+                  // `changed_files` is the discriminator: any PR with commits
+                  // has at least one changed file, whereas additions or
+                  // deletions can legitimately be 0 (pure rename, mode change).
+                  // `pull_requests.<col>` is SQLite's way of naming the original
+                  // row inside DO UPDATE, i.e. "keep what we already had".
+                  additions: sql`CASE WHEN excluded.changed_files > 0 THEN excluded.additions ELSE pull_requests.additions END`,
+                  deletions: sql`CASE WHEN excluded.changed_files > 0 THEN excluded.deletions ELSE pull_requests.deletions END`,
+                  changedFiles: sql`CASE WHEN excluded.changed_files > 0 THEN excluded.changed_files ELSE pull_requests.changed_files END`,
                   headSha: sql`excluded.head_sha`,
                   baseSha: sql`excluded.base_sha`,
                   updatedAt: sql`excluded.updated_at`,
                   fetchedAt: sql`excluded.fetched_at`,
                   requestedReviewers: sql`excluded.requested_reviewers`,
                   closedAt: sql`excluded.closed_at`,
-                  mentionedUsers: sql`excluded.mentioned_users`,
+                  // `mentioned_users` is deliberately absent: it is the union of
+                  // body mentions AND mentions found in review comments (see
+                  // `appendMentionedUsers`). Assigning the body-only set here
+                  // erased the comment-sourced half on every poll tick.
                 },
               })
               .run(),
           );
+        },
+        catch: (e) => new ValidationError({ message: String(e) }),
+      });
+
+      // Merge body mentions into whatever the row already accumulated. Runs
+      // after the upsert so fresh inserts (which took `mentionedUsers` from the
+      // insert values) are a no-op here.
+      yield* Effect.try({
+        try: () => {
+          for (const [prId, logins] of bodyMentionsByPrId) {
+            mergeMentionedUsers(db, prId, logins);
+          }
         },
         catch: (e) => new ValidationError({ message: String(e) }),
       });
@@ -780,21 +853,7 @@ export const PullRequestServiceLive = Layer.succeed(PullRequestService, {
       if (logins.length === 0) return;
       const { db } = yield* DbService;
       yield* Effect.try({
-        try: () => {
-          // Read existing mentioned users, merge with new logins, write back.
-          const row = db
-            .select({ mentionedUsers: pullRequests.mentionedUsers })
-            .from(pullRequests)
-            .where(eq(pullRequests.id, prId))
-            .get();
-          if (!row) return;
-          const existing = JSON.parse(row.mentionedUsers ?? "[]") as string[];
-          const merged = [...new Set([...existing, ...logins])];
-          db.update(pullRequests)
-            .set({ mentionedUsers: JSON.stringify(merged) })
-            .where(eq(pullRequests.id, prId))
-            .run();
-        },
+        try: () => mergeMentionedUsers(db, prId, logins),
         catch: (e) => new ValidationError({ message: String(e) }),
       });
     }),

--- a/apps/server/src/services/Sync.ts
+++ b/apps/server/src/services/Sync.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { CommentThread, ThreadSummary, UserRole } from "@revv/shared";
 import { eq } from "drizzle-orm";
 import { Context, Effect, Layer } from "effect";
@@ -5,7 +6,7 @@ import { reviewSessions } from "../db/schema/review-sessions";
 import { SyncError } from "../domain/errors";
 import { Broadcaster } from "./Broadcaster";
 import { DbService } from "./Db";
-import { type GhReviewComment, GitHubGateway } from "./GitHub";
+import { type GhReviewComment, type GhReviewThread, GitHubGateway } from "./GitHub";
 import type { GitHubEtagCache } from "./GitHubEtagCache";
 import { PrContextService } from "./PrContext";
 import { PullRequestService } from "./PullRequest";
@@ -21,6 +22,12 @@ export interface PullResult {
   readonly newMessages: number;
   readonly statusChanges: number;
   readonly edits: number;
+  /**
+   * Whether this pull observed anything new on GitHub — either it wrote rows,
+   * or the review-thread fingerprint moved. False means the local mirror
+   * already matched GitHub, so there is nothing worth announcing.
+   */
+  readonly changed: boolean;
 }
 
 export interface SyncResult {
@@ -43,8 +50,17 @@ export class SyncService extends Context.Tag("SyncService")<
     readonly pullComments: (
       prId: string,
     ) => Effect.Effect<PullResult, SyncError, DbService | GitHubEtagCache | SettingsService>;
+    /**
+     * Reconcile one PR's threads against GitHub.
+     *
+     * Pass `force: true` for user-initiated syncs: the `threads:synced`
+     * envelope is what clears the client's per-PR spinner, so it must go out
+     * even when nothing changed. The background sweep leaves it unset and stays
+     * silent on no-op PRs.
+     */
     readonly syncThreads: (
       prId: string,
+      opts?: { readonly force?: boolean },
     ) => Effect.Effect<SyncResult, SyncError, DbService | GitHubEtagCache | SettingsService>;
     readonly getThreadSummary: (
       prId: string,
@@ -119,7 +135,7 @@ export const SyncServiceLive = Layer.effect(
         if (thread.externalCommentId) return; // already pushed
 
         const sessionPrId = yield* resolvePrIdFromSession(thread.reviewSessionId);
-        const { pr, repo, token } = yield* resolvePrContext(sessionPrId);
+        const { pr, repo, token, apiBase } = yield* resolvePrContext(sessionPrId);
 
         if (!pr.headSha) {
           return yield* Effect.fail(
@@ -160,6 +176,7 @@ export const SyncServiceLive = Layer.effect(
           pr.externalId,
           commentPayload,
           token,
+          apiBase,
         );
 
         const externalCommentId = String(posted.id);
@@ -173,6 +190,7 @@ export const SyncServiceLive = Layer.effect(
           repo.fullName,
           pr.externalId,
           token,
+          apiBase,
         );
         const match = threadsOnGithub.find((t) => t.commentDatabaseIds.includes(posted.id));
         if (match) {
@@ -208,7 +226,7 @@ export const SyncServiceLive = Layer.effect(
         }
 
         const sessionPrId = yield* resolvePrIdFromSession(thread.reviewSessionId);
-        const { pr, repo, token } = yield* resolvePrContext(sessionPrId);
+        const { pr, repo, token, apiBase } = yield* resolvePrContext(sessionPrId);
 
         const posted = yield* github.reviews.replyToComment(
           repo.fullName,
@@ -216,6 +234,7 @@ export const SyncServiceLive = Layer.effect(
           parentCommentId,
           message.body,
           token,
+          apiBase,
         );
         yield* reviewService.setMessageExternalId(message.id, String(posted.id));
       }).pipe(Effect.mapError(toSyncError()));
@@ -228,12 +247,12 @@ export const SyncServiceLive = Layer.effect(
         if (!thread.externalThreadId) return;
 
         const sessionPrId = yield* resolvePrIdFromSession(thread.reviewSessionId);
-        const { token } = yield* resolvePrContext(sessionPrId);
+        const { token, apiBase } = yield* resolvePrContext(sessionPrId);
 
         const isResolved = thread.status === "resolved" || thread.status === "wont_fix";
         yield* isResolved
-          ? github.reviews.resolveThread(thread.externalThreadId, token)
-          : github.reviews.unresolveThread(thread.externalThreadId, token);
+          ? github.reviews.resolveThread(thread.externalThreadId, token, apiBase)
+          : github.reviews.unresolveThread(thread.externalThreadId, token, apiBase);
       }).pipe(Effect.mapError(toSyncError(threadId)));
 
     const getThreadSummary = (
@@ -270,7 +289,7 @@ export const SyncServiceLive = Layer.effect(
       prId: string,
     ): Effect.Effect<PullResult, SyncError, DbService | GitHubEtagCache | SettingsService> =>
       Effect.gen(function* () {
-        const { pr, repo, token } = yield* resolvePrContext(prId);
+        const { pr, repo, token, apiBase } = yield* resolvePrContext(prId);
         const accountId = yield* repoService.getAccountIdForRepo(repo.id);
         const session = yield* reviewService.getOrCreateActiveSession(pr.id);
 
@@ -282,6 +301,7 @@ export const SyncServiceLive = Layer.effect(
           pr.externalId,
           since,
           token,
+          apiBase,
         );
 
         let newThreads = 0;
@@ -291,6 +311,40 @@ export const SyncServiceLive = Layer.effect(
 
         const byExternalId = new Map<number, GhReviewComment>();
         for (const c of comments) byExternalId.set(c.id, c);
+
+        // GitHub's own thread grouping is the authoritative answer to "which
+        // thread does this reply belong to", and we need it twice — once to
+        // attach incoming replies, once to reconcile resolved/unresolved. Fetch
+        // it once, and only when one of those jobs is actually live: a PR with
+        // no local threads and no incoming replies has nothing to match, and
+        // skipping the GraphQL call there is what keeps quiet PRs free on the
+        // background sweep (GraphQL has no conditional-request equivalent, so
+        // unlike the REST calls above it is never a free 304).
+        const localThreadsBefore = yield* reviewService.getThreadsForSession(session.id);
+        const hasIncomingReplies = comments.some((c) => c.inReplyToId !== null);
+        const needsGhThreads = localThreadsBefore.length > 0 || hasIncomingReplies;
+        const ghThreads = needsGhThreads
+          ? yield* github.reviews.listThreads(repo.fullName, pr.externalId, token, apiBase)
+          : [];
+
+        // Every comment id GitHub lists in a thread maps to that thread's root
+        // (its first comment). This is what `findRootInBatch` can only guess at:
+        // that fallback walks `in_reply_to_id` through the current batch, which
+        // misses whenever the root falls outside the `since` window — and a miss
+        // used to drop the comment permanently, since the watermark then
+        // advances past it.
+        const rootByCommentId = new Map<number, number>();
+        for (const t of ghThreads) {
+          const root = t.commentDatabaseIds[0];
+          if (root === undefined) continue;
+          for (const id of t.commentDatabaseIds) rootByCommentId.set(id, root);
+        }
+
+        // Comment authors, deduped by login. One person usually writes several
+        // comments in a batch and each upsert costs a SELECT + UPSERT (plus an
+        // avatar refetch once the 24h TTL lapses), so collapse them and flush
+        // after the ingest loop.
+        const pendingAuthors = new Map<string, string | null>();
 
         for (const c of comments) {
           const existingMsg = yield* reviewService.findMessageByExternalId(String(c.id));
@@ -311,43 +365,44 @@ export const SyncServiceLive = Layer.effect(
             continue;
           }
 
-          // Upsert the comment author into remote_users.
-          yield* remoteUserService.upsert({
-            provider: "github",
-            providerUserId: "", // We don't have the numeric ID from GraphQL comments
-            login: c.authorLogin,
-            avatarUrl: c.authorAvatarUrl,
-          });
+          if (!pendingAuthors.has(c.authorLogin)) {
+            pendingAuthors.set(c.authorLogin, c.authorAvatarUrl);
+          }
 
           const authorRole: "reviewer" | "coder" | "ai_agent" =
             c.authorLogin === pr.authorLogin ? "coder" : "reviewer";
 
           if (c.inReplyToId !== null) {
-            const root = findRoot(c, byExternalId);
+            const rootId = rootByCommentId.get(c.id) ?? findRootInBatch(c, byExternalId);
             const thread = yield* reviewService.getThreadByExternalCommentId(
               session.id,
-              String(root),
+              String(rootId),
             );
-            if (!thread) continue;
+            if (thread) {
+              const msg = yield* reviewService.addMessage(thread.id, {
+                authorRole,
+                authorName: c.authorLogin,
+                authorLogin: c.authorLogin,
+                body: c.body,
+                messageType: "reply",
+                externalId: String(c.id),
+                createdAt: c.createdAt,
+              });
+              newMessages++;
 
-            const msg = yield* reviewService.addMessage(thread.id, {
-              authorRole,
-              authorName: c.authorLogin,
-              authorLogin: c.authorLogin,
-              body: c.body,
-              messageType: "reply",
-              externalId: String(c.id),
-              createdAt: c.createdAt,
-            });
-            newMessages++;
+              yield* reviewService.transitionStatus(thread.id, authorRole);
 
-            yield* reviewService.transitionStatus(thread.id, authorRole);
-
-            yield* broadcaster.broadcastToAccount(accountId, {
-              type: "threads:new-reply",
-              data: { prId: pr.id, thread, message: msg },
-            });
-            continue;
+              yield* broadcaster.broadcastToAccount(accountId, {
+                type: "threads:new-reply",
+                data: { prId: pr.id, thread, message: msg },
+              });
+              continue;
+            }
+            // No local thread owns this reply — its root predates our first
+            // sync of this PR, or was pruned by retention. Fall through and
+            // ingest it as its own root thread: showing it detached is strictly
+            // better than the old behaviour of dropping it and never looking
+            // again.
           }
 
           const thread = yield* reviewService.createThread(session.id, {
@@ -379,6 +434,15 @@ export const SyncServiceLive = Layer.effect(
           });
         }
 
+        for (const [login, avatarUrl] of pendingAuthors) {
+          yield* remoteUserService.upsert({
+            provider: "github",
+            providerUserId: "", // We don't have the numeric ID from GraphQL comments
+            login,
+            avatarUrl,
+          });
+        }
+
         // Extract @-mentions from newly-synced review comments and append
         // them to the PR's `mentionedUsers` array.
         const commentMentions = comments.flatMap((c) => extractGitHubMentions(c.body));
@@ -388,18 +452,6 @@ export const SyncServiceLive = Layer.effect(
             .pipe(Effect.catchAll(() => Effect.void));
         }
 
-        // Reconcile resolution status via GraphQL — but only when this PR
-        // actually has local threads to reconcile. The reconciliation loop
-        // matches GitHub threads back to local rows by external comment id;
-        // with zero local threads every match is a miss, so the GraphQL call
-        // is pure waste. Skipping it removes one GraphQL request per quiet PR
-        // on every 30s poll tick — the bulk of PRs most of the time — which is
-        // the single biggest contributor to GitHub rate-limit pressure.
-        const localThreads = yield* reviewService.getThreadsForSession(session.id);
-        const ghThreads =
-          localThreads.length === 0
-            ? []
-            : yield* github.reviews.listThreads(repo.fullName, pr.externalId, token);
         for (const ght of ghThreads) {
           for (const cdbId of ght.commentDatabaseIds) {
             const local = yield* reviewService.getThreadByExternalCommentId(
@@ -444,21 +496,44 @@ export const SyncServiceLive = Layer.effect(
           }
         }
 
-        return { newThreads, newMessages, statusChanges, edits };
+        // Did GitHub's side actually move? Row writes are the obvious signal;
+        // the thread fingerprint catches the rest (a resolve, an unresolve, a
+        // thread appearing or vanishing) without re-deriving it from the DB.
+        // When the GraphQL call was skipped there was nothing to fingerprint,
+        // so the row writes are the whole answer.
+        let changed = newThreads + newMessages + edits + statusChanges > 0;
+        if (needsGhThreads) {
+          const fingerprint = fingerprintThreads(ghThreads);
+          const previous = yield* prService.getThreadsFingerprint(pr.id);
+          if (previous !== fingerprint) {
+            changed = true;
+            yield* prService.setThreadsFingerprint(pr.id, fingerprint);
+          }
+        }
+
+        return { newThreads, newMessages, statusChanges, edits, changed };
       }).pipe(Effect.mapError(toSyncError()));
 
     const syncThreads = (
       prId: string,
+      opts?: { readonly force?: boolean },
     ): Effect.Effect<SyncResult, SyncError, DbService | GitHubEtagCache | SettingsService> =>
       Effect.gen(function* () {
         const pulled = yield* pullComments(prId);
         const summary = yield* getThreadSummary(prId, null);
-        const { repo } = yield* resolvePrContext(prId);
-        const accountId = yield* repoService.getAccountIdForRepo(repo.id);
-        yield* broadcaster.broadcastToAccount(accountId, {
-          type: "threads:synced",
-          data: { prId, summary, timestamp: new Date().toISOString() },
-        });
+        // The background sweep visits every open PR on every tick. Announcing
+        // an unchanged summary for each one costs an SSE message per PR and two
+        // Map clones in every connected client, for no new information — so stay
+        // quiet unless something moved. User-initiated syncs always announce:
+        // this envelope is what clears their per-PR spinner.
+        if (pulled.changed || opts?.force === true) {
+          const { repo } = yield* resolvePrContext(prId);
+          const accountId = yield* repoService.getAccountIdForRepo(repo.id);
+          yield* broadcaster.broadcastToAccount(accountId, {
+            type: "threads:synced",
+            data: { prId, summary, timestamp: new Date().toISOString() },
+          });
+        }
         return { pulled, summary };
       }).pipe(Effect.mapError(toSyncError()));
 
@@ -473,8 +548,29 @@ export const SyncServiceLive = Layer.effect(
   }),
 );
 
-/** Walk up the reply chain to find the root comment's database id. */
-function findRoot(c: GhReviewComment, byExternalId: Map<number, GhReviewComment>): number {
+/**
+ * Fingerprint the externally-observable review-thread state: every thread's
+ * node id, resolution flag, and comment ids, order-independent. Two pulls that
+ * produce the same fingerprint saw the same GitHub state, so the second has
+ * nothing to write and nothing to announce.
+ */
+function fingerprintThreads(threads: ReadonlyArray<GhReviewThread>): string {
+  const canonical = threads
+    .map((t) => {
+      const ids = [...t.commentDatabaseIds].sort((a, b) => a - b).join(",");
+      return `${t.nodeId}:${t.isResolved ? 1 : 0}:${ids}`;
+    })
+    .sort()
+    .join("|");
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Best-effort root lookup for a reply, walking `in_reply_to_id` through the
+ * comments in the current batch. Only a fallback for when GitHub's own thread
+ * grouping is unavailable — it cannot see comments outside the `since` window.
+ */
+function findRootInBatch(c: GhReviewComment, byExternalId: Map<number, GhReviewComment>): number {
   let cursor: GhReviewComment | undefined = c;
   for (let i = 0; i < 32 && cursor; i++) {
     if (cursor.inReplyToId === null) return cursor.id;

--- a/apps/server/src/services/github-rest.ts
+++ b/apps/server/src/services/github-rest.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { Effect, Schedule } from "effect";
 import {
   GitHubAccessDeniedError,
+  GitHubApiError,
   GitHubAuthError,
   type GitHubError,
   GitHubNetworkError,
@@ -34,11 +35,25 @@ export function toGitHubError(e: unknown): GitHubError {
     e instanceof GitHubAccessDeniedError ||
     e instanceof GitHubRateLimitError ||
     e instanceof GitHubNotFoundError ||
+    e instanceof GitHubApiError ||
     e instanceof GitHubNetworkError
   ) {
     return e;
   }
   return new GitHubNetworkError({ cause: e });
+}
+
+/**
+ * Build the REST API base URL for an explicit GitHub host. `github.com` maps
+ * to the public `api.github.com`; every GitHub Enterprise host maps to
+ * `api.<host>`.
+ *
+ * Host is a **per-repository** property (`repositories.github_host`), never a
+ * global one — the settings-derived base URL is only a fallback for flows that
+ * have no repo in hand (add-repo, onboarding, device auth).
+ */
+export function apiBaseForHost(host: string): string {
+  return host === "github.com" ? "https://api.github.com" : `https://api.${host}`;
 }
 
 /** Build the standard headers for GitHub API requests. */
@@ -117,7 +132,14 @@ export function assertGitHubOk(res: Response, path: string): void {
     throw new GitHubNotFoundError({ resource: path, id: path });
   }
   if (!res.ok) {
-    throw new GitHubNetworkError({ cause: `HTTP ${res.status}` });
+    // 5xx and 408 are the only statuses worth replaying — GitHub is having a
+    // bad moment and the identical request may succeed. Every other status is
+    // a considered rejection (422 validation, 405 method, 409 conflict, …);
+    // retrying those just spends the backoff budget to get the same answer.
+    if (res.status >= 500 || res.status === 408) {
+      throw new GitHubNetworkError({ cause: `HTTP ${res.status} for ${path}` });
+    }
+    throw new GitHubApiError({ status: res.status, cause: `HTTP ${res.status} for ${path}` });
   }
 }
 
@@ -339,7 +361,7 @@ export function githubPost(
         );
         if (res.status === 422) {
           const text = await res.text().catch(() => "");
-          throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
+          throw new GitHubApiError({ status: 422, cause: `422 Unprocessable Entity: ${text}` });
         }
         assertGitHubOk(res, path);
         return res.json();
@@ -368,7 +390,7 @@ export function githubPatch(
       );
       if (res.status === 422) {
         const text = await res.text().catch(() => "");
-        throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
+        throw new GitHubApiError({ status: 422, cause: `422 Unprocessable Entity: ${text}` });
       }
       assertGitHubOk(res, path);
       return res.json();
@@ -396,11 +418,14 @@ export function githubPut(
       );
       if (res.status === 405) {
         const text = await res.text().catch(() => "");
-        throw new GitHubNetworkError({ cause: `HTTP 405 Method Not Allowed: ${text}` });
+        throw new GitHubApiError({
+          status: 405,
+          cause: `HTTP 405 Method Not Allowed: ${text}`,
+        });
       }
       if (res.status === 422) {
         const text = await res.text().catch(() => "");
-        throw new GitHubNetworkError({ cause: `422 Unprocessable Entity: ${text}` });
+        throw new GitHubApiError({ status: 422, cause: `422 Unprocessable Entity: ${text}` });
       }
       assertGitHubOk(res, path);
       return res.json();
@@ -455,13 +480,19 @@ export function githubGraphql<T = unknown>(
         );
         assertGitHubOk(res, "/graphql");
         const payload = (await res.json()) as { data?: T; errors?: Array<{ message: string }> };
+        // A 200 carrying `errors` means GraphQL parsed and rejected the query
+        // (unknown field, missing scope, node not visible). That verdict is
+        // stable, so this must NOT be a retryable network error — otherwise
+        // every such call costs 4 attempts and ~14s of backoff, which in the
+        // sequential thread sweep stalls every PR behind it.
         if (payload.errors && payload.errors.length > 0) {
-          throw new GitHubNetworkError({
+          throw new GitHubApiError({
+            status: res.status,
             cause: `GraphQL: ${payload.errors.map((e) => e.message).join("; ")}`,
           });
         }
         if (!payload.data) {
-          throw new GitHubNetworkError({ cause: "GraphQL: empty data field" });
+          throw new GitHubApiError({ status: res.status, cause: "GraphQL: empty data field" });
         }
         return payload.data;
       },

--- a/apps/web/src/lib/components/sidebar/PierreFileTree.svelte
+++ b/apps/web/src/lib/components/sidebar/PierreFileTree.svelte
@@ -70,8 +70,14 @@ const PHANTOM_PATHS: readonly string[] = Array.from(
   (_, i) => `${PHANTOM_PATH_PREFIX}${i}`,
 );
 
+// `@pierre/trees` throws `Duplicate path: "…"` when the same path appears
+// twice in its input, and it throws from inside the `$effect` below — which
+// aborts the entire Svelte flush, so every effect queued after this component
+// (notably the walkthrough's `use:mountCodeBlock` actions) silently never
+// runs. The server dedupes GitHub's file list at the gateway now, but a tree
+// crash is far too destructive to leave undefended one layer up.
 function withPhantomPaths(real: readonly string[]): string[] {
-  return [...real, ...PHANTOM_PATHS];
+  return [...new Set(real), ...PHANTOM_PATHS];
 }
 
 function isPhantomPath(path: string): boolean {
@@ -577,6 +583,10 @@ $effect(() => {
         // we land on the right button.
         tree.focusPath(activePath);
         requestAnimationFrame(() => {
+          // `bind:this` nulls `host` when the component is destroyed, and this
+          // callback is two frames removed from the effect that scheduled it —
+          // easily long enough for a PR switch to unmount us in between.
+          if (!host) return;
           const sr = tree?.getFileTreeContainer()?.shadowRoot;
           // After re-render, the focused row has tabIndex=0.
           const row =
@@ -588,6 +598,7 @@ $effect(() => {
       } else {
         // No active file yet — focus the first visible row so
         // arrow-key navigation has a starting point.
+        if (!host) return;
         const container = tree?.getFileTreeContainer();
         const firstRow = container?.shadowRoot?.querySelector<HTMLElement>('[data-type="item"]');
         if (firstRow) {

--- a/apps/web/src/lib/stores/auth.svelte.ts
+++ b/apps/web/src/lib/stores/auth.svelte.ts
@@ -27,6 +27,14 @@ let user = $state<{
   onboardedAt?: string | null;
 } | null>(null);
 let isLoading = $state(false);
+/**
+ * Set once `/api/user/identity` has been *attempted* for the current session
+ * — on success and on failure alike, so a flaky identity call can never wedge
+ * a caller that waits on it. Distinguishes "GitHub login not fetched yet" from
+ * "fetched, and there is none", which `getCurrentUserLogin()` reports
+ * identically. See {@link hasAttemptedIdentityLoad}.
+ */
+let identityAttempted = $state(false);
 let isSwitching = $state(false);
 let error = $state<string | null>(null);
 
@@ -184,6 +192,7 @@ export function clearToken(): void {
   resetLoadUserRetryState();
   token = null;
   user = null;
+  identityAttempted = false;
   _connectedAccounts = [];
   // The re-auth modal is gated solely on `reauthRequired`, so an invalidated /
   // signed-out session must clear it (and any stale sign-in error) — otherwise
@@ -478,6 +487,8 @@ export async function loadUser(): Promise<void> {
         }
       } catch {
         // best-effort
+      } finally {
+        identityAttempted = true;
       }
       // Init per-user org selection before fetching orgs
       initForUser(u.id);
@@ -747,6 +758,16 @@ export function getUser(): {
 /** Current user's GitHub login, or null if not yet loaded or missing. */
 export function getCurrentUserLogin(): string | null {
   return user?.githubLogin ?? null;
+}
+
+/**
+ * Whether the GitHub identity fetch has run for this session (successfully or
+ * not). Callers that *branch* on `getCurrentUserLogin()` — rather than merely
+ * displaying it — should wait for this, otherwise they act on a provisional
+ * `null` and have to redo the work when the real answer lands.
+ */
+export function hasAttemptedIdentityLoad(): boolean {
+  return identityAttempted;
 }
 
 /**

--- a/apps/web/src/lib/stores/events.svelte.ts
+++ b/apps/web/src/lib/stores/events.svelte.ts
@@ -118,6 +118,34 @@ function reconcileOnReconnect(): void {
 }
 
 /**
+ * Re-read local state when the window comes back to the foreground.
+ *
+ * The server's poll fiber sleeps between cycles, so after the machine suspends
+ * — or the app simply sits in the background — the first thing the user sees on
+ * return is up to a full interval stale, with no event inbound to correct it.
+ * These are DB-only REST reads (no GitHub traffic), so running them on every
+ * focus is cheap; the same debounce as the reconnect path keeps a rapid
+ * alt-tab from firing repeatedly.
+ */
+function reconcileOnForeground(): void {
+  if (document.visibilityState !== "visible") return;
+  if (!source || source.readyState === EventSource.CLOSED) return;
+  const now = Date.now();
+  if (now - lastReconcileAt < RECONNECT_RECONCILE_DEBOUNCE_MS) return;
+  lastReconcileAt = now;
+  void Promise.all([fetchRepos(), fetchPrs(), fetchPinnedPrs()]);
+}
+
+let foregroundListenersBound = false;
+
+function bindForegroundReconcile(): void {
+  if (foregroundListenersBound || typeof document === "undefined") return;
+  foregroundListenersBound = true;
+  document.addEventListener("visibilitychange", reconcileOnForeground);
+  window.addEventListener("focus", reconcileOnForeground);
+}
+
+/**
  * Open the global SSE stream for the given bearer token. Closes any
  * existing connection first. Called from `auth.svelte.ts` on sign-in /
  * account-switch.
@@ -140,6 +168,7 @@ export function connect(token: string, hostOverride?: string): void {
   openCount = 0;
   lastEventTime = Date.now();
   startWatchdog(token);
+  bindForegroundReconcile();
 
   es.addEventListener("open", () => {
     lastEventTime = Date.now();
@@ -215,6 +244,10 @@ function dispatch(msg: ServerEventMessage): void {
       });
       break;
     case "error":
+      // A sync failure is a terminal outcome for that sync, and no
+      // `prs:sync-complete` follows it — so release the sidebar spinner here or
+      // it spins until the next successful cycle.
+      if (msg.data.code === "SYNC_ERROR") setPrListSyncing(false);
       setError(msg.data);
       break;
     case "auth:reauth-required":

--- a/apps/web/src/lib/stores/prs.svelte.ts
+++ b/apps/web/src/lib/stores/prs.svelte.ts
@@ -11,7 +11,7 @@ import { REVIEW_MODE, type ReviewMode } from "@revv/shared";
 import { toast } from "svelte-sonner";
 import { goto } from "$app/navigation";
 import { api } from "$lib/api/client";
-import { getCurrentUserLogin } from "$lib/stores/auth.svelte";
+import { getCurrentUserLogin, hasAttemptedIdentityLoad } from "$lib/stores/auth.svelte";
 
 import { setBatchSummaries } from "$lib/stores/sync.svelte";
 import { clearOwnerHueCache, preloadOwnerHues } from "$lib/utils/avatarPalette";
@@ -52,6 +52,10 @@ let teamsByOrg = $state<Map<string, Team[]>>(new Map());
 let teamsLoadingByOrg = $state<Map<string, boolean>>(new Map());
 let teamsFailedByOrg = $state<Map<string, boolean>>(new Map());
 let isLoading = $state(false);
+// Set once `fetchPrs` has settled (success or failure). Lets callers tell
+// "this PR isn't in the list yet" from "this PR isn't in the list at all"
+// without waiting forever on a row that will never arrive.
+let prsFetchAttempted = $state(false);
 let archivedPrs = $state<PullRequest[]>([]);
 // Cursor for the next page of archived PRs. Null = exhausted or never
 // fetched. Updated by `fetchArchivedPrs` (replaces the list, sets cursor
@@ -250,6 +254,31 @@ export function getReviewModeForPr(prId: string): ReviewMode {
     : REVIEW_MODE.reviewer;
 }
 
+/**
+ * Whether {@link getReviewModeForPr} can give a real answer yet.
+ *
+ * The lens needs two async inputs — the PR row (for `authorLogin`) and the
+ * signed-in user's GitHub login. Missing either, `getReviewModeForPr` quietly
+ * reports `"reviewer"`, which is indistinguishable from a genuine reviewer
+ * verdict. On a cold start that provisional answer is wrong for every PR the
+ * user authored, and any caller that *fetches* on it pays for the request
+ * twice — once against the wrong lens, once again when the real mode lands.
+ * For a 3 000-file PR that is two ~12 MB `/files` responses per app launch.
+ *
+ * Callers that only render the mode can keep reading it directly; callers that
+ * issue requests should wait for this.
+ */
+export function isReviewModeResolved(prId: string): boolean {
+  if (!hasAttemptedIdentityLoad()) return false;
+  if (pullRequests.some((p) => p.id === prId) || archivedPrs.some((p) => p.id === prId)) {
+    return true;
+  }
+  // The row may never arrive — a deep link can point at a PR outside the
+  // synced set. Once the list fetch has settled, "reviewer" is the real
+  // answer rather than a placeholder, so callers must not keep waiting.
+  return prsFetchAttempted;
+}
+
 export function getTaggedPrs(repoId: string): PullRequest[] {
   return taggedPrsByRepo.get(repoId) ?? [];
 }
@@ -375,6 +404,7 @@ export async function fetchPrs(): Promise<void> {
     // error handled by wsStore or caller
   } finally {
     isLoading = false;
+    prsFetchAttempted = true;
   }
 }
 

--- a/apps/web/src/lib/stores/sync.svelte.ts
+++ b/apps/web/src/lib/stores/sync.svelte.ts
@@ -63,13 +63,30 @@ export function requestThreadSync(prId: string): void {
     });
 }
 
+/**
+ * Refresh everything about ONE pull request: its GitHub metadata and its
+ * comment threads.
+ *
+ * Deliberately not the global `/prs/sync` — that walks every repo on every
+ * account (plus, on a cold cycle, the hourly metadata refresh and archive
+ * backfill) to answer a question about a single PR. `/prs/:id/refresh` is a
+ * couple of requests, and it reads GitHub's PR detail endpoint, so it also
+ * fills in the diff stats the list-endpoint poll can't see.
+ */
 export function requestFullSync(prId: string): void {
   markThreadsSyncing(prId);
   setPrListSyncing(true);
-  void api.api.prs.sync.post().catch(() => {
-    setPrListSyncing(false);
-    toast.error("Failed to sync pull requests");
-  });
+  void api.api
+    .prs({ id: prId })
+    .refresh.post()
+    .catch(() => {
+      toast.error("Failed to refresh pull request");
+    })
+    .finally(() => {
+      // This request is awaited server-side, so its completion IS the signal —
+      // there's no `prs:sync-complete` coming to release the spinner.
+      setPrListSyncing(false);
+    });
   void api.api
     .prs({ id: prId })
     ["sync-threads"].post()

--- a/apps/web/src/routes/review/[prId]/+page.svelte
+++ b/apps/web/src/routes/review/[prId]/+page.svelte
@@ -10,7 +10,7 @@ import { Badge } from "$lib/components/ui/badge";
 import { Dotmatrix } from "$lib/components/ui/dotmatrix";
 import GuidedWalkthrough from "$lib/components/walkthrough/GuidedWalkthrough.svelte";
 import { markVisited as markPrVisited } from "$lib/stores/pr-visits.svelte";
-import { getSelectedPr, setSelectedPrId } from "$lib/stores/prs.svelte";
+import { getSelectedPr, isReviewModeResolved, setSelectedPrId } from "$lib/stores/prs.svelte";
 import {
   clearReviewFiles,
   getActiveFilePath,
@@ -156,6 +156,18 @@ $effect(() => {
   const prId = page.params.prId;
   const mode = reviewMode;
   if (!prId) return;
+
+  // Hold until the author-vs-reviewer lens is real. On a cold start (deep
+  // link, or the desktop app reopening on this route) the PR row and the
+  // signed-in user's login are both still in flight, and `reviewMode` reads
+  // "reviewer" for everything — including PRs the user authored. Fetching on
+  // that provisional value means the whole `/files` payload is downloaded
+  // twice, which on a 3 000-file PR is two ~12 MB responses back to back.
+  // Keep the spinner up instead; this effect re-runs the moment mode resolves.
+  if (!isReviewModeResolved(prId)) {
+    setIsLoadingFiles(true);
+    return;
+  }
 
   // Everything below mutates store state. Calls like `clearReviewFiles()`
   // invoke `clearSession()`, which does `threadsVersion++` — a read-then-


### PR DESCRIPTION
Loading a PR's diff and its already-generated walkthrough was slow on **every** view, not just after a restart: GitHub emits two file entries for one path when the file's type changes (`removed` + `added`), but `pr_diff_files` is keyed on `(prId, path)`, so the stored row count could never reach GitHub's `changed_files` stat and the completeness guard re-fetched all 30 pages every time — 15–18 s for a 3 000-file PR. The non-deduped list then made `@pierre/trees` throw `Duplicate path` from inside a Svelte `$effect`, which aborts the whole flush, so the walkthrough's `use:mountCodeBlock` actions never ran and its code blocks rendered empty. Fixed by deduping GitHub's file list at the gateway and recording the last fetch's row count in a new `pull_requests.diff_files_cached_count` column (migration `0320`), which `hasCompleteCachedFiles` now treats as authoritative — measured `/files` 15–18 s → 29 ms warm, one request per load instead of two, 8/8 walkthrough code blocks rendering, zero uncaught errors.

The branch also carries a broader pass at GitHub API cost and correctness: a new `GitHubApiError` so considered rejections (non-401/403/404/429 4xx, GraphQL `errors` payloads) stop burning ~14 s of retry backoff and surface their real status; an explicit per-repo `apiBase` threaded through the gateway and `PrContext` so a GitHub Enterprise repo and a github.com repo on the same machine aren't both addressed at whichever host settings happen to name; a thread sweep narrowed to PRs that actually moved, with GitHub's thread grouping fetched once per pull so replies whose root falls outside the `since` window are no longer dropped permanently; fingerprinting so `threads:synced` / `prs:updated` only broadcast on real change; a coalescing `syncNow` plus a new ownership-checked `POST /prs/:id/refresh` replacing the UI's full every-repo sync; preserved `mentioned_users` and diff stats across poll upserts; and a weekly sweep of `github_etag_cache`, which had no `expires_at` and had grown to 83 MB of a 116 MB database.

Client-side: the review page now holds its file fetch until the author-vs-reviewer lens resolves instead of fetching twice on every cold start, `PierreFileTree` dedupes paths and guards two `host.focus` calls that threw on unmount, and the app reconciles local state on window foreground and releases the sidebar spinner on `SYNC_ERROR`.

Verified against the live desktop app (webview bridge timeline before/after) plus `typecheck && lint && knip && build` and 203/203 server tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)