### PR TITLE
fix: update fallback Rust toolchain handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,18 +116,30 @@ dist: ## Build the Revv.app bundle used by the source installer
 	@printf "  Step 2/3: Building web frontend + API server\n"
 	bun run build
 	@printf "  Step 3/3: Building Tauri desktop bundle (.app only)\n"
-	# --bundles app skips the DMG. Revv is distributed via source install,
-	# not via a signed DMG, and tauri-bundler's bundle_dmg.sh has been flaky
-	# on machines where it's blocked from Finder/AppleEvents. Use `make dmg`
-	# explicitly if you actually need the .dmg.
-	#
-	# createUpdaterArtifacts is true in tauri.conf.json so CI-signed release
-	# builds emit a signed .app.tar.gz for the updater. This target runs on
-	# end-user/dev machines (install.sh and `revv update`'s local-build
-	# fallback) that never hold TAURI_SIGNING_PRIVATE_KEY, so it's overridden
-	# off here — otherwise the bundler hard-fails with "public key has been
-	# found, but no private key".
-	cd apps/desktop && bunx tauri build --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'
+	@if ! command -v cargo >/dev/null 2>&1; then \
+		if command -v bash >/dev/null 2>&1 && [ -f scripts/lib/common.sh ]; then \
+			bash -c 'set -euo pipefail; source scripts/lib/common.sh; detect_platform; ensure_xcode_clt; ensure_rust'; \
+		else \
+			printf "\n\033[0;31m  ✗ cargo not found.\033[0m\n"; \
+			printf "  Install Rust/Cargo, then rerun this command:\n"; \
+			printf "    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh\n\n"; \
+			printf "  If Rust is already installed, refresh this shell first:\n"; \
+			printf "    source $$HOME/.cargo/env\n\n"; \
+			exit 1; \
+		fi; \
+	fi
+	@# --bundles app skips the DMG. Revv is distributed via source install,
+	@# not via a signed DMG, and tauri-bundler's bundle_dmg.sh has been flaky
+	@# on machines where it's blocked from Finder/AppleEvents. Use `make dmg`
+	@# explicitly if you actually need the .dmg.
+	@#
+	@# createUpdaterArtifacts is true in tauri.conf.json so CI-signed release
+	@# builds emit a signed .app.tar.gz for the updater. This target runs on
+	@# end-user/dev machines (install.sh and `revv update`'s local-build
+	@# fallback) that never hold TAURI_SIGNING_PRIVATE_KEY, so it's overridden
+	@# off here -- otherwise the bundler hard-fails with "public key has been
+	@# found, but no private key".
+	@export PATH="$$HOME/.cargo/bin:$$PATH"; cd apps/desktop && bunx tauri build --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'
 	@printf "\n\033[1m\033[32m  Build complete!\033[0m\n"
 	@printf "  Bundle located in: apps/desktop/target/release/bundle/macos/\n\n"
 

--- a/apps/web/src/lib/stores/review.svelte.ts
+++ b/apps/web/src/lib/stores/review.svelte.ts
@@ -13,12 +13,7 @@ import { RequestState, type RequestState as RequestStateType } from "$lib/stores
 import { invalidateChatHistory } from "$lib/stores/chat.svelte";
 import { enterSidebarMode } from "$lib/stores/focus-mode.svelte";
 import { getPullRequests, getReviewModeForPr } from "$lib/stores/prs.svelte";
-import {
-  getReportIdForSha,
-  invalidateForPull,
-  regenerate,
-  selectWalkthroughReport,
-} from "$lib/stores/walkthrough.svelte";
+import { invalidateForPull, regenerate } from "$lib/stores/walkthrough.svelte";
 import type { ReviewFile } from "$lib/types/review";
 
 // --- Review files (shared between sidebar tree + review page) ---
@@ -60,9 +55,6 @@ export function clearReviewFiles(): void {
   // runs. Wiping it would lose that restore.
   clearRepoFile();
   clearSession();
-  // An explicit clear means the caller wants a fresh diff on the next load,
-  // same contract as `clearSession`'s reset of its own short-circuit window.
-  invalidateFilesLoaded();
 }
 
 // --- Unchanged-file content viewer ------------------------------------------
@@ -114,114 +106,6 @@ export function getLoadedHeadSha(prId: string): string | null {
   return loadedHeadShas.get(prId) ?? null;
 }
 
-// --- Commit-scoped review ----------------------------------------------------
-//
-// A PR can be reviewed "as of" one of its commits: the file tree, the diffs
-// and the walkthrough all re-scope to `base...C` instead of the full PR. The
-// commits dropdown is the only selector.
-//
-// This lives in its own map rather than on `PrViewState` on purpose. That
-// state sits inside the single `store = $state({ entries, activePrId })`
-// object whose `entries` map is reassigned on every scroll tick by
-// `setPrScrollPosition`, and the `/files` effect has to read the selection
-// *reactively* — reading it off `store` would subscribe that effect to scroll
-// traffic and fire a request per frame. A dedicated map has exactly one
-// writer and cannot self-retrigger. Keying by `prId` gives it the same
-// survive-a-PR-switch lifetime as `loadedHeadShas`, so `switchPrViewState`
-// needs no change.
-let selectedCommitShas = $state(new Map<string, string>());
-
-/** The commit the review is scoped to, or null for "the whole PR". */
-export function getSelectedCommitSha(prId: string): string | null {
-  return selectedCommitShas.get(prId) ?? null;
-}
-
-export function isCommitScoped(prId: string): boolean {
-  return selectedCommitShas.has(prId);
-}
-
-export function clearSelectedCommitSha(prId: string): void {
-  if (!selectedCommitShas.has(prId)) return;
-  selectedCommitShas.delete(prId);
-  selectedCommitShas = new Map(selectedCommitShas);
-}
-
-/**
- * Scope the review to `sha`, or back to the whole PR with `null`.
- *
- * The only public writer of the selection, and the orchestrator for the
- * walkthrough side of the switch. Selecting the head commit normalises to
- * `null` so "head" has exactly one spelling and no reader has to compare
- * against `headSha`.
- *
- * Deliberately does not fetch: the `/files` refetch is reactive off this
- * state in `+page.svelte`, which stays the single owner of request-id
- * cancellation, session loading and error state.
- */
-export async function selectCommit(prId: string, sha: string | null): Promise<void> {
-  const pr = getPullRequests().find((p) => p.id === prId);
-  const next = sha !== null && sha === pr?.headSha ? null : sha;
-  const current = getSelectedCommitSha(prId);
-  // Early-return on no-op: without it, a repeat click on the selected commit
-  // reassigns the map and re-triggers the files effect for the same range.
-  if (current === next) return;
-
-  if (next === null) {
-    clearSelectedCommitSha(prId);
-  } else {
-    selectedCommitShas.set(prId, next);
-    selectedCommitShas = new Map(selectedCommitShas);
-  }
-  requestDiffScrollReset();
-
-  const mode = getReviewMode(prId);
-  if (next === null) {
-    // Back to following the latest report.
-    await selectWalkthroughReport(prId, null, mode);
-    return;
-  }
-  const reportId = getReportIdForSha(prId, next, mode);
-  if (reportId !== null) {
-    await selectWalkthroughReport(prId, reportId, mode);
-  }
-  // No report at this commit: leave the walkthrough store untouched. The
-  // "commit-scoped, no report" state is derived in GuidedWalkthrough from
-  // the selection plus the rounds list, so there is nothing to store.
-}
-
-// --- Diff-files short-circuit window -----------------------------------------
-//
-// Shared by the `/files` effect in `+page.svelte` and `pullLatestCommit`, so
-// the two cannot both decide a fetch is needed for the same key. Without a
-// shared window, `pullLatestCommit` clearing the commit scope invalidates the
-// effect's tracked read and produces a second concurrent full `/files` fetch —
-// two ~12 MB responses on a large PR.
-const FILES_REFETCH_WINDOW_MS = 60_000;
-let lastFilesKey: string | null = null;
-let lastFilesAt = 0;
-
-function filesKey(prId: string, mode: ReviewMode, atSha: string | null): string {
-  return `${prId}:${mode}:${atSha ?? "head"}`;
-}
-
-export function shouldSkipFilesLoad(prId: string, mode: ReviewMode, atSha: string | null): boolean {
-  return (
-    filesKey(prId, mode, atSha) === lastFilesKey &&
-    Date.now() - lastFilesAt < FILES_REFETCH_WINDOW_MS &&
-    getReviewFiles().length > 0
-  );
-}
-
-export function markFilesLoaded(prId: string, mode: ReviewMode, atSha: string | null): void {
-  lastFilesKey = filesKey(prId, mode, atSha);
-  lastFilesAt = Date.now();
-}
-
-export function invalidateFilesLoaded(): void {
-  lastFilesKey = null;
-  lastFilesAt = 0;
-}
-
 // Per-PR in-flight flag so the pull button can show a spinner without
 // racing a second click. Set-reassignment for reactivity, matching the
 // loadedHeadShas pattern above.
@@ -266,10 +150,6 @@ export function pullLatestCommit(prId: string): Promise<boolean> {
 
 async function runPullLatestCommit(prId: string): Promise<boolean> {
   try {
-    // Pulling head is the one flow that swaps the whole diff, so it also
-    // drops any commit scope — the fresh diff we install below is the full
-    // PR at the new head.
-    clearSelectedCommitSha(prId);
     setIsLoadingFiles(true);
     setFilesError(null);
 
@@ -296,10 +176,6 @@ async function runPullLatestCommit(prId: string): Promise<boolean> {
     }));
 
     setReviewFiles(mapped);
-    // Claim the short-circuit window for the full-PR key we just installed,
-    // so the reactive `/files` effect doesn't fetch the same thing again
-    // after `clearSelectedCommitSha` above invalidated its tracked read.
-    markFilesLoaded(prId, mode, null);
     // If the user has an active file that's gone in the new diff, fall back
     // to the first file. If the active file still exists, leave it alone so
     // the user's scroll position in the diff tab isn't reset.

--- a/apps/web/src/lib/stores/walkthrough.svelte.ts
+++ b/apps/web/src/lib/stores/walkthrough.svelte.ts
@@ -483,49 +483,6 @@ export function getHasUnreviewedCommits(
   return getReviewRounds(prId, mode)?.hasNewCommits ?? false;
 }
 
-/**
- * True when `a` and `b` name the same commit, tolerating either side being an
- * abbreviation of the other.
- *
- * The commits list hands the client whatever SHA length GitHub returned, so a
- * selection can be shorter than the 40-char `toSha` the rounds carry.
- */
-function shaMatches(a: string, b: string): boolean {
-  return a.length <= b.length ? b.startsWith(a) : a.startsWith(b);
-}
-
-/**
- * The walkthrough report that reviewed the PR as of `sha`, or `null` when no
- * round ends at that commit.
- *
- * A round's `toSha` is the head it reviewed up to, so "the report for this
- * commit" is the round that ends there. Hidden rounds are skipped and ties are
- * broken the same way the report selector in `GuidedWalkthrough` orders them —
- * a finished report ahead of one still generating, then most recent first — so
- * picking a commit and picking its report off the dropdown land on the same row.
- */
-export function getReportIdForSha(
-  prId: string,
-  sha: string,
-  mode: WalkthroughMode = getSelectedMode(prId),
-): string | null {
-  const candidates = (getReviewRounds(prId, mode)?.rounds ?? [])
-    .filter((round) => round.visibility !== "hidden" && shaMatches(sha, round.toSha))
-    .sort((a, b) => {
-      const aPending = a.status === "generating";
-      const bPending = b.status === "generating";
-      if (aPending !== bPending) return aPending ? 1 : -1;
-
-      const aTime = Date.parse(a.completedAt ?? a.createdAt);
-      const bTime = Date.parse(b.completedAt ?? b.createdAt);
-      if (aTime !== bTime) return bTime - aTime;
-
-      return b.roundNumber - a.roundNumber;
-    });
-
-  return candidates[0]?.walkthroughId ?? null;
-}
-
 export async function loadReviewRounds(
   prId: string,
   mode: WalkthroughMode = getSelectedMode(prId),

--- a/install.sh
+++ b/install.sh
@@ -317,7 +317,7 @@ if ! install_release_app "$release_tag" "$REVV_APP_DIR"; then
     cd "$PROJECT_ROOT" && bun run build
   )
   (
-    cd "$PROJECT_ROOT/apps/desktop" && bunx tauri build --bundles app
+    cd "$PROJECT_ROOT/apps/desktop" && bunx tauri build --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'
   )
 
   bundle_macos_dir="$PROJECT_ROOT/apps/desktop/target/release/bundle/macos"

--- a/scripts/revv
+++ b/scripts/revv
@@ -500,6 +500,17 @@ cmd_update() {
   fi
 
   if [[ "$used_prebuilt" -eq 0 ]]; then
+    if declare -F detect_platform >/dev/null 2>&1 \
+      && declare -F ensure_xcode_clt >/dev/null 2>&1 \
+      && declare -F ensure_rust >/dev/null 2>&1; then
+      step "Checking local build toolchain"
+      detect_platform
+      ensure_xcode_clt
+      ensure_rust
+    elif ! command -v cargo >/dev/null 2>&1; then
+      fail "Rust/Cargo is required for the local Tauri build fallback. Install it with: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+    fi
+
     step "Build"
     (cd "$INSTALL_DIR" && make dist)
 


### PR DESCRIPTION
## Summary
- run Rust/Xcode prerequisite checks before `revv update` falls back to a local Tauri build
- make `make dist` recover when the currently installed CLI is older by invoking the shared Rust installer path if Cargo is missing
- quiet the internal Step 3 Makefile comments/command echo and keep installer fallback builds from requiring updater signing keys

## Verification
- `bun run typecheck && bun run lint && bun run knip && bun run build && make dist`