### PR TITLE
fix(review): pull the fresh diff before reviewing new commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ apps/desktop/target/
 # Tooling
 .context/
 .openlogs/
+.repos/effect

--- a/apps/server/src/ai/acp/acp-connection.test.ts
+++ b/apps/server/src/ai/acp/acp-connection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { selectAcpAuthMethod } from "./acp-connection";
+import { sanitizeMcpServerName, selectAcpAuthMethod } from "./acp-connection";
 
 describe("selectAcpAuthMethod", () => {
   it("prefers the ChatGPT session over an API key for Codex", () => {
@@ -16,5 +16,23 @@ describe("selectAcpAuthMethod", () => {
     expect(selectAcpAuthMethod("claude-code", [{ id: "api-key" }, { id: "oauth" }])).toBe(
       "api-key",
     );
+  });
+});
+
+describe("sanitizeMcpServerName", () => {
+  it("replaces the prId colon Codex chokes on", () => {
+    expect(
+      sanitizeMcpServerName("revv-chat-context-2eef0a52-e3d7-4c60-8d9d-48858084868c:2467"),
+    ).toBe("revv-chat-context-2eef0a52-e3d7-4c60-8d9d-48858084868c-2467");
+  });
+
+  it("leaves already-safe names untouched", () => {
+    expect(sanitizeMcpServerName("revv-walkthrough-0f0e41c7_7d09")).toBe(
+      "revv-walkthrough-0f0e41c7_7d09",
+    );
+  });
+
+  it("replaces every unsafe character, not just the first", () => {
+    expect(sanitizeMcpServerName("revv chat:ctx/2467.x")).toBe("revv-chat-ctx-2467-x");
   });
 });

--- a/apps/server/src/ai/acp/acp-connection.ts
+++ b/apps/server/src/ai/acp/acp-connection.ts
@@ -56,6 +56,27 @@ export function selectAcpAuthMethod(
   return methods[0]?.id;
 }
 
+/**
+ * Codex silently refuses to start an MCP server whose name contains anything
+ * outside `[A-Za-z0-9_-]`: it emits an internal `mcp__<name>__startup` tool call
+ * that never connects, our HTTP route is never hit, and the turn runs with none
+ * of our tools — the agent just reports them "unavailable". The chat server is
+ * named after the prId (`<repoId>:<prNumber>`), so that colon cost every Codex
+ * chat turn the walkthrough-edit tools. Normalize here, at the one point every
+ * ACP caller funnels through, so no adapter can be handed an unsafe name.
+ * Nothing reads the name back, so rewriting it is invisible to callers.
+ */
+export function sanitizeMcpServerName(name: string): string {
+  return name.replace(/[^A-Za-z0-9_-]/g, "-");
+}
+
+function sanitizeMcpServers(servers: McpServer[]): McpServer[] {
+  return servers.map((server) => {
+    const name = sanitizeMcpServerName(server.name);
+    return name === server.name ? server : { ...server, name };
+  });
+}
+
 export type AcpSessionUpdate = SessionUpdate;
 
 /** Listener invoked for every `session/update` notification on a session. */
@@ -403,7 +424,7 @@ function makeHandle(entry: ConnectionEntry): AcpConnectionHandle {
     newSession: async (mcpServers) => {
       const res = await connection.newSession({
         cwd: entry.cwd,
-        mcpServers,
+        mcpServers: sanitizeMcpServers(mcpServers),
       });
       return { sessionId: res.sessionId, modes: res.modes ?? null };
     },
@@ -411,7 +432,7 @@ function makeHandle(entry: ConnectionEntry): AcpConnectionHandle {
       const res = await connection.loadSession({
         sessionId,
         cwd: entry.cwd,
-        mcpServers,
+        mcpServers: sanitizeMcpServers(mcpServers),
       });
       return res.modes ?? null;
     },

--- a/apps/server/src/comment-permissions.test.ts
+++ b/apps/server/src/comment-permissions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { canUserModifyComment, isPublishableDraftComment } from "@revv/shared";
+
+const draft = {
+  authorRole: "reviewer" as const,
+  authorLogin: "Alex",
+  externalId: null,
+};
+
+describe("canUserModifyComment", () => {
+  it("allows the active user's draft regardless of login casing", () => {
+    expect(canUserModifyComment(draft, "alex")).toBe(true);
+  });
+
+  it("allows Revv-authored drafts", () => {
+    expect(
+      canUserModifyComment({ authorRole: "ai_agent", authorLogin: null, externalId: null }, "alex"),
+    ).toBe(true);
+  });
+
+  it("rejects another user's draft and every GitHub-backed comment", () => {
+    expect(canUserModifyComment(draft, "marie")).toBe(false);
+    expect(canUserModifyComment({ ...draft, externalId: "42" }, "alex")).toBe(false);
+  });
+});
+
+describe("isPublishableDraftComment", () => {
+  it("includes Revv-authored drafts in GitHub reviews", () => {
+    expect(
+      isPublishableDraftComment({
+        authorRole: "ai_agent",
+        authorLogin: null,
+        externalId: null,
+        body: "A concrete review concern",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects empty, synced, and coder-authored messages", () => {
+    expect(isPublishableDraftComment({ ...draft, body: "  " })).toBe(false);
+    expect(isPublishableDraftComment({ ...draft, externalId: "42", body: "Concern" })).toBe(false);
+    expect(
+      isPublishableDraftComment({
+        ...draft,
+        authorRole: "coder",
+        body: "Concern",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/routes/middleware.ts
+++ b/apps/server/src/routes/middleware.ts
@@ -172,6 +172,10 @@ export function handleAppError(
       ctx.set.status = 404;
       return { error: e.message };
     }
+    if (e.code === "FORBIDDEN") {
+      ctx.set.status = 403;
+      return { error: e.message };
+    }
     ctx.set.status = 500;
     return { error: e.message };
   }

--- a/apps/server/src/routes/reviews/handlers/github-submit.ts
+++ b/apps/server/src/routes/reviews/handlers/github-submit.ts
@@ -1,3 +1,4 @@
+import { isPublishableDraftComment } from "@revv/shared";
 import { Effect } from "effect";
 import { GitHubApiError, GitHubNetworkError } from "../../../domain/errors";
 import { AppRuntime } from "../../../runtime";
@@ -194,13 +195,12 @@ export function submitGithubReviewHandler(prId: string, userId: string, body: Su
             })
             .pipe(Effect.orElseSucceed(() => undefined));
 
-          // Find the last unsynced reviewer message in this thread and link it
+          // Link the local draft, whether written by the reviewer or Revv, to
+          // the GitHub comment created under the authenticated user's identity.
           const messages = yield* reviewService
             .getMessages(input.threadId)
             .pipe(Effect.orElseSucceed(() => []));
-          const unsyncedMsg = [...messages]
-            .reverse()
-            .find((m) => m.authorRole === "reviewer" && m.externalId == null);
+          const unsyncedMsg = [...messages].reverse().find(isPublishableDraftComment);
           if (unsyncedMsg) {
             yield* reviewService
               .setMessageExternalId(unsyncedMsg.id, String(match.id))

--- a/apps/server/src/routes/threads.ts
+++ b/apps/server/src/routes/threads.ts
@@ -1,6 +1,7 @@
-import type { ThreadStatus } from "@revv/shared";
+import { canUserModifyComment, type ThreadStatus } from "@revv/shared";
 import { Effect } from "effect";
 import { Elysia, t } from "elysia";
+import { ReviewError } from "../domain/errors";
 import { AppRuntime } from "../runtime";
 import { Broadcaster } from "../services/Broadcaster";
 import { ReviewService } from "../services/Review";
@@ -84,7 +85,29 @@ export const threadRoutes = new Elysia({ prefix: "/api/threads" })
   // Used by the frontend immediately after creating a thread to get it round-tripping.
   .post("/:id/push", async (ctx) => {
     try {
-      await AppRuntime.runPromise(Effect.flatMap(SyncService, (s) => s.pushThread(ctx.params.id)));
+      await AppRuntime.runPromise(
+        Effect.gen(function* () {
+          const reviewService = yield* ReviewService;
+          const messages = yield* reviewService.getMessages(ctx.params.id);
+          const firstMessage = messages[0];
+          if (!firstMessage) {
+            return yield* Effect.fail(
+              new ReviewError({ message: "Thread has no message", code: "NOT_FOUND" }),
+            );
+          }
+          if (!canUserModifyComment(firstMessage, ctx.account.githubLogin)) {
+            return yield* Effect.fail(
+              new ReviewError({
+                message: "You can only publish your own comments or comments left by Revv",
+                code: "FORBIDDEN",
+              }),
+            );
+          }
+
+          const sync = yield* SyncService;
+          yield* sync.pushThread(ctx.params.id, ctx.session.user.id);
+        }),
+      );
       return { success: true };
     } catch (e) {
       return handleAppError(e, ctx);
@@ -99,15 +122,7 @@ export const threadRoutes = new Elysia({ prefix: "/api/threads" })
           const reviewService = yield* ReviewService;
           const broadcaster = yield* Broadcaster;
 
-          const thread = yield* reviewService.getThread(ctx.params.id);
-
-          if (thread.externalCommentId !== null) {
-            return yield* Effect.fail(
-              new Error("Cannot discard a thread already synced to GitHub"),
-            );
-          }
-
-          yield* reviewService.deleteThread(ctx.params.id);
+          yield* reviewService.deleteThreadAsUser(ctx.params.id, ctx.account.githubLogin);
 
           yield* broadcaster.broadcastToAccount(ctx.account.accountId, {
             type: "thread:deleted",
@@ -131,7 +146,11 @@ export const threadRoutes = new Elysia({ prefix: "/api/threads" })
             const reviewService = yield* ReviewService;
             const broadcaster = yield* Broadcaster;
 
-            const message = yield* reviewService.editMessage(ctx.params.messageId, ctx.body.body);
+            const message = yield* reviewService.editMessage(
+              ctx.params.messageId,
+              ctx.body.body,
+              ctx.account.githubLogin,
+            );
 
             yield* broadcaster.broadcastToAccount(ctx.account.accountId, {
               type: "thread:message:edited",
@@ -175,7 +194,7 @@ export const threadRoutes = new Elysia({ prefix: "/api/threads" })
           const reviewService = yield* ReviewService;
           const broadcaster = yield* Broadcaster;
 
-          yield* reviewService.deleteMessage(ctx.params.messageId);
+          yield* reviewService.deleteMessage(ctx.params.messageId, ctx.account.githubLogin);
 
           yield* broadcaster.broadcastToAccount(ctx.account.accountId, {
             type: "thread:message:deleted",

--- a/apps/server/src/services/Identity.ts
+++ b/apps/server/src/services/Identity.ts
@@ -14,6 +14,7 @@ export interface AccountIdentity {
   readonly accountId: string;
   readonly accessToken: string;
   readonly providerId: string;
+  readonly githubLogin: string | null;
   readonly host: string | null;
 }
 

--- a/apps/server/src/services/Review.ts
+++ b/apps/server/src/services/Review.ts
@@ -9,6 +9,7 @@ import type {
   ThreadMessage,
   ThreadStatus,
 } from "@revv/shared";
+import { canUserModifyComment } from "@revv/shared";
 import { and, eq } from "drizzle-orm";
 import { Context, Effect, Layer } from "effect";
 import { commentThreads } from "../db/schema/comment-threads";
@@ -159,6 +160,10 @@ export class ReviewService extends Context.Tag("ReviewService")<
       authorRole: AuthorRole,
     ) => Effect.Effect<CommentThread, ReviewError, DbService>;
     readonly deleteThread: (threadId: string) => Effect.Effect<void, ReviewError, DbService>;
+    readonly deleteThreadAsUser: (
+      threadId: string,
+      actorLogin: string | null,
+    ) => Effect.Effect<void, ReviewError, DbService>;
 
     // Messages
     readonly addMessage: (
@@ -183,6 +188,7 @@ export class ReviewService extends Context.Tag("ReviewService")<
     readonly editMessage: (
       messageId: string,
       body: string,
+      actorLogin: string | null,
     ) => Effect.Effect<ThreadMessage, ReviewError, DbService>;
     /**
      * Delete a reply message that hasn't been synced to GitHub yet.
@@ -195,6 +201,7 @@ export class ReviewService extends Context.Tag("ReviewService")<
      */
     readonly deleteMessage: (
       messageId: string,
+      actorLogin: string | null,
     ) => Effect.Effect<{ threadId: string }, ReviewError, DbService>;
     readonly findMessageByExternalId: (
       externalId: string,
@@ -425,6 +432,53 @@ export const ReviewServiceLive = Layer.succeed(ReviewService, {
       );
     }),
 
+  deleteThreadAsUser: (threadId, actorLogin) =>
+    Effect.gen(function* () {
+      const thread = yield* tryDb("find thread for discard", (db) =>
+        db.select().from(commentThreads).where(eq(commentThreads.id, threadId)).get(),
+      );
+      if (!thread) {
+        return yield* Effect.fail(
+          new ReviewError({ message: "Thread not found", code: "NOT_FOUND" }),
+        );
+      }
+      if (thread.externalCommentId !== null) {
+        return yield* Effect.fail(
+          new ReviewError({
+            message: "Cannot discard a thread already synced to GitHub",
+            code: "FORBIDDEN",
+          }),
+        );
+      }
+
+      const firstMessage = yield* tryDb("find first message for discard", (db) =>
+        db
+          .select()
+          .from(threadMessages)
+          .where(eq(threadMessages.threadId, threadId))
+          .orderBy(threadMessages.createdAt)
+          .limit(1)
+          .get(),
+      );
+      if (!firstMessage) {
+        return yield* Effect.fail(
+          new ReviewError({ message: "Thread has no message", code: "NOT_FOUND" }),
+        );
+      }
+      if (!canUserModifyComment(firstMessage, actorLogin)) {
+        return yield* Effect.fail(
+          new ReviewError({
+            message: "You can only discard your own comments or comments left by Revv",
+            code: "FORBIDDEN",
+          }),
+        );
+      }
+
+      yield* tryDb("delete thread", (db) =>
+        db.delete(commentThreads).where(eq(commentThreads.id, threadId)).run(),
+      );
+    }),
+
   getThreadsForFile: (sessionId, filePath) =>
     Effect.gen(function* () {
       const rows = yield* tryDb("list threads for file", (db) =>
@@ -601,7 +655,7 @@ export const ReviewServiceLive = Layer.succeed(ReviewService, {
         .run(),
     ).pipe(Effect.asVoid),
 
-  editMessage: (messageId, body) =>
+  editMessage: (messageId, body, actorLogin) =>
     Effect.gen(function* () {
       const msgRow = yield* tryDb("find message for edit", (db) =>
         db.select().from(threadMessages).where(eq(threadMessages.id, messageId)).get(),
@@ -613,20 +667,18 @@ export const ReviewServiceLive = Layer.succeed(ReviewService, {
         );
       }
 
-      const threadRow = yield* tryDb("find thread for edit", (db) =>
-        db.select().from(commentThreads).where(eq(commentThreads.id, msgRow.threadId)).get(),
-      );
-
-      if (!threadRow) {
-        return yield* Effect.fail(
-          new ReviewError({ message: "Thread not found", code: "NOT_FOUND" }),
-        );
-      }
-
-      if (threadRow.externalCommentId !== null) {
+      if (msgRow.externalId !== null) {
         return yield* Effect.fail(
           new ReviewError({
             message: "Cannot edit a message that has already been synced to GitHub",
+            code: "FORBIDDEN",
+          }),
+        );
+      }
+      if (!canUserModifyComment(msgRow, actorLogin)) {
+        return yield* Effect.fail(
+          new ReviewError({
+            message: "You can only edit your own comments or comments left by Revv",
             code: "FORBIDDEN",
           }),
         );
@@ -645,7 +697,7 @@ export const ReviewServiceLive = Layer.succeed(ReviewService, {
       return rowToMessage({ ...msgRow, body, editedAt });
     }),
 
-  deleteMessage: (messageId) =>
+  deleteMessage: (messageId, actorLogin) =>
     Effect.gen(function* () {
       const msgRow = yield* tryDb("find message for delete", (db) =>
         db.select().from(threadMessages).where(eq(threadMessages.id, messageId)).get(),
@@ -661,6 +713,14 @@ export const ReviewServiceLive = Layer.succeed(ReviewService, {
         return yield* Effect.fail(
           new ReviewError({
             message: "Cannot discard a reply already synced to GitHub",
+            code: "FORBIDDEN",
+          }),
+        );
+      }
+      if (!canUserModifyComment(msgRow, actorLogin)) {
+        return yield* Effect.fail(
+          new ReviewError({
+            message: "You can only discard your own comments or comments left by Revv",
             code: "FORBIDDEN",
           }),
         );

--- a/apps/server/src/services/Sync.ts
+++ b/apps/server/src/services/Sync.ts
@@ -40,6 +40,7 @@ export class SyncService extends Context.Tag("SyncService")<
   {
     readonly pushThread: (
       threadId: string,
+      userId?: string,
     ) => Effect.Effect<void, SyncError, DbService | SettingsService>;
     readonly pushReply: (
       messageId: string,
@@ -129,13 +130,14 @@ export const SyncServiceLive = Layer.effect(
 
     const pushThread = (
       threadId: string,
+      userId = "single-user",
     ): Effect.Effect<void, SyncError, DbService | SettingsService> =>
       Effect.gen(function* () {
         const thread = yield* reviewService.getThread(threadId);
         if (thread.externalCommentId) return; // already pushed
 
         const sessionPrId = yield* resolvePrIdFromSession(thread.reviewSessionId);
-        const { pr, repo, token, apiBase } = yield* resolvePrContext(sessionPrId);
+        const { pr, repo, token, apiBase } = yield* prContext.resolveBasic(sessionPrId, userId);
 
         if (!pr.headSha) {
           return yield* Effect.fail(

--- a/apps/server/src/services/TokenProvider.ts
+++ b/apps/server/src/services/TokenProvider.ts
@@ -49,7 +49,7 @@ export class TokenProvider extends Context.Tag("TokenProvider")<
       userId: string,
       host?: string,
     ) => Effect.Effect<
-      { accountId: string; accessToken: string; providerId: string },
+      { accountId: string; accessToken: string; providerId: string; githubLogin: string | null },
       GitHubAuthError
     >;
     /**
@@ -315,7 +315,7 @@ export const TokenProviderLive = Layer.effect(
       userId: string,
       host?: string,
     ): Effect.Effect<
-      { accountId: string; accessToken: string; providerId: string },
+      { accountId: string; accessToken: string; providerId: string; githubLogin: string | null },
       GitHubAuthError
     > =>
       Effect.gen(function* () {
@@ -328,6 +328,7 @@ export const TokenProviderLive = Layer.effect(
           .select({
             id: account.id,
             providerId: account.providerId,
+            githubLogin: account.githubLogin,
             accessTokenExpiresAt: account.accessTokenExpiresAt,
           })
           .from(account)
@@ -357,7 +358,12 @@ export const TokenProviderLive = Layer.effect(
             stored.accessToken,
             stored.refreshToken,
           );
-          return { accountId: meta.id, accessToken: token, providerId: meta.providerId };
+          return {
+            accountId: meta.id,
+            accessToken: token,
+            providerId: meta.providerId,
+            githubLogin: meta.githubLogin ?? null,
+          };
         }
         return yield* Effect.fail(new GitHubAuthError({ message: "No access token found" }));
       });

--- a/apps/web/src/lib/components/layout/FloatingTabs.svelte
+++ b/apps/web/src/lib/components/layout/FloatingTabs.svelte
@@ -61,6 +61,26 @@ let dotEl: HTMLSpanElement | null = $state(null);
 let pullBtnEl: HTMLButtonElement | null = $state(null);
 let pulseTl: gsap.core.Timeline | null = null;
 
+// How much room the trailing slot currently needs, handed to PillTabs so it
+// can keep that room inside the pane (see its trailing-slot clamp). The dot
+// is a fixed 6 px; the pull button's width depends on its label, so measure
+// it — `offsetWidth` is layout width, unaffected by the GSAP scale below.
+const STATUS_DOT_SIZE = 6;
+let pullBtnWidth = $state(0);
+
+$effect(() => {
+  const btn = pullBtnEl;
+  if (!btn) return;
+  pullBtnWidth = btn.offsetWidth;
+  const observer = new ResizeObserver(() => {
+    pullBtnWidth = btn.offsetWidth;
+  });
+  observer.observe(btn);
+  return () => observer.disconnect();
+});
+
+const trailingReserve = $derived(buttonVisible ? pullBtnWidth : dotVisible ? STATUS_DOT_SIZE : 0);
+
 // Status-dot visibility (autoAlpha + scale crossfade). Replaces the CSS
 // transitions on `.status-dot { transition: opacity, transform, ... }`.
 $effect(() => {
@@ -119,67 +139,55 @@ $effect(() => {
 });
 </script>
 
-<PillTabs {tabs} {activeTab} onTabChange={handleTabChange} {cmdHeld}>
+<PillTabs {tabs} {activeTab} onTabChange={handleTabChange} {cmdHeld} {trailingReserve}>
 	{#snippet trailing()}
-		<div class="status-slot" aria-hidden={!dotVisible && !buttonVisible}>
-			<span
-				bind:this={dotEl}
-				class="status-dot"
-				class:status-dot--generating={walkthroughStatus === 'generating'}
-				class:status-dot--complete={walkthroughStatus === 'complete'}
-				class:status-dot--error={walkthroughStatus === 'error'}
-				aria-hidden="true"
-			></span>
+		<span
+			bind:this={dotEl}
+			class="status-dot"
+			class:status-dot--generating={walkthroughStatus === 'generating'}
+			class:status-dot--complete={walkthroughStatus === 'complete'}
+			class:status-dot--error={walkthroughStatus === 'error'}
+			aria-hidden="true"
+		></span>
 
-			<button
-				bind:this={pullBtnEl}
-				type="button"
-				class="pull-btn"
-				class:pull-btn--visible={buttonVisible}
-				class:pull-btn--pulling={isPulling}
-				disabled={!buttonInteractive}
-				tabindex={buttonVisible && !isPulling ? 0 : -1}
-				aria-hidden={!buttonVisible}
-				onclick={handlePullClick}
-				title={isPulling ? 'Pulling new commit…' : 'New commit. Click to pull.'}
-				aria-label={isPulling
-					? 'Pulling new commit'
-					: 'New commit available. Click to pull the latest changes.'}
-			>
-				{#if isPulling}
-					<Loader2 size={12} weight="regular" class="motion-essential-spin" />
-				{:else}
-					<DownloadCloud size={12} weight="fill" />
-				{/if}
-				<span class="pull-btn-label">Pull</span>
-			</button>
-		</div>
+		<button
+			bind:this={pullBtnEl}
+			type="button"
+			class="pull-btn"
+			class:pull-btn--visible={buttonVisible}
+			class:pull-btn--pulling={isPulling}
+			disabled={!buttonInteractive}
+			tabindex={buttonVisible && !isPulling ? 0 : -1}
+			aria-hidden={!buttonVisible}
+			onclick={handlePullClick}
+			title={isPulling ? 'Pulling new commit…' : 'New commit. Click to pull.'}
+			aria-label={isPulling
+				? 'Pulling new commit'
+				: 'New commit available. Click to pull the latest changes.'}
+		>
+			{#if isPulling}
+				<Loader2 size={12} weight="regular" class="motion-essential-spin" />
+			{:else}
+				<DownloadCloud size={12} weight="fill" />
+			{/if}
+			<span class="pull-btn-label">Pull</span>
+		</button>
 	{/snippet}
 </PillTabs>
 
 <style>
 	/*
-	 * Status slot — anchored to the right of the pill. Holds two stacked
-	 * children (the walkthrough-status dot and the pull button). The slot
-	 * is `position: absolute` so it never pushes the centered tabs wrapper
-	 * leftward when the button appears.
+	 * Both children render into PillTabs' `.status-slot` — an absolutely
+	 * positioned, zero-width anchor hanging off the pill's right edge (it
+	 * stays out of flow so the pull button appearing never pushes the
+	 * centered tabs wrapper leftward). PillTabs also keeps the anchor
+	 * inside its container, so neither child gets clipped by the pane.
 	 *
-	 * The two children are also `position: absolute` with `left: 0`, so
-	 * they occupy the same anchor and crossfade via opacity + scale.
-	 * Only one is visible at a time; the other sits invisible and
-	 * non-interactive underneath.
+	 * The two children are `position: absolute` with `left: 0`, so they
+	 * occupy the same anchor and crossfade via opacity + scale. Only one
+	 * is visible at a time; the other sits invisible and non-interactive
+	 * underneath.
 	 */
-	.status-slot {
-		position: absolute;
-		left: calc(100% + var(--spacing-island));
-		top: 50%;
-		/* Height matches the tallest child (the 18 px button) so the
-		 * slot's center line — which both children align to — stays fixed
-		 * regardless of which one is currently visible. */
-		height: 18px;
-		transform: translateY(-50%);
-		pointer-events: none;
-	}
 
 	/* ── Walkthrough status dot (6 × 6, centered in the slot) ──
 	   Visibility, scale, and the generating-pulse loop are all driven by GSAP

--- a/apps/web/src/lib/components/layout/PillTabs.svelte
+++ b/apps/web/src/lib/components/layout/PillTabs.svelte
@@ -10,10 +10,25 @@ interface Props {
   onTabChange: (tab: string) => void;
   trailing?: Snippet;
   cmdHeld?: boolean;
+  /**
+   * Width, in px, of whatever the `trailing` snippet is currently showing —
+   * 0 when it shows nothing. The snippet's content is out of flow, so this
+   * is the only way PillTabs can know how much room to keep for it to the
+   * right of the pill. See the trailing-slot clamp below.
+   */
+  trailingReserve?: number;
 }
 
-let { tabs, activeTab, onTabChange, trailing, cmdHeld = false }: Props = $props();
+let {
+  tabs,
+  activeTab,
+  onTabChange,
+  trailing,
+  cmdHeld = false,
+  trailingReserve = 0,
+}: Props = $props();
 
+let wrapperEl: HTMLDivElement | null = $state(null);
 let pillEl: HTMLDivElement | null = $state(null);
 let indicatorEl: HTMLSpanElement | null = $state(null);
 let segmentEls = $state<(HTMLButtonElement | null)[]>([]);
@@ -77,6 +92,74 @@ function isDividerHidden(index: number): boolean {
   return index === highlighted || index + 1 === highlighted;
 }
 
+// ── Trailing-slot clamp ──
+// The trailing slot is out of flow (see `.status-slot` below), so the pill
+// stays centred in its container no matter what the slot holds. The cost is
+// that the slot's content hangs past the wrapper's right edge, and the
+// container — a floating bar inside an `overflow: hidden` pane — clips it once
+// the pane gets narrow. That is what used to slice the walkthrough status dot
+// in half with the sidebar and the context panel both open.
+//
+// So: nudge the whole wrapper left by exactly the amount that would otherwise
+// overflow. Zero shift whenever there is room, which is the common case.
+const TRAILING_GAP = 8;
+const EDGE_GAP = 8;
+let shift = 0;
+let hasClamped = false;
+
+$effect(() => {
+  const wrapper = wrapperEl;
+  const container = wrapper?.parentElement;
+  const reserve = trailingReserve;
+  if (!wrapper || !container) return;
+
+  // `animate` is true only when the slot's content changed size, where the
+  // pill easing out of the way reads as motion. Container-driven measures
+  // (window resize, panel drag) snap instead — a tween there would trail the
+  // pointer for the whole drag.
+  const measure = (animate: boolean) => {
+    const containerRect = container.getBoundingClientRect();
+    const wrapperRect = wrapper.getBoundingClientRect();
+    // Back the applied translation out of the measurement so it reads the
+    // wrapper's natural (centred) position and can't feed back on itself.
+    // Read it from GSAP rather than from `shift`: mid-tween the two differ.
+    const applied = Number(gsap.getProperty(wrapper, "x")) || 0;
+    const naturalLeft = wrapperRect.left - applied;
+    const naturalRight = wrapperRect.right - applied;
+    // Nothing in the slot means nothing to protect — leave the pill centred
+    // even if it is itself wider than the container.
+    const needed = reserve > 0 ? TRAILING_GAP + reserve : 0;
+    const overflow = needed > 0 ? naturalRight + needed - (containerRect.right - EDGE_GAP) : 0;
+    // Never shift so far that the pill's own left edge leaves the container:
+    // clipping the trailing content beats clipping a tab label. No EDGE_GAP on
+    // this side — in a pane this tight, letting the pill sit flush against the
+    // left edge is what buys the trailing content the room to stay whole.
+    const headroom = Math.max(0, naturalLeft - containerRect.left);
+    const next = Math.max(0, Math.min(overflow, headroom));
+    if (Math.abs(next - shift) < 0.5) return;
+    shift = next;
+    if (!animate || prefersReducedMotion()) {
+      gsap.set(wrapper, { x: -shift });
+      return;
+    }
+    gsap.to(wrapper, {
+      x: -shift,
+      duration: tokens.smooth,
+      ease: tokens.easeOutExpo,
+      overwrite: "auto",
+    });
+  };
+
+  // First run is initial layout, so it lands without motion.
+  measure(hasClamped);
+  hasClamped = true;
+
+  const observer = new ResizeObserver(() => measure(false));
+  observer.observe(container);
+  observer.observe(wrapper);
+  return () => observer.disconnect();
+});
+
 // Cmd-hold shortcut hint reveal. Animates the ⌘N labels next to each tab
 // label when the user holds Cmd. Reveal/hide are simultaneous across all
 // segments and symmetric in easing: a modifier-key hint should feel like
@@ -102,7 +185,7 @@ $effect(() => {
 });
 </script>
 
-<div class="tabs-wrapper">
+<div class="tabs-wrapper" bind:this={wrapperEl}>
 	<div class="pill" bind:this={pillEl}>
 		<span
 			class="pill-indicator"
@@ -145,6 +228,14 @@ $effect(() => {
 		align-items: center;
 	}
 
+	/* Anchor for the trailing content, hanging off the pill's right edge.
+	   Out of flow so its contents never push the centred pill sideways;
+	   zero-width, so consumers position their own children against it with
+	   `position: absolute; left: 0`. `height` matches the tallest expected
+	   child (an 18 px pill button) so the centre line those children align
+	   to stays fixed regardless of which one is showing. The clamp effect
+	   above keeps this anchor inside the container. Keep `left` in sync with
+	   TRAILING_GAP. */
 	.status-slot {
 		position: absolute;
 		left: calc(100% + 8px);

--- a/apps/web/src/lib/components/layout/TopBar.svelte
+++ b/apps/web/src/lib/components/layout/TopBar.svelte
@@ -14,7 +14,6 @@ import {
   type ThemePreference,
 } from "$lib/stores/theme.svelte";
 import { getTopbarSubtitle } from "$lib/stores/topbar.svelte";
-import FloatingTabs from "./FloatingTabs.svelte";
 
 interface Props {
   rightPanelOpen: boolean;

--- a/apps/web/src/lib/components/review/AnnotationThread.svelte
+++ b/apps/web/src/lib/components/review/AnnotationThread.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
-import type { CommentThread, ThreadMessage } from "@revv/shared";
+import { type CommentThread, canUserModifyComment, type ThreadMessage } from "@revv/shared";
 import CornerDownLeft from "phosphor-svelte/lib/ArrowElbowDownLeft";
 import Clock from "phosphor-svelte/lib/Clock";
+import PaperPlaneTilt from "phosphor-svelte/lib/PaperPlaneTilt";
+import type { Attachment } from "svelte/attachments";
+import { getCurrentUserLogin } from "$lib/stores/auth.svelte";
 import { formatRelativeTime } from "$lib/utils/format-relative-time";
 import { renderMarkdown } from "$lib/utils/markdown";
 import AnnotationCommentInput from "./AnnotationCommentInput.svelte";
@@ -18,6 +21,7 @@ interface Props {
   onCollapse?: (() => void) | undefined;
   onApplySuggestion?: (suggestion: string) => void;
   onEditMessage?: (messageId: string, body: string) => void;
+  onPush?: (() => void | Promise<void>) | undefined;
   isReplying?: boolean;
   onReplySubmit?: (body: string) => void;
   onReplyDismiss?: () => void;
@@ -35,6 +39,7 @@ let {
   onCollapse,
   onApplySuggestion,
   onEditMessage,
+  onPush,
   isReplying = false,
   onReplySubmit,
   onReplyDismiss,
@@ -42,6 +47,16 @@ let {
 }: Props = $props();
 
 const isResolved = $derived(thread.status === "resolved" || thread.status === "wont_fix");
+const currentUserLogin = $derived(getCurrentUserLogin());
+const firstMessage = $derived(messages[0] ?? null);
+const canDiscardThread = $derived(
+  isPending && firstMessage !== null && canUserModifyComment(firstMessage, currentUserLogin),
+);
+const canPushThread = $derived(canDiscardThread && onPush !== undefined);
+
+function canModifyMessage(message: ThreadMessage): boolean {
+  return canUserModifyComment(message, currentUserLogin);
+}
 
 // ── Pending (unsynced) reply detection ────────────────────────────────────
 // A reply is "pending" once submitted but before the sync loop has pushed it
@@ -54,7 +69,7 @@ const pendingReply = $derived.by((): ThreadMessage | null => {
   if (isPending) return null;
   for (let i = messages.length - 1; i > 0; i--) {
     const m = messages[i];
-    if (m && m.externalId === null) return m;
+    if (m && canModifyMessage(m)) return m;
   }
   return null;
 });
@@ -63,6 +78,7 @@ const pendingReply = $derived.by((): ThreadMessage | null => {
 
 let editingMessageId = $state<string | null>(null);
 let editBody = $state("");
+let isPushing = $state(false);
 
 function startEdit(msg: ThreadMessage): void {
   editingMessageId = msg.id;
@@ -83,10 +99,29 @@ function cancelEdit(): void {
   editingMessageId = null;
 }
 
-function focusOnMount(node: HTMLTextAreaElement) {
-  node.focus();
-  node.setSelectionRange(node.value.length, node.value.length);
+async function pushToGitHub(): Promise<void> {
+  if (!onPush || isPushing) return;
+  isPushing = true;
+  try {
+    await onPush();
+  } finally {
+    isPushing = false;
+  }
 }
+
+const autoSizeEditTextarea: Attachment<HTMLTextAreaElement> = (node) => {
+  function resize(): void {
+    node.style.height = "auto";
+    node.style.height = `${node.scrollHeight}px`;
+  }
+
+  resize();
+  node.focus({ preventScroll: true });
+  node.setSelectionRange(node.value.length, node.value.length);
+  node.addEventListener("input", resize);
+
+  return () => node.removeEventListener("input", resize);
+};
 </script>
 
 <div
@@ -113,7 +148,7 @@ function focusOnMount(node: HTMLTextAreaElement) {
 				<span class="timestamp">{formatRelativeTime(msg.createdAt)}</span>
 			</div>
 
-			{#if isPending && i === 0}
+			{#if canModifyMessage(msg)}
 				{#if editingMessageId === msg.id}
 					<div class="msg-edit">
 						<textarea
@@ -124,7 +159,7 @@ function focusOnMount(node: HTMLTextAreaElement) {
 								if (e.key === 'Escape') cancelEdit();
 								else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) saveEdit();
 							}}
-							use:focusOnMount
+							{@attach autoSizeEditTextarea}
 						></textarea>
 						<div class="edit-actions">
 							<button class="edit-save-btn" onclick={saveEdit} disabled={!editBody.trim()}>Save</button>
@@ -182,6 +217,16 @@ function focusOnMount(node: HTMLTextAreaElement) {
 	{/if}
 
 	<div class="thread-footer">
+		{#if canPushThread}
+			<button
+				class="footer-link footer-link--send"
+				onclick={pushToGitHub}
+				disabled={isPushing}
+			>
+				<PaperPlaneTilt size={12} weight="fill" aria-hidden="true" />
+				{isPushing ? 'Sending…' : 'Send to GitHub'}
+			</button>
+		{/if}
 		{#if !isResolved && onReply}
 			<button
 				class="footer-link"
@@ -192,7 +237,7 @@ function focusOnMount(node: HTMLTextAreaElement) {
 				{isReplying ? 'Cancel' : 'Add reply...'}
 			</button>
 		{/if}
-		{#if isPending && onDiscard}
+		{#if canDiscardThread && onDiscard}
 			<button
 				class="footer-link footer-link--danger"
 				onclick={onDiscard}
@@ -359,6 +404,16 @@ function focusOnMount(node: HTMLTextAreaElement) {
 		text-underline-offset: 2px;
 	}
 
+	.footer-link:disabled {
+		cursor: default;
+		opacity: 0.6;
+		text-decoration: none;
+	}
+
+	.footer-link--send {
+		font-weight: 500;
+	}
+
 	.footer-link--muted {
 		color: var(--color-text-muted);
 	}
@@ -421,7 +476,11 @@ function focusOnMount(node: HTMLTextAreaElement) {
 		transition: background-color var(--duration-instant) var(--ease-soft);
 	}
 	.msg-body--editable:hover {
-		background: var(--color-bg-tertiary);
+		background: color-mix(
+			in srgb,
+			var(--color-bg-tertiary) 55%,
+			var(--color-thread-bg)
+		);
 	}
 	.msg-edit {
 		display: flex;
@@ -439,7 +498,8 @@ function focusOnMount(node: HTMLTextAreaElement) {
 		font-size: 13px;
 		line-height: 1.6;
 		color: var(--color-text-primary);
-		resize: vertical;
+		resize: none;
+		overflow-y: hidden;
 		outline: none;
 		box-sizing: border-box;
 		transition: box-shadow var(--duration-quick) var(--ease-out-expo);

--- a/apps/web/src/lib/components/review/DiffViewer.svelte
+++ b/apps/web/src/lib/components/review/DiffViewer.svelte
@@ -13,6 +13,7 @@ import {
   getThreadMessages,
   getThreadsForFile,
   getThreadsVersion,
+  pushThreadToGitHub,
   reopenThread,
   resolveThread,
 } from "$lib/stores/review.svelte";
@@ -264,6 +265,10 @@ async function handleApplySuggestion(threadId: string, suggestion: string) {
 async function handleEditMessage(threadId: string, messageId: string, body: string) {
   await editThreadMessage(threadId, messageId, body);
 }
+
+async function handlePushThread(threadId: string) {
+  await pushThreadToGitHub(threadId);
+}
 </script>
 
 {#if file}
@@ -287,6 +292,7 @@ async function handleEditMessage(threadId: string, messageId: string, body: stri
 			{onTokenHover}
 			onApplySuggestion={handleApplySuggestion}
 			onEditMessage={handleEditMessage}
+			onPushThread={handlePushThread}
 			{scrollRoot}
 		/>
 	{/key}

--- a/apps/web/src/lib/components/review/DiffViewerInner.svelte
+++ b/apps/web/src/lib/components/review/DiffViewerInner.svelte
@@ -77,6 +77,7 @@ interface Props {
   onTokenHover?: ((info: TokenHoverInfo | null) => void) | undefined;
   onApplySuggestion?: ((threadId: string, suggestion: string) => void) | undefined;
   onEditMessage?: ((threadId: string, messageId: string, body: string) => void) | undefined;
+  onPushThread?: ((threadId: string) => void | Promise<void>) | undefined;
   scrollRoot?: HTMLElement | null;
 }
 
@@ -100,6 +101,7 @@ let {
   onTokenHover,
   onApplySuggestion,
   onEditMessage,
+  onPushThread,
   scrollRoot = null,
 }: Props = $props();
 
@@ -574,6 +576,7 @@ onMount(() => {
             onApplySuggestion,
             onReplySubmit,
             onEditMessage,
+            onPushThread,
           });
         } else {
           host.appendChild(createMarkerDot(meta, () => onAnnotationToggle?.(meta.threadId)));

--- a/apps/web/src/lib/components/review/FileViewer.svelte
+++ b/apps/web/src/lib/components/review/FileViewer.svelte
@@ -21,6 +21,7 @@ import {
   getThreadMessages,
   getThreadsForFile,
   getThreadsVersion,
+  pushThreadToGitHub,
   reopenThread,
   resolveThread,
 } from "$lib/stores/review.svelte";
@@ -231,6 +232,10 @@ async function handleApplySuggestion(threadId: string, suggestion: string) {
 async function handleEditMessage(threadId: string, messageId: string, body: string) {
   await editThreadMessage(threadId, messageId, body);
 }
+
+async function handlePushThread(threadId: string) {
+  await pushThreadToGitHub(threadId);
+}
 </script>
 
 <!--
@@ -286,6 +291,7 @@ async function handleEditMessage(threadId: string, messageId: string, body: stri
 			{onTokenHover}
 			onApplySuggestion={handleApplySuggestion}
 			onEditMessage={handleEditMessage}
+			onPushThread={handlePushThread}
 			{scrollRoot}
 		/>
 	{/key}

--- a/apps/web/src/lib/components/review/FileViewerInner.svelte
+++ b/apps/web/src/lib/components/review/FileViewerInner.svelte
@@ -88,6 +88,7 @@ export interface TokenHoverInfo {
 		onTokenHover?: ((info: TokenHoverInfo | null) => void) | undefined;
 		onApplySuggestion?: ((threadId: string, suggestion: string) => void) | undefined;
 		onEditMessage?: ((threadId: string, messageId: string, body: string) => void) | undefined;
+		onPushThread?: ((threadId: string) => void | Promise<void>) | undefined;
 		scrollRoot?: HTMLElement | null;
 	}
 
@@ -111,6 +112,7 @@ export interface TokenHoverInfo {
 		onTokenHover,
 		onApplySuggestion,
 		onEditMessage,
+		onPushThread,
 		scrollRoot = null,
 	}: Props = $props();
 
@@ -309,6 +311,7 @@ export interface TokenHoverInfo {
 							onApplySuggestion,
 							onReplySubmit,
 							onEditMessage,
+							onPushThread,
 						});
 					} else {
 						host.appendChild(

--- a/apps/web/src/lib/components/review/RequestChanges.svelte
+++ b/apps/web/src/lib/components/review/RequestChanges.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { isPublishableDraftComment } from "@revv/shared";
 import { toast } from "svelte-sonner";
 import { api } from "$lib/api/client";
 import WalkthroughRatingsPanel from "$lib/components/walkthrough/WalkthroughRatingsPanel.svelte";
@@ -83,11 +84,7 @@ const selectedCount = $derived(selectedIssueIds.size);
 // Mirrors the filtering in buildComments() so the Comment button's enabled
 // state matches what gets sent.
 const pendingCommentCount = $derived(
-  unresolvedThreads.filter((t) =>
-    getThreadMessages(t.id).some(
-      (m) => m.authorRole === "reviewer" && m.externalId == null && m.body.trim().length > 0,
-    ),
-  ).length,
+  unresolvedThreads.filter((t) => getThreadMessages(t.id).some(isPublishableDraftComment)).length,
 );
 // A plain COMMENT review can go up with selected issues OR pending comments.
 const canComment = $derived(selectedCount > 0 || pendingCommentCount > 0);
@@ -159,9 +156,7 @@ function buildComments(): Array<{
     // the user can remove with the Discard button. Skip the check when the
     // diff hasn't loaded (empty set) so valid comments are never dropped.
     if (currentFilePaths.size > 0 && !currentFilePaths.has(thread.filePath)) continue;
-    const messages = getThreadMessages(thread.id).filter(
-      (m) => m.authorRole === "reviewer" && m.externalId == null,
-    );
+    const messages = getThreadMessages(thread.id).filter(isPublishableDraftComment);
     const body = messages
       .map((m) => m.body)
       .filter((b) => b.trim().length > 0)

--- a/apps/web/src/lib/components/review/annotation-renderers.ts
+++ b/apps/web/src/lib/components/review/annotation-renderers.ts
@@ -51,6 +51,7 @@ export interface MountThreadArgs {
   onApplySuggestion?: ((threadId: string, suggestion: string) => void) | undefined;
   onReplySubmit?: ((threadId: string, body: string) => void) | undefined;
   onEditMessage?: ((threadId: string, messageId: string, body: string) => void) | undefined;
+  onPushThread?: ((threadId: string) => void | Promise<void>) | undefined;
 }
 
 /**
@@ -74,6 +75,7 @@ export function mountAnnotationThread(host: HTMLElement, args: MountThreadArgs):
     onApplySuggestion,
     onReplySubmit,
     onEditMessage,
+    onPushThread,
   } = args;
 
   mountInto(host, AnnotationThread, {
@@ -91,5 +93,6 @@ export function mountAnnotationThread(host: HTMLElement, args: MountThreadArgs):
     onReplySubmit: (body: string) => onReplySubmit?.(threadId, body),
     onReplyDismiss: () => onReplyToggle?.(threadId),
     onEditMessage: (messageId: string, body: string) => onEditMessage?.(threadId, messageId, body),
+    onPush: onPushThread ? () => onPushThread(threadId) : undefined,
   });
 }

--- a/apps/web/src/lib/components/review/comments-panel/CommentExpandedBody.svelte
+++ b/apps/web/src/lib/components/review/comments-panel/CommentExpandedBody.svelte
@@ -8,9 +8,10 @@
  * thin left guide.
  */
 
-import type { CommentThread, ThreadMessage } from "@revv/shared";
+import { type CommentThread, canUserModifyComment, type ThreadMessage } from "@revv/shared";
 import ArrowUpRight from "phosphor-svelte/lib/ArrowUpRight";
 import Trash from "phosphor-svelte/lib/Trash";
+import { getCurrentUserLogin } from "$lib/stores/auth.svelte";
 import { isHighlighterReady } from "$lib/utils/code-highlight.svelte";
 import { formatRelativeTime } from "$lib/utils/format-relative-time";
 import { renderMarkdown } from "$lib/utils/markdown";
@@ -26,6 +27,7 @@ interface Props {
 }
 
 let { threads, getThreadMessages, onJump, onDiscard }: Props = $props();
+const currentUserLogin = $derived(getCurrentUserLogin());
 
 // Flatten to a render-ready shape so the template doesn't recompute on
 // every iteration. Re-derive when the shiki highlighter becomes ready
@@ -65,7 +67,7 @@ const renderedThreads = $derived.by(() => {
                         <ArrowUpRight size={11} weight="fill" aria-hidden="true" />
                     </button>
                 {/if}
-                {#if onDiscard && entry.thread.externalCommentId == null}
+                {#if onDiscard && entry.thread.externalCommentId == null && entry.messages[0] && canUserModifyComment(entry.messages[0], currentUserLogin)}
                     <button
                         type="button"
                         class="thread-discard"

--- a/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
+++ b/apps/web/src/lib/components/walkthrough/GuidedWalkthrough.svelte
@@ -33,6 +33,7 @@ import {
   getPendingWalkthroughBlockJump,
   getReviewMode,
   jumpToDiffLine,
+  reviewLatestCommit,
 } from "$lib/stores/review.svelte";
 import { openSettings } from "$lib/stores/settingsModal.svelte";
 import { getResolvedTheme } from "$lib/stores/theme.svelte";
@@ -346,7 +347,7 @@ $effect(() => {
     description: "The PR has new commits since this review was generated.",
     action: {
       label: "Review new commits",
-      onClick: () => handleRegenerate(),
+      onClick: () => reviewLatestCommit(prId, selectedMode),
     },
     duration: Number.POSITIVE_INFINITY,
   });

--- a/apps/web/src/lib/review/review-new-commits.test.ts
+++ b/apps/web/src/lib/review/review-new-commits.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { reviewNewCommits } from "./review-new-commits";
+
+describe("reviewNewCommits", () => {
+  it("waits for the fresh diff before starting the incremental review", async () => {
+    const calls: string[] = [];
+
+    await reviewNewCommits({
+      pull: async () => {
+        calls.push("pull");
+        return true;
+      },
+      regenerate: async () => {
+        calls.push("regenerate");
+      },
+    });
+
+    expect(calls).toEqual(["pull", "regenerate"]);
+  });
+
+  it("does not regenerate when refreshing the diff fails", async () => {
+    let regenerated = false;
+
+    await reviewNewCommits({
+      pull: async () => false,
+      regenerate: async () => {
+        regenerated = true;
+      },
+    });
+
+    expect(regenerated).toBe(false);
+  });
+});

--- a/apps/web/src/lib/review/review-new-commits.ts
+++ b/apps/web/src/lib/review/review-new-commits.ts
@@ -1,0 +1,10 @@
+interface ReviewNewCommitsActions {
+  pull: () => Promise<boolean>;
+  regenerate: () => Promise<void>;
+}
+
+/** Refresh the visible diff before reviewing the new head. */
+export async function reviewNewCommits(actions: ReviewNewCommitsActions): Promise<void> {
+  const pulled = await actions.pull();
+  if (pulled) await actions.regenerate();
+}

--- a/apps/web/src/lib/stores/review.svelte.ts
+++ b/apps/web/src/lib/stores/review.svelte.ts
@@ -8,11 +8,12 @@ import type {
 } from "@revv/shared";
 import { toast } from "svelte-sonner";
 import { api } from "$lib/api/client";
+import { reviewNewCommits } from "$lib/review/review-new-commits";
 import { RequestState, type RequestState as RequestStateType } from "$lib/stores/_types";
 import { invalidateChatHistory } from "$lib/stores/chat.svelte";
 import { enterSidebarMode } from "$lib/stores/focus-mode.svelte";
 import { getPullRequests, getReviewModeForPr } from "$lib/stores/prs.svelte";
-import { invalidateForPull } from "$lib/stores/walkthrough.svelte";
+import { invalidateForPull, regenerate } from "$lib/stores/walkthrough.svelte";
 import type { ReviewFile } from "$lib/types/review";
 
 // --- Review files (shared between sidebar tree + review page) ---
@@ -109,6 +110,7 @@ export function getLoadedHeadSha(prId: string): string | null {
 // racing a second click. Set-reassignment for reactivity, matching the
 // loadedHeadShas pattern above.
 let isPullingCommit = $state(new Set<string>());
+const pullCommitRequests = new Map<string, Promise<boolean>>();
 
 export function getIsPullingCommit(prId: string): boolean {
   return isPullingCommit.has(prId);
@@ -123,16 +125,30 @@ function apiErrorMessage(error: { status: number; value?: unknown }, fallback: s
 
 /**
  * Refetch the PR's diff files against the current `pr.headSha`, restamp
- * the loaded SHA, and regenerate the walkthrough against the new content.
+ * the loaded SHA, and invalidate the walkthrough against the old content.
  * The server's PollScheduler has already invalidated + repopulated its diff
  * cache on SHA change, so the `files.get()` call returns the fresh diff.
- * Coalesces concurrent calls for the same PR.
+ * Coalesces concurrent calls for the same PR and resolves true only when the
+ * fresh diff has been installed successfully.
  */
-export async function pullLatestCommit(prId: string): Promise<void> {
-  if (isPullingCommit.has(prId)) return;
+export function pullLatestCommit(prId: string): Promise<boolean> {
+  const inFlight = pullCommitRequests.get(prId);
+  if (inFlight) return inFlight;
+
   isPullingCommit.add(prId);
   isPullingCommit = new Set(isPullingCommit);
 
+  const request = runPullLatestCommit(prId).finally(() => {
+    pullCommitRequests.delete(prId);
+    setIsLoadingFiles(false);
+    isPullingCommit.delete(prId);
+    isPullingCommit = new Set(isPullingCommit);
+  });
+  pullCommitRequests.set(prId, request);
+  return request;
+}
+
+async function runPullLatestCommit(prId: string): Promise<boolean> {
   try {
     setIsLoadingFiles(true);
     setFilesError(null);
@@ -180,13 +196,22 @@ export async function pullLatestCommit(prId: string): Promise<void> {
     // and unblocks the page immediately — we no longer await the SSE stream.
     await invalidateForPull(prId);
     invalidateChatHistory(prId);
+    return true;
   } catch (e) {
     setFilesError(e instanceof Error ? e.message : "Failed to pull latest commit");
-  } finally {
-    setIsLoadingFiles(false);
-    isPullingCommit.delete(prId);
-    isPullingCommit = new Set(isPullingCommit);
+    return false;
   }
+}
+
+/**
+ * Pull the current head through the same path as the tab-side Pull button,
+ * then start the incremental walkthrough requested by the superseded toast.
+ */
+export async function reviewLatestCommit(prId: string, mode: ReviewMode): Promise<void> {
+  await reviewNewCommits({
+    pull: () => pullLatestCommit(prId),
+    regenerate: () => regenerate(prId, mode, "incremental"),
+  });
 }
 
 // --- Session state ---

--- a/apps/web/src/lib/stores/review.svelte.ts
+++ b/apps/web/src/lib/stores/review.svelte.ts
@@ -760,6 +760,22 @@ export async function deleteThread(threadId: string): Promise<boolean> {
   return true;
 }
 
+/** Push one local draft comment to GitHub under the active account's identity. */
+export async function pushThreadToGitHub(threadId: string): Promise<boolean> {
+  const { error } = await api.api.threads({ id: threadId }).push.post();
+  if (error) {
+    toast.error("Failed to send comment to GitHub");
+    return false;
+  }
+
+  const prId = store.activePrId;
+  if (prId !== null) {
+    await loadSession(prId, undefined, true);
+  }
+  toast.success("Comment sent to GitHub");
+  return true;
+}
+
 /**
  * Remove a thread from local state in response to an SSE broadcast.
  */

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "scripts": {
+    "prepare": "./scripts/prepare-effect.sh",
     "dev": "turbo run dev",
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",

--- a/packages/shared/src/comment-permissions.ts
+++ b/packages/shared/src/comment-permissions.ts
@@ -1,0 +1,37 @@
+export interface CommentPermissionMessage {
+  readonly authorRole: string;
+  readonly authorLogin: string | null;
+  readonly externalId: string | null;
+}
+
+export interface DraftReviewMessage extends CommentPermissionMessage {
+  readonly body: string;
+}
+
+function normalizeLogin(login: string): string {
+  return login.trim().toLowerCase();
+}
+
+/**
+ * A local draft can be edited or discarded by the signed-in user when Revv
+ * authored it, or when its provider login matches the active account.
+ * GitHub-backed messages are immutable in Revv and must be edited on GitHub.
+ */
+export function canUserModifyComment(
+  message: CommentPermissionMessage,
+  currentUserLogin: string | null,
+): boolean {
+  if (message.externalId !== null) return false;
+  if (message.authorRole === "ai_agent") return true;
+  if (!message.authorLogin || !currentUserLogin) return false;
+  return normalizeLogin(message.authorLogin) === normalizeLogin(currentUserLogin);
+}
+
+/** A local human or Revv-authored draft that can be included in a GitHub review. */
+export function isPublishableDraftComment(message: DraftReviewMessage): boolean {
+  return (
+    message.externalId === null &&
+    (message.authorRole === "reviewer" || message.authorRole === "ai_agent") &&
+    message.body.trim().length > 0
+  );
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -68,6 +68,12 @@ export {
   MAX_CHAT_ATTACHMENTS_COUNT,
   MAX_CHAT_ATTACHMENTS_TOTAL_BYTES,
 } from "./chat";
+export {
+  type CommentPermissionMessage,
+  canUserModifyComment,
+  type DraftReviewMessage,
+  isPublishableDraftComment,
+} from "./comment-permissions";
 export type { AppChannel, UpdateChannel } from "./constants";
 export {
   API_BASE_URL,

--- a/scripts/prepare-effect.sh
+++ b/scripts/prepare-effect.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -eu
+
+repo_dir=".repos/effect"
+repo_url="https://github.com/Effect-TS/effect-smol"
+
+if [ -d "$repo_dir/.git" ]; then
+  exit 0
+fi
+
+mkdir -p ".repos"
+git clone "$repo_url" "$repo_dir"


### PR DESCRIPTION
The "Review new commits" action on the superseded-walkthrough toast called `handleRegenerate()` directly, so the incremental walkthrough ran against the stale diff still loaded in the page — the toast and the tab-side Pull button did different things. It now routes through `reviewLatestCommit()`, which pulls the new head first and only starts the incremental regeneration once the fresh diff is installed.

To make that sequencing possible, `pullLatestCommit()` returns a `Promise<boolean>` and coalesces concurrent callers on a shared in-flight promise, so a second caller awaits the same pull instead of returning early with no signal about the outcome. The ordering rule itself lives in `$lib/review/review-new-commits.ts` with unit tests covering both the happy path and the pull-failed case.

Also adds an unrelated dev-tooling commit: a `prepare` script that clones `Effect-TS/effect-smol` into a gitignored `.repos/effect` for local reference. Note this runs on every `bun install`, including CI — happy to drop that commit if it wasn't meant for this PR.